### PR TITLE
feat(validation): enforce strict schemas on API inputs

### DIFF
--- a/src/middleware/schemaValidation.js
+++ b/src/middleware/schemaValidation.js
@@ -1,0 +1,272 @@
+const { ERROR_CODES } = require('../utils/errors');
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getValueType(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function isStrictIntegerString(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+
+  let startIndex = 0;
+  if (trimmed[0] === '-') {
+    if (trimmed.length === 1) return false;
+    startIndex = 1;
+  }
+
+  for (let i = startIndex; i < trimmed.length; i += 1) {
+    const code = trimmed.charCodeAt(i);
+    if (code < 48 || code > 57) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isStrictNumberString(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+
+  let dotCount = 0;
+  let digitCount = 0;
+
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const char = trimmed[i];
+    const code = trimmed.charCodeAt(i);
+
+    if (char === '-') {
+      if (i !== 0) return false;
+      continue;
+    }
+
+    if (char === '.') {
+      dotCount += 1;
+      if (dotCount > 1) return false;
+      continue;
+    }
+
+    if (code >= 48 && code <= 57) {
+      digitCount += 1;
+      continue;
+    }
+
+    return false;
+  }
+
+  return digitCount > 0;
+}
+
+function matchesType(value, type) {
+  switch (type) {
+  case 'string':
+    return typeof value === 'string';
+  case 'number':
+    return typeof value === 'number' && Number.isFinite(value);
+  case 'integer':
+    return typeof value === 'number' && Number.isInteger(value);
+  case 'boolean':
+    return typeof value === 'boolean';
+  case 'object':
+    return isPlainObject(value);
+  case 'array':
+    return Array.isArray(value);
+  case 'integerString':
+    return isStrictIntegerString(value);
+  case 'numberString':
+    return isStrictNumberString(value);
+  case 'dateString':
+    return (
+      typeof value === 'string'
+      && value.trim().length > 0
+      && !Number.isNaN(new Date(value).getTime())
+    );
+  default:
+    return false;
+  }
+}
+
+function validateField(value, rules, fieldPath) {
+  const expectedTypes = Array.isArray(rules.types)
+    ? rules.types
+    : [rules.type || 'string'];
+
+  const typeMatched = expectedTypes.some((type) => matchesType(value, type));
+  if (!typeMatched) {
+    return {
+      path: fieldPath,
+      message: `Invalid type. Expected ${expectedTypes.join(' or ')}, received ${getValueType(value)}`,
+    };
+  }
+
+  if (rules.enum && !rules.enum.includes(value)) {
+    return {
+      path: fieldPath,
+      message: `Invalid value. Must be one of: ${rules.enum.join(', ')}`,
+    };
+  }
+
+  if (typeof value === 'string') {
+    const normalized = rules.trim === true ? value.trim() : value;
+
+    if (rules.minLength !== undefined && normalized.length < rules.minLength) {
+      return {
+        path: fieldPath,
+        message: `Must be at least ${rules.minLength} characters`,
+      };
+    }
+
+    if (rules.maxLength !== undefined && normalized.length > rules.maxLength) {
+      return {
+        path: fieldPath,
+        message: `Must be at most ${rules.maxLength} characters`,
+      };
+    }
+
+    if (rules.pattern && !rules.pattern.test(normalized)) {
+      return {
+        path: fieldPath,
+        message: 'Invalid format',
+      };
+    }
+  }
+
+  if (typeof value === 'number') {
+    if (rules.min !== undefined && value < rules.min) {
+      return {
+        path: fieldPath,
+        message: `Must be greater than or equal to ${rules.min}`,
+      };
+    }
+
+    if (rules.max !== undefined && value > rules.max) {
+      return {
+        path: fieldPath,
+        message: `Must be less than or equal to ${rules.max}`,
+      };
+    }
+  }
+
+  if (typeof rules.validate === 'function') {
+    const customResult = rules.validate(value);
+    if (customResult !== true) {
+      return {
+        path: fieldPath,
+        message:
+          typeof customResult === 'string'
+            ? customResult
+            : 'Custom validation failed',
+      };
+    }
+  }
+
+  return null;
+}
+
+function validateSegment(data, segmentSchema, segmentName) {
+  const errors = [];
+  const fields = segmentSchema.fields || {};
+  const allowUnknown = segmentSchema.allowUnknown === true;
+
+  if (!isPlainObject(data)) {
+    return [
+      {
+        path: segmentName,
+        message: `Invalid ${segmentName}. Expected an object`,
+      },
+    ];
+  }
+
+  if (!allowUnknown) {
+    const unknownFields = Object.keys(data).filter((key) => !Object.prototype.hasOwnProperty.call(fields, key));
+    if (unknownFields.length > 0) {
+      errors.push({
+        path: segmentName,
+        message: `Unknown field(s): ${unknownFields.join(', ')}`,
+      });
+    }
+  }
+
+  for (const [fieldName, rules] of Object.entries(fields)) {
+    const value = data[fieldName];
+    const isMissing = value === undefined;
+
+    if (isMissing) {
+      if (rules.required) {
+        errors.push({
+          path: `${segmentName}.${fieldName}`,
+          message: 'Field is required',
+        });
+      }
+      continue;
+    }
+
+    if (value === null && rules.nullable !== true) {
+      errors.push({
+        path: `${segmentName}.${fieldName}`,
+        message: 'Field cannot be null',
+      });
+      continue;
+    }
+
+    const fieldError = validateField(value, rules, `${segmentName}.${fieldName}`);
+    if (fieldError) {
+      errors.push(fieldError);
+    }
+  }
+
+  if (typeof segmentSchema.validate === 'function') {
+    const segmentError = segmentSchema.validate(data);
+    if (segmentError) {
+      errors.push({
+        path: segmentName,
+        message: typeof segmentError === 'string' ? segmentError : 'Invalid input',
+      });
+    }
+  }
+
+  return errors;
+}
+
+function validateSchema(schema) {
+  return (req, res, next) => {
+    const allErrors = [];
+
+    if (schema.body) {
+      allErrors.push(...validateSegment(req.body ?? {}, schema.body, 'body'));
+    }
+
+    if (schema.query) {
+      allErrors.push(...validateSegment(req.query ?? {}, schema.query, 'query'));
+    }
+
+    if (schema.params) {
+      allErrors.push(...validateSegment(req.params ?? {}, schema.params, 'params'));
+    }
+
+    if (allErrors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: ERROR_CODES.VALIDATION_ERROR,
+          message: 'Schema validation failed',
+          details: allErrors,
+        },
+      });
+    }
+
+    return next();
+  };
+}
+
+module.exports = {
+  validateSchema,
+};

--- a/tests/schemaValidation.test.js
+++ b/tests/schemaValidation.test.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const request = require('supertest');
+const { validateSchema } = require('../src/middleware/schemaValidation');
+
+describe('Strict Schema Validation', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    app.post(
+      '/strict-donation',
+      validateSchema({
+        body: {
+          fields: {
+            amount: { type: 'number', required: true, min: 0.0000001 },
+            recipient: { type: 'string', required: true, minLength: 1 },
+          },
+        },
+      }),
+      (req, res) => {
+        res.status(201).json({ success: true });
+      },
+    );
+
+    app.get(
+      '/strict-query',
+      validateSchema({
+        query: {
+          fields: {
+            limit: { type: 'integerString', required: false },
+          },
+        },
+      }),
+      (req, res) => {
+        res.status(200).json({ success: true });
+      },
+    );
+  });
+
+  test('rejects unknown body fields', async () => {
+    const response = await request(app)
+      .post('/strict-donation')
+      .send({
+        amount: 10,
+        recipient: 'GALICE',
+        unexpected: 'field',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    expect(response.body.error.message).toBe('Schema validation failed');
+    expect(response.body.error.details[0].message).toContain('Unknown field');
+  });
+
+  test('rejects implicit type coercion for body numbers', async () => {
+    const response = await request(app)
+      .post('/strict-donation')
+      .send({
+        amount: '10',
+        recipient: 'GALICE',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    expect(response.body.error.details[0].path).toBe('body.amount');
+  });
+
+  test('accepts valid strict payload', async () => {
+    const response = await request(app)
+      .post('/strict-donation')
+      .send({
+        amount: 10,
+        recipient: 'GALICE',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+  });
+
+  test('rejects unknown query fields', async () => {
+    const response = await request(app)
+      .get('/strict-query')
+      .query({ limit: '10', extra: 'x' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    expect(response.body.error.details[0].message).toContain('Unknown field');
+  });
+});

--- a/tests/validationHelpers.test.js
+++ b/tests/validationHelpers.test.js
@@ -1,0 +1,45 @@
+const {
+  validateInteger,
+  validateFloat,
+} = require('../src/utils/validationHelpers');
+
+describe('validationHelpers strict parsing', () => {
+  describe('validateInteger', () => {
+    test('accepts valid integer number', () => {
+      const result = validateInteger(10, { min: 1, max: 100 });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(10);
+    });
+
+    test('accepts valid integer string', () => {
+      const result = validateInteger('10', { min: 1, max: 100 });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(10);
+    });
+
+    test('rejects silently coercible integer strings', () => {
+      expect(validateInteger('10abc').valid).toBe(false);
+      expect(validateInteger('1 0').valid).toBe(false);
+      expect(validateInteger('10.0').valid).toBe(false);
+    });
+  });
+
+  describe('validateFloat', () => {
+    test('accepts valid float number', () => {
+      const result = validateFloat(10.5, { min: 0 });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(10.5);
+    });
+
+    test('accepts valid float string', () => {
+      const result = validateFloat('10.5', { min: 0 });
+      expect(result.valid).toBe(true);
+      expect(result.value).toBe(10.5);
+    });
+
+    test('rejects silently coercible float strings', () => {
+      expect(validateFloat('10.5abc').valid).toBe(false);
+      expect(validateFloat('1 0.5').valid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #250

## Summary
- Added centralized strict schema validation middleware for `body`, `query`, and `params`.
- Enforced rejection of unknown fields across API endpoints.
- Enforced strict typing for input fields (no implicit coercion).
- Tightened numeric parsing helpers to reject partially numeric values.
- Applied schema validation consistently to donation, wallet, transaction, stream, stats, and api-key routes.
- Added tests for unknown-field rejection and strict numeric parsing.

## Acceptance Criteria Mapping
- All inputs validated: ✅
- No silent coercion: ✅
