### PR TITLE
Prevent self-donations

### DIFF
--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -22,6 +22,15 @@ router.post('/', (req, res) => {
       });
     }
 
+    const normalizedDonor = typeof donor === 'string' ? donor.trim() : '';
+    const normalizedRecipient = typeof recipient === 'string' ? recipient.trim() : '';
+
+    if (normalizedDonor && normalizedRecipient && normalizedDonor === normalizedRecipient) {
+      return res.status(400).json({
+        error: 'Sender and recipient wallets must be different'
+      });
+    }
+
     const transaction = Transaction.create({
       amount: parseFloat(amount),
       donor: donor || 'Anonymous',

--- a/src/services/MockStellarService.js
+++ b/src/services/MockStellarService.js
@@ -110,6 +110,10 @@ class MockStellarService {
       throw new Error('Invalid source secret key');
     }
 
+    if (sourceWallet.publicKey === destinationPublic) {
+      throw new Error('Sender and recipient wallets must be different');
+    }
+
     const destWallet = this.wallets.get(destinationPublic);
     if (!destWallet) {
       throw new Error(`Destination wallet not found: ${destinationPublic}`);


### PR DESCRIPTION
- closes #33

- Add validation to reject donations where sender and recipient match.

- Return clear 400 error message for self-donations.

- Block self-transfers in mock Stellar service to align with API validation.