### PR TITLE
feat: improve environment variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,24 @@ Stellar-Micro-Donation-API/
 
 ### Environment Variables
 
-Create a `.env` file in the `src/` directory:
+Create a `.env` file in the project root:
 
 ```env
 STELLAR_NETWORK=testnet
 HORIZON_URL=https://horizon-testnet.stellar.org
 PORT=3000
+API_KEYS=your-api-key-here
 ```
+
+Required at startup:
+- `API_KEYS` (must include at least one comma-separated key)
+- `ENCRYPTION_KEY` (required only when `NODE_ENV=production`)
+
+Validated at startup (if provided):
+- `PORT` must be an integer from 1 to 65535
+- `STELLAR_NETWORK` must be one of `testnet`, `mainnet`, `futurenet`
+- `MOCK_STELLAR` must be `true` or `false`
+- `HORIZON_URL` must be a valid URL
 
 ## 🧪 Testing
 

--- a/src/config/envValidation.js
+++ b/src/config/envValidation.js
@@ -1,0 +1,81 @@
+const VALID_STELLAR_NETWORKS = ['testnet', 'mainnet', 'futurenet'];
+
+const getRequiredEnvVars = () => {
+  const required = ['API_KEYS'];
+
+  if (process.env.NODE_ENV === 'production') {
+    required.push('ENCRYPTION_KEY');
+  }
+
+  return required;
+};
+
+const isValidBooleanString = (value) => value === 'true' || value === 'false';
+
+const validateEnvironment = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+
+  const errors = [];
+  const requiredEnvVars = getRequiredEnvVars();
+
+  for (const variableName of requiredEnvVars) {
+    if (!process.env[variableName] || !process.env[variableName].trim()) {
+      errors.push(`${variableName} is required but was not set.`);
+    }
+  }
+
+  if (process.env.API_KEYS) {
+    const keys = process.env.API_KEYS
+      .split(',')
+      .map((key) => key.trim())
+      .filter(Boolean);
+
+    if (keys.length === 0) {
+      errors.push('API_KEYS must contain at least one non-empty key.');
+    }
+  }
+
+  if (process.env.PORT) {
+    const port = Number(process.env.PORT);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      errors.push(`PORT must be an integer between 1 and 65535. Received: "${process.env.PORT}".`);
+    }
+  }
+
+  if (process.env.STELLAR_NETWORK) {
+    const network = process.env.STELLAR_NETWORK.toLowerCase();
+    if (!VALID_STELLAR_NETWORKS.includes(network)) {
+      errors.push(
+        `STELLAR_NETWORK must be one of: ${VALID_STELLAR_NETWORKS.join(', ')}. Received: "${process.env.STELLAR_NETWORK}".`
+      );
+    }
+  }
+
+  if (process.env.MOCK_STELLAR && !isValidBooleanString(process.env.MOCK_STELLAR)) {
+    errors.push(`MOCK_STELLAR must be either "true" or "false". Received: "${process.env.MOCK_STELLAR}".`);
+  }
+
+  if (process.env.HORIZON_URL) {
+    try {
+      new URL(process.env.HORIZON_URL);
+    } catch (error) {
+      errors.push(`HORIZON_URL must be a valid URL. Received: "${process.env.HORIZON_URL}".`);
+    }
+  }
+
+  if (errors.length > 0) {
+    const requiredList = getRequiredEnvVars().map((name) => `- ${name}`).join('\n');
+    const details = errors.map((error) => `- ${error}`).join('\n');
+
+    throw new Error(
+      `Environment variable validation failed:\n${details}\n\nRequired variables for this environment:\n${requiredList}`
+    );
+  }
+};
+
+module.exports = {
+  validateEnvironment,
+  getRequiredEnvVars,
+};

--- a/src/config/stellar.js
+++ b/src/config/stellar.js
@@ -6,6 +6,9 @@
 
 require('dotenv').config({ path: require('path').join(__dirname, '../../.env') });
 const path = require('path');
+const { validateEnvironment } = require('./envValidation');
+
+validateEnvironment();
 
 const StellarService = require('../services/StellarService');
 const MockStellarService = require('../services/MockStellarService');


### PR DESCRIPTION
This PR closes #81 

## Title
Validate required environment variables at startup

## Summary
This PR adds centralized environment variable validation that runs during app startup and fails fast with clear, actionable errors when configuration is missing or invalid.

## What Changed
- Added `src/config/envValidation.js`:
  - Defines required env vars by environment:
    - `API_KEYS` required by default
    - `ENCRYPTION_KEY` required when `NODE_ENV=production`
  - Validates optional env var formats when provided:
    - `PORT` must be an integer between `1` and `65535`
    - `STELLAR_NETWORK` must be one of `testnet`, `mainnet`, `futurenet`
    - `MOCK_STELLAR` must be `true` or `false`
    - `HORIZON_URL` must be a valid URL
  - Aggregates validation failures into a single descriptive startup error.
- Wired validation into startup in `src/config/stellar.js`:
  - Calls `validateEnvironment()` immediately after loading `.env`.
- Updated docs in `README.md`:
  - Added required variables and startup validation behavior.
  - Clarified `.env` is expected in the project root.

## Why
Missing or malformed environment variables were causing runtime failures and ambiguous behavior. This change enforces configuration correctness at startup so issues are caught immediately.

## Behavior / Acceptance Criteria
- App fails early if required vars are missing.
- Error messages are clear and descriptive, including invalid values where relevant.
- Required environment variables are explicitly listed in code and documentation.

## Notes
- Validation is intentionally skipped when `NODE_ENV=test` to avoid disrupting test setup.