### PR TITLE
feat: implement RBAC validation against permission matrix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "npm run validate-env && node src/routes/app.js",
     "validate-env": "node -e \"require('./src/config/envValidation').validateEnvironment()\"",
     "init-db": "node src/scripts/initDB.js",
-    "validate-env": "node -e \"require('./src/config/envValidator').validateEnvironment()\"",
     "migrate:memo": "node src/scripts/addMemoColumn.js",
     "test": "jest",
     "test:coverage": "jest --coverage",
@@ -19,7 +18,8 @@
     "keys": "node src/scripts/manageApiKeys.js",
     "keys:create": "node src/scripts/manageApiKeys.js create",
     "keys:list": "node src/scripts/manageApiKeys.js list",
-    "keys:help": "node src/scripts/manageApiKeys.js help"
+    "keys:help": "node src/scripts/manageApiKeys.js help",
+    "validate:rbac": "node scripts/validate-rbac.js"
   },
   "dependencies": {
     "dotenv": "^16.0.3",

--- a/scripts/validate-rbac.js
+++ b/scripts/validate-rbac.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+/**
+ * RBAC Validation CLI Tool
+ * Validates role permissions against the permission matrix
+ */
+
+const { validateRBAC, getPermissionCoverage } = require('../src/utils/rbacValidator');
+const { PERMISSION_MATRIX } = require('../src/config/permissionMatrix');
+
+function printHeader(title) {
+  console.log('\n' + '='.repeat(70));
+  console.log(`  ${title}`);
+  console.log('='.repeat(70) + '\n');
+}
+
+function printSection(title) {
+  console.log(`\n${title}`);
+  console.log('-'.repeat(title.length));
+}
+
+function printValidationResults() {
+  printHeader('RBAC VALIDATION REPORT');
+
+  const results = validateRBAC({ logWarnings: false, throwOnError: false });
+
+  // Summary
+  printSection('Summary');
+  console.log(`Total Roles: ${results.summary.totalRoles}`);
+  console.log(`Total Routes: ${results.summary.totalRoutes}`);
+  console.log(`Errors: ${results.summary.totalErrors}`);
+  console.log(`Warnings: ${results.summary.totalWarnings}`);
+  console.log(`Status: ${results.valid ? '✅ VALID' : '❌ INVALID'}`);
+
+  // Role Validation
+  if (Object.keys(results.roleValidation.roles).length > 0) {
+    printSection('Role Permissions');
+    
+    Object.entries(results.roleValidation.roles).forEach(([roleName, roleInfo]) => {
+      const status = roleInfo.missing.length === 0 && roleInfo.extra.length === 0 ? '✅' : '⚠️';
+      console.log(`\n${status} Role: ${roleName}`);
+      console.log(`  Description: ${PERMISSION_MATRIX[roleName]?.description || 'N/A'}`);
+      console.log(`  Expected Permissions: ${roleInfo.expected.length}`);
+      console.log(`  Actual Permissions: ${roleInfo.actual.length}`);
+      
+      if (roleInfo.missing.length > 0) {
+        console.log(`  ❌ Missing: ${roleInfo.missing.join(', ')}`);
+      }
+      
+      if (roleInfo.extra.length > 0) {
+        console.log(`  ⚠️  Extra: ${roleInfo.extra.join(', ')}`);
+      }
+    });
+  }
+
+  // Errors
+  if (results.roleValidation.errors.length > 0) {
+    printSection('Errors');
+    results.roleValidation.errors.forEach(error => {
+      console.log(`  ❌ ${error}`);
+    });
+  }
+
+  if (results.routeValidation.errors.length > 0) {
+    results.routeValidation.errors.forEach(error => {
+      console.log(`  ❌ ${error}`);
+    });
+  }
+
+  // Warnings
+  if (results.roleValidation.warnings.length > 0 || results.routeValidation.warnings.length > 0) {
+    printSection('Warnings');
+    
+    results.roleValidation.warnings.forEach(warning => {
+      console.log(`  ⚠️  ${warning}`);
+    });
+    
+    results.routeValidation.warnings.forEach(warning => {
+      console.log(`  ⚠️  ${warning}`);
+    });
+  }
+
+  // Permission Coverage
+  const coverage = getPermissionCoverage();
+  printSection('Permission Coverage');
+  console.log(`Total Permissions Defined: ${coverage.total}`);
+  console.log(`Permissions Used in Routes: ${coverage.used}`);
+  console.log(`Coverage: ${coverage.percentage}%`);
+  
+  if (coverage.unused.length > 0) {
+    console.log(`\nUnused Permissions:`);
+    coverage.unused.forEach(perm => {
+      console.log(`  • ${perm}`);
+    });
+  }
+
+  // Route Access Matrix
+  printSection('Route Access Matrix');
+  console.log('\nRoutes by Role Access:\n');
+  
+  const roleRoutes = {};
+  Object.keys(PERMISSION_MATRIX).forEach(role => {
+    roleRoutes[role] = [];
+  });
+
+  results.routeValidation.routes.forEach(route => {
+    route.rolesWithAccess.forEach(role => {
+      roleRoutes[role].push(`${route.method} ${route.path}`);
+    });
+  });
+
+  Object.entries(roleRoutes).forEach(([role, routes]) => {
+    console.log(`${role.toUpperCase()} (${routes.length} routes):`);
+    if (routes.length > 0) {
+      routes.slice(0, 5).forEach(route => {
+        console.log(`  • ${route}`);
+      });
+      if (routes.length > 5) {
+        console.log(`  ... and ${routes.length - 5} more`);
+      }
+    } else {
+      console.log(`  (no routes)`);
+    }
+    console.log('');
+  });
+
+  // Final Status
+  console.log('\n' + '='.repeat(70));
+  if (results.valid && results.summary.totalWarnings === 0) {
+    console.log('✅ RBAC configuration is valid with no warnings');
+  } else if (results.valid) {
+    console.log('⚠️  RBAC configuration is valid but has warnings');
+  } else {
+    console.log('❌ RBAC configuration has errors and must be fixed');
+  }
+  console.log('='.repeat(70) + '\n');
+
+  // Exit with appropriate code
+  process.exit(results.valid ? 0 : 1);
+}
+
+// Run validation
+try {
+  printValidationResults();
+} catch (error) {
+  console.error('\n❌ Validation failed with error:', error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/src/config/permissionMatrix.js
+++ b/src/config/permissionMatrix.js
@@ -1,0 +1,93 @@
+const { PERMISSIONS } = require('../utils/permissions');
+
+/**
+ * Permission Matrix - Defines which permissions each role should have
+ * This is the source of truth for RBAC configuration
+ */
+const PERMISSION_MATRIX = {
+  admin: {
+    permissions: ['*'],
+    description: 'Full system access'
+  },
+  user: {
+    permissions: [
+      PERMISSIONS.DONATIONS_CREATE,
+      PERMISSIONS.DONATIONS_READ,
+      PERMISSIONS.DONATIONS_VERIFY,
+      PERMISSIONS.DONATIONS_UPDATE,
+      PERMISSIONS.WALLETS_CREATE,
+      PERMISSIONS.WALLETS_READ,
+      PERMISSIONS.WALLETS_UPDATE,
+      PERMISSIONS.STREAM_CREATE,
+      PERMISSIONS.STREAM_READ,
+      PERMISSIONS.STREAM_UPDATE,
+      PERMISSIONS.STREAM_DELETE,
+      PERMISSIONS.STATS_READ,
+      PERMISSIONS.TRANSACTIONS_READ,
+      PERMISSIONS.TRANSACTIONS_SYNC
+    ],
+    description: 'Standard user with donation and wallet management'
+  },
+  guest: {
+    permissions: [
+      PERMISSIONS.DONATIONS_READ,
+      PERMISSIONS.STATS_READ
+    ],
+    description: 'Read-only access to public data'
+  }
+};
+
+/**
+ * Route Permission Requirements - Maps routes to required permissions
+ * Format: { method: 'GET|POST|PATCH|DELETE', path: '/path', permission: 'permission:action' }
+ */
+const ROUTE_PERMISSIONS = [
+  // Donation routes
+  { method: 'POST', path: '/donations/verify', permission: PERMISSIONS.DONATIONS_VERIFY },
+  { method: 'POST', path: '/donations/send', permission: PERMISSIONS.DONATIONS_CREATE },
+  { method: 'GET', path: '/donations', permission: PERMISSIONS.DONATIONS_READ },
+  { method: 'GET', path: '/donations/limits', permission: PERMISSIONS.DONATIONS_READ },
+  { method: 'GET', path: '/donations/recent', permission: PERMISSIONS.DONATIONS_READ },
+  { method: 'GET', path: '/donations/:id', permission: PERMISSIONS.DONATIONS_READ },
+  { method: 'PATCH', path: '/donations/:id/status', permission: PERMISSIONS.DONATIONS_UPDATE },
+  
+  // Wallet routes
+  { method: 'POST', path: '/wallets', permission: PERMISSIONS.WALLETS_CREATE },
+  { method: 'GET', path: '/wallets', permission: PERMISSIONS.WALLETS_READ },
+  { method: 'GET', path: '/wallets/:id', permission: PERMISSIONS.WALLETS_READ },
+  { method: 'GET', path: '/wallets/:publicKey/transactions', permission: PERMISSIONS.WALLETS_READ },
+  { method: 'PATCH', path: '/wallets/:id', permission: PERMISSIONS.WALLETS_UPDATE },
+  
+  // Stream (recurring donations) routes
+  { method: 'POST', path: '/stream/create', permission: PERMISSIONS.STREAM_CREATE },
+  { method: 'GET', path: '/stream/schedules', permission: PERMISSIONS.STREAM_READ },
+  { method: 'GET', path: '/stream/schedules/:id', permission: PERMISSIONS.STREAM_READ },
+  { method: 'DELETE', path: '/stream/schedules/:id', permission: PERMISSIONS.STREAM_DELETE },
+  
+  // Stats routes
+  { method: 'GET', path: '/stats/daily', permission: PERMISSIONS.STATS_READ },
+  { method: 'GET', path: '/stats/weekly', permission: PERMISSIONS.STATS_READ },
+  { method: 'GET', path: '/stats/summary', permission: PERMISSIONS.STATS_READ },
+  { method: 'GET', path: '/stats/donors', permission: PERMISSIONS.STATS_READ },
+  { method: 'GET', path: '/stats/recipients', permission: PERMISSIONS.STATS_READ },
+  { method: 'GET', path: '/stats/analytics-fees', permission: PERMISSIONS.STATS_READ },
+  { method: 'GET', path: '/stats/wallet/:walletAddress/analytics', permission: PERMISSIONS.STATS_READ },
+  
+  // Transaction routes
+  { method: 'GET', path: '/transactions', permission: PERMISSIONS.TRANSACTIONS_READ },
+  { method: 'POST', path: '/transactions/sync', permission: PERMISSIONS.TRANSACTIONS_SYNC },
+  
+  // Admin-only routes
+  { method: 'POST', path: '/api-keys', permission: PERMISSIONS.ADMIN_ALL },
+  { method: 'GET', path: '/api-keys', permission: PERMISSIONS.ADMIN_ALL },
+  { method: 'POST', path: '/api-keys/:id/deprecate', permission: PERMISSIONS.ADMIN_ALL },
+  { method: 'DELETE', path: '/api-keys/:id', permission: PERMISSIONS.ADMIN_ALL },
+  { method: 'POST', path: '/api-keys/cleanup', permission: PERMISSIONS.ADMIN_ALL },
+  { method: 'GET', path: '/abuse-signals', permission: PERMISSIONS.ADMIN_ALL },
+  { method: 'POST', path: '/reconcile', permission: PERMISSIONS.ADMIN_ALL }
+];
+
+module.exports = {
+  PERMISSION_MATRIX,
+  ROUTE_PERMISSIONS
+};

--- a/src/config/roles.json
+++ b/src/config/roles.json
@@ -1,0 +1,34 @@
+{
+  "roles": [
+    {
+      "name": "admin",
+      "permissions": ["*"]
+    },
+    {
+      "name": "user",
+      "permissions": [
+        "donations:create",
+        "donations:read",
+        "donations:verify",
+        "donations:update",
+        "wallets:create",
+        "wallets:read",
+        "wallets:update",
+        "stream:create",
+        "stream:read",
+        "stream:update",
+        "stream:delete",
+        "stats:read",
+        "transactions:read",
+        "transactions:sync"
+      ]
+    },
+    {
+      "name": "guest",
+      "permissions": [
+        "donations:read",
+        "stats:read"
+      ]
+    }
+  ]
+}

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -16,6 +16,7 @@ const { attachUserRole } = require('../middleware/rbac');
 const abuseDetectionMiddleware = require('../middleware/abuseDetection');
 const Database = require('../utils/database');
 const { initializeApiKeysTable } = require('../models/apiKeys');
+const { validateRBAC } = require('../utils/rbacValidator');
 const log = require('../utils/log');
 const requestId = require('../middleware/requestId');
 
@@ -135,6 +136,13 @@ async function startServer() {
     await initializeApiKeysTable();
   } catch (error) {
     log.error('APP', 'Failed to initialize API keys table', { error: error.message });
+  }
+
+  // Validate RBAC configuration
+  try {
+    validateRBAC({ logWarnings: true, throwOnError: false });
+  } catch (error) {
+    log.error('APP', 'RBAC validation failed', { error: error.message });
   }
 
   app.listen(PORT, () => {

--- a/src/utils/rbacValidator.js
+++ b/src/utils/rbacValidator.js
@@ -1,0 +1,214 @@
+const { PERMISSION_MATRIX, ROUTE_PERMISSIONS } = require('../config/permissionMatrix');
+const { getPermissionsByRole, getAllRoles } = require('../models/permissions');
+const { PERMISSIONS, permissionsMatch } = require('../utils/permissions');
+const log = require('../utils/log');
+
+/**
+ * Validate that role definitions match the permission matrix
+ * @returns {Object} Validation result with warnings and errors
+ */
+function validateRolePermissions() {
+  const results = {
+    valid: true,
+    warnings: [],
+    errors: [],
+    roles: {}
+  };
+
+  const actualRoles = getAllRoles();
+  const matrixRoles = Object.keys(PERMISSION_MATRIX);
+
+  // Check for missing roles
+  matrixRoles.forEach(roleName => {
+    const actualRole = actualRoles.find(r => r.name === roleName);
+    
+    if (!actualRole) {
+      results.errors.push(`Role "${roleName}" defined in matrix but not found in configuration`);
+      results.valid = false;
+      return;
+    }
+
+    const matrixPerms = PERMISSION_MATRIX[roleName].permissions;
+    const actualPerms = getPermissionsByRole(roleName);
+
+    results.roles[roleName] = {
+      expected: matrixPerms,
+      actual: actualPerms,
+      missing: [],
+      extra: []
+    };
+
+    // Check for missing permissions
+    matrixPerms.forEach(perm => {
+      const hasPermission = actualPerms.some(actual => permissionsMatch(perm, actual));
+      if (!hasPermission) {
+        results.roles[roleName].missing.push(perm);
+        results.warnings.push(`Role "${roleName}" missing permission: ${perm}`);
+      }
+    });
+
+    // Check for extra permissions
+    actualPerms.forEach(perm => {
+      if (perm === '*') return; // Wildcard is always valid
+      const isExpected = matrixPerms.some(expected => permissionsMatch(perm, expected));
+      if (!isExpected) {
+        results.roles[roleName].extra.push(perm);
+        results.warnings.push(`Role "${roleName}" has unexpected permission: ${perm}`);
+      }
+    });
+  });
+
+  // Check for undefined roles
+  actualRoles.forEach(role => {
+    if (!PERMISSION_MATRIX[role.name]) {
+      results.warnings.push(`Role "${role.name}" exists in configuration but not in permission matrix`);
+    }
+  });
+
+  return results;
+}
+
+/**
+ * Validate that all routes have proper permission checks
+ * @returns {Object} Validation result
+ */
+function validateRoutePermissions() {
+  const results = {
+    valid: true,
+    warnings: [],
+    errors: [],
+    routes: []
+  };
+
+  ROUTE_PERMISSIONS.forEach(route => {
+    const routeInfo = {
+      method: route.method,
+      path: route.path,
+      permission: route.permission,
+      issues: []
+    };
+
+    // Check if permission exists in PERMISSIONS constant
+    const permissionExists = Object.values(PERMISSIONS).includes(route.permission);
+    if (!permissionExists) {
+      routeInfo.issues.push(`Unknown permission: ${route.permission}`);
+      results.errors.push(`Route ${route.method} ${route.path} uses unknown permission: ${route.permission}`);
+      results.valid = false;
+    }
+
+    // Check if at least one role has this permission
+    const rolesWithPermission = Object.keys(PERMISSION_MATRIX).filter(roleName => {
+      const rolePerms = PERMISSION_MATRIX[roleName].permissions;
+      return rolePerms.includes('*') || rolePerms.includes(route.permission);
+    });
+
+    if (rolesWithPermission.length === 0) {
+      routeInfo.issues.push('No role has this permission');
+      results.warnings.push(`Route ${route.method} ${route.path} requires ${route.permission} but no role has it`);
+    }
+
+    routeInfo.rolesWithAccess = rolesWithPermission;
+    results.routes.push(routeInfo);
+  });
+
+  return results;
+}
+
+/**
+ * Perform complete RBAC validation
+ * @param {Object} options - Validation options
+ * @returns {Object} Complete validation results
+ */
+function validateRBAC(options = {}) {
+  const { throwOnError = false, logWarnings = true } = options;
+
+  const roleValidation = validateRolePermissions();
+  const routeValidation = validateRoutePermissions();
+
+  const results = {
+    valid: roleValidation.valid && routeValidation.valid,
+    roleValidation,
+    routeValidation,
+    summary: {
+      totalRoles: Object.keys(PERMISSION_MATRIX).length,
+      totalRoutes: ROUTE_PERMISSIONS.length,
+      totalWarnings: roleValidation.warnings.length + routeValidation.warnings.length,
+      totalErrors: roleValidation.errors.length + routeValidation.errors.length
+    }
+  };
+
+  // Log warnings if enabled
+  if (logWarnings) {
+    if (results.summary.totalErrors > 0) {
+      log.error('RBAC_VALIDATION', 'RBAC validation failed', {
+        errors: results.summary.totalErrors,
+        warnings: results.summary.totalWarnings
+      });
+      
+      roleValidation.errors.forEach(error => {
+        log.error('RBAC_VALIDATION', error);
+      });
+      
+      routeValidation.errors.forEach(error => {
+        log.error('RBAC_VALIDATION', error);
+      });
+    }
+
+    if (results.summary.totalWarnings > 0) {
+      log.warn('RBAC_VALIDATION', 'RBAC validation warnings detected', {
+        warnings: results.summary.totalWarnings
+      });
+      
+      roleValidation.warnings.forEach(warning => {
+        log.warn('RBAC_VALIDATION', warning);
+      });
+      
+      routeValidation.warnings.forEach(warning => {
+        log.warn('RBAC_VALIDATION', warning);
+      });
+    }
+
+    if (results.valid && results.summary.totalWarnings === 0) {
+      log.info('RBAC_VALIDATION', 'RBAC validation passed', {
+        roles: results.summary.totalRoles,
+        routes: results.summary.totalRoutes
+      });
+    }
+  }
+
+  // Throw error if requested
+  if (throwOnError && !results.valid) {
+    const errorMessages = [
+      ...roleValidation.errors,
+      ...routeValidation.errors
+    ];
+    throw new Error(`RBAC validation failed:\n${errorMessages.join('\n')}`);
+  }
+
+  return results;
+}
+
+/**
+ * Get permission coverage report
+ * @returns {Object} Coverage report
+ */
+function getPermissionCoverage() {
+  const allPermissions = Object.values(PERMISSIONS);
+  const usedPermissions = new Set(ROUTE_PERMISSIONS.map(r => r.permission));
+  
+  const coverage = {
+    total: allPermissions.length,
+    used: usedPermissions.size,
+    unused: allPermissions.filter(p => !usedPermissions.has(p)),
+    percentage: Math.round((usedPermissions.size / allPermissions.length) * 100)
+  };
+
+  return coverage;
+}
+
+module.exports = {
+  validateRolePermissions,
+  validateRoutePermissions,
+  validateRBAC,
+  getPermissionCoverage
+};

--- a/tests/rbac-validation.test.js
+++ b/tests/rbac-validation.test.js
@@ -1,0 +1,243 @@
+const { validateRBAC, validateRolePermissions, validateRoutePermissions, getPermissionCoverage } = require('../src/utils/rbacValidator');
+const { PERMISSION_MATRIX } = require('../src/config/permissionMatrix');
+const { PERMISSIONS } = require('../src/utils/permissions');
+
+describe('RBAC Validator', () => {
+  describe('validateRolePermissions', () => {
+    test('should validate all roles in permission matrix', () => {
+      const results = validateRolePermissions();
+      
+      expect(results).toHaveProperty('valid');
+      expect(results).toHaveProperty('warnings');
+      expect(results).toHaveProperty('errors');
+      expect(results).toHaveProperty('roles');
+    });
+
+    test('should detect admin role with wildcard permission', () => {
+      const results = validateRolePermissions();
+      
+      expect(results.roles.admin).toBeDefined();
+      expect(results.roles.admin.expected).toContain('*');
+    });
+
+    test('should validate user role permissions', () => {
+      const results = validateRolePermissions();
+      
+      expect(results.roles.user).toBeDefined();
+      expect(results.roles.user.expected.length).toBeGreaterThan(0);
+    });
+
+    test('should validate guest role permissions', () => {
+      const results = validateRolePermissions();
+      
+      expect(results.roles.guest).toBeDefined();
+      expect(results.roles.guest.expected).toContain(PERMISSIONS.DONATIONS_READ);
+      expect(results.roles.guest.expected).toContain(PERMISSIONS.STATS_READ);
+    });
+
+    test('should detect missing permissions', () => {
+      const results = validateRolePermissions();
+      
+      Object.values(results.roles).forEach(role => {
+        expect(Array.isArray(role.missing)).toBe(true);
+        expect(Array.isArray(role.extra)).toBe(true);
+      });
+    });
+  });
+
+  describe('validateRoutePermissions', () => {
+    test('should validate all route permissions', () => {
+      const results = validateRoutePermissions();
+      
+      expect(results).toHaveProperty('valid');
+      expect(results).toHaveProperty('warnings');
+      expect(results).toHaveProperty('errors');
+      expect(results).toHaveProperty('routes');
+      expect(results.routes.length).toBeGreaterThan(0);
+    });
+
+    test('should ensure all routes have valid permissions', () => {
+      const results = validateRoutePermissions();
+      
+      results.routes.forEach(route => {
+        expect(route).toHaveProperty('method');
+        expect(route).toHaveProperty('path');
+        expect(route).toHaveProperty('permission');
+        expect(route).toHaveProperty('rolesWithAccess');
+      });
+    });
+
+    test('should detect routes with no role access', () => {
+      const results = validateRoutePermissions();
+      
+      const routesWithoutAccess = results.routes.filter(r => r.rolesWithAccess.length === 0);
+      
+      if (routesWithoutAccess.length > 0) {
+        expect(results.warnings.length).toBeGreaterThan(0);
+      }
+    });
+
+    test('should validate admin routes require admin permission', () => {
+      const results = validateRoutePermissions();
+      
+      const adminRoutes = results.routes.filter(r => r.path.includes('/api-keys'));
+      
+      adminRoutes.forEach(route => {
+        expect(route.permission).toBe(PERMISSIONS.ADMIN_ALL);
+        expect(route.rolesWithAccess).toContain('admin');
+      });
+    });
+
+    test('should validate donation routes', () => {
+      const results = validateRoutePermissions();
+      
+      const donationRoutes = results.routes.filter(r => r.path.startsWith('/donations'));
+      
+      expect(donationRoutes.length).toBeGreaterThan(0);
+      donationRoutes.forEach(route => {
+        expect(route.permission).toMatch(/^donations:/);
+      });
+    });
+
+    test('should validate wallet routes', () => {
+      const results = validateRoutePermissions();
+      
+      const walletRoutes = results.routes.filter(r => r.path.startsWith('/wallets'));
+      
+      expect(walletRoutes.length).toBeGreaterThan(0);
+      walletRoutes.forEach(route => {
+        expect(route.permission).toMatch(/^wallets:/);
+      });
+    });
+  });
+
+  describe('validateRBAC', () => {
+    test('should perform complete RBAC validation', () => {
+      const results = validateRBAC({ logWarnings: false });
+      
+      expect(results).toHaveProperty('valid');
+      expect(results).toHaveProperty('roleValidation');
+      expect(results).toHaveProperty('routeValidation');
+      expect(results).toHaveProperty('summary');
+    });
+
+    test('should provide summary statistics', () => {
+      const results = validateRBAC({ logWarnings: false });
+      
+      expect(results.summary).toHaveProperty('totalRoles');
+      expect(results.summary).toHaveProperty('totalRoutes');
+      expect(results.summary).toHaveProperty('totalWarnings');
+      expect(results.summary).toHaveProperty('totalErrors');
+      
+      expect(results.summary.totalRoles).toBe(Object.keys(PERMISSION_MATRIX).length);
+      expect(results.summary.totalRoutes).toBeGreaterThan(0);
+    });
+
+    test('should not throw error by default', () => {
+      expect(() => {
+        validateRBAC({ logWarnings: false, throwOnError: false });
+      }).not.toThrow();
+    });
+
+    test('should validate without errors', () => {
+      const results = validateRBAC({ logWarnings: false });
+      
+      expect(results.valid).toBe(true);
+      expect(results.summary.totalErrors).toBe(0);
+    });
+  });
+
+  describe('getPermissionCoverage', () => {
+    test('should calculate permission coverage', () => {
+      const coverage = getPermissionCoverage();
+      
+      expect(coverage).toHaveProperty('total');
+      expect(coverage).toHaveProperty('used');
+      expect(coverage).toHaveProperty('unused');
+      expect(coverage).toHaveProperty('percentage');
+    });
+
+    test('should have high permission coverage', () => {
+      const coverage = getPermissionCoverage();
+      
+      expect(coverage.percentage).toBeGreaterThan(50);
+      expect(coverage.used).toBeGreaterThan(0);
+    });
+
+    test('should list unused permissions', () => {
+      const coverage = getPermissionCoverage();
+      
+      expect(Array.isArray(coverage.unused)).toBe(true);
+    });
+  });
+
+  describe('Permission Matrix Integrity', () => {
+    test('should have all required roles defined', () => {
+      expect(PERMISSION_MATRIX).toHaveProperty('admin');
+      expect(PERMISSION_MATRIX).toHaveProperty('user');
+      expect(PERMISSION_MATRIX).toHaveProperty('guest');
+    });
+
+    test('should have descriptions for all roles', () => {
+      Object.entries(PERMISSION_MATRIX).forEach(([roleName, roleConfig]) => {
+        expect(roleConfig).toHaveProperty('description');
+        expect(roleConfig.description).toBeTruthy();
+      });
+    });
+
+    test('should have permissions array for all roles', () => {
+      Object.entries(PERMISSION_MATRIX).forEach(([roleName, roleConfig]) => {
+        expect(roleConfig).toHaveProperty('permissions');
+        expect(Array.isArray(roleConfig.permissions)).toBe(true);
+        expect(roleConfig.permissions.length).toBeGreaterThan(0);
+      });
+    });
+
+    test('admin should have wildcard permission', () => {
+      expect(PERMISSION_MATRIX.admin.permissions).toContain('*');
+    });
+
+    test('guest should have minimal permissions', () => {
+      const guestPerms = PERMISSION_MATRIX.guest.permissions;
+      
+      expect(guestPerms.length).toBeLessThan(PERMISSION_MATRIX.user.permissions.length);
+      expect(guestPerms).toContain(PERMISSIONS.DONATIONS_READ);
+      expect(guestPerms).toContain(PERMISSIONS.STATS_READ);
+    });
+
+    test('user should have more permissions than guest', () => {
+      const userPerms = PERMISSION_MATRIX.user.permissions;
+      const guestPerms = PERMISSION_MATRIX.guest.permissions;
+      
+      expect(userPerms.length).toBeGreaterThan(guestPerms.length);
+    });
+  });
+
+  describe('Role Hierarchy', () => {
+    test('admin should have access to all routes', () => {
+      const results = validateRoutePermissions();
+      
+      results.routes.forEach(route => {
+        expect(route.rolesWithAccess).toContain('admin');
+      });
+    });
+
+    test('guest should have limited access', () => {
+      const results = validateRoutePermissions();
+      
+      const guestRoutes = results.routes.filter(r => r.rolesWithAccess.includes('guest'));
+      const totalRoutes = results.routes.length;
+      
+      expect(guestRoutes.length).toBeLessThan(totalRoutes);
+    });
+
+    test('user should have more access than guest', () => {
+      const results = validateRoutePermissions();
+      
+      const userRoutes = results.routes.filter(r => r.rolesWithAccess.includes('user'));
+      const guestRoutes = results.routes.filter(r => r.rolesWithAccess.includes('guest'));
+      
+      expect(userRoutes.length).toBeGreaterThan(guestRoutes.length);
+    });
+  });
+});


### PR DESCRIPTION
closes #110 
- Add permission matrix defining role permissions and route requirements
- Create RBAC validator to check role definitions against matrix
- Add roles.json configuration file with explicit permissions
- Integrate validation into server startup with warnings/errors
- Add CLI tool for manual RBAC validation (npm run validate:rbac)
- Add comprehensive test suite (27 tests, all passing)
- Validate 32 routes across 3 roles (admin, user, guest)
- Detect misconfigurations early with detailed error messages
- 78% permission coverage with unused permission tracking