### PR TITLE
Add health check endpoint with dependency status

### DIFF
--- a/docs/features/ADD_HEALTH_CHECK_ENDPOINT_WITH_DEPENDENCY_STATUS.md
+++ b/docs/features/ADD_HEALTH_CHECK_ENDPOINT_WITH_DEPENDENCY_STATUS.md
@@ -1,0 +1,109 @@
+# Enhanced Health Check Endpoint with Dependency Status
+
+## Overview
+
+The `/health` endpoint has been upgraded from a simple status check to a full dependency-aware health report. Two additional endpoints — `/health/live` and `/health/ready` — support Kubernetes-style liveness and readiness probes.
+
+All checks are bounded to **2 seconds** per dependency to prevent slow dependencies from blocking the response.
+
+---
+
+## Endpoints
+
+### `GET /health`
+
+Returns the overall health of the service and the status of each dependency.
+
+**Response shape**
+
+```json
+{
+  "status": "healthy" | "degraded" | "unhealthy",
+  "dependencies": {
+    "database": { "status": "healthy", "responseTime": 4 },
+    "stellar":  { "status": "healthy", "responseTime": 12, "network": "testnet", "horizonUrl": "https://horizon-testnet.stellar.org" },
+    "idempotency": { "status": "healthy", "responseTime": 3 }
+  },
+  "timestamp": "2026-03-23T14:00:00.000Z"
+}
+```
+
+**Status rules**
+
+| Condition | `status` | HTTP |
+|---|---|---|
+| All dependencies healthy | `healthy` | 200 |
+| Database healthy, ≥1 non-critical dependency unhealthy | `degraded` | 200 |
+| Database unhealthy | `unhealthy` | 503 |
+
+---
+
+### `GET /health/live`
+
+Liveness probe. Returns `200` as long as the Node.js process is running. Never checks external dependencies.
+
+```json
+{ "status": "alive", "timestamp": "..." }
+```
+
+---
+
+### `GET /health/ready`
+
+Readiness probe. Returns `200` only when all dependencies are healthy (i.e., `status === "healthy"`). Returns `503` for `degraded` or `unhealthy`.
+
+```json
+{
+  "ready": true,
+  "status": "healthy",
+  "dependencies": { ... },
+  "timestamp": "..."
+}
+```
+
+---
+
+## Implementation
+
+### `src/services/HealthCheckService.js`
+
+Pure functions — no side effects, no singleton state.
+
+| Export | Description |
+|---|---|
+| `checkDatabase()` | Runs `SELECT 1` against SQLite |
+| `checkStellar(stellarService)` | Calls `server.root()` on real Horizon; no-op on MockStellarService |
+| `checkIdempotency()` | Runs `SELECT COUNT(*)` on `idempotency_keys` table |
+| `getFullHealth(stellarService)` | Runs all three checks in parallel, aggregates status |
+| `getLiveness()` | Synchronous — returns `{ status: "alive" }` |
+| `getReadiness(stellarService)` | Delegates to `getFullHealth`, adds `ready` boolean |
+| `DEPENDENCY_TIMEOUT_MS` | `2000` — hard timeout per check |
+
+Each check returns `{ status, responseTime, error? }`. Unhealthy checks include an `error` string.
+
+### `src/routes/app.js`
+
+The old inline health handler was replaced with three route handlers that delegate to `HealthCheckService`.
+
+---
+
+## Security
+
+- No authentication required on health endpoints (standard practice for load balancer probes).
+- Dependency error messages are included in the response but do not expose stack traces or internal paths.
+- The `checkStellar` function only calls `server.root()` — a read-only metadata endpoint — so no credentials are involved.
+
+---
+
+## Testing
+
+Test file: `tests/add-health-check-endpoint-with-dependency-status.test.js`
+
+- 27 tests, 0 failures
+- No live Stellar network required — uses `MockStellarService`
+- Covers: healthy, degraded, unhealthy states; timeout simulation; liveness; readiness; unit tests for each service function
+
+Run:
+```bash
+node node_modules/jest-cli/bin/jest.js tests/add-health-check-endpoint-with-dependency-status.test.js
+```

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -24,6 +24,7 @@ const { attachUserRole } = require('../middleware/rbac');
 const abuseDetectionMiddleware = require('../middleware/abuseDetection');
 const replayDetectionMiddleware = require('../middleware/replayDetection');
 const Database = require('../utils/database');
+const HealthCheckService = require('../services/HealthCheckService');
 const { initializeApiKeysTable } = require('../models/apiKeys');
 const { validateRBAC } = require('../utils/rbacValidator');
 const log = require('../utils/log');
@@ -77,27 +78,23 @@ app.use('/stream', streamRoutes);
 app.use('/transactions', transactionRoutes);
 app.use('/api-keys', apiKeysRoutes);
 
-// Health check endpoint
+// Health check endpoints
 app.get('/health', async (req, res) => {
-  try {
-    await Database.get('SELECT 1 as ok');
-    return res.status(200).json({
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      dependencies: { database: 'ok' },
-      services: {
-        recurringDonations: recurringDonationScheduler.getStatus(),
-        reconciliation: reconciliationService.getStatus()
-      }
-    });
-  } catch (error) {
-    return res.status(503).json({
-      status: 'degraded',
-      timestamp: new Date().toISOString(),
-      dependencies: { database: 'error' },
-      error: error.message
-    });
-  }
+  const health = await HealthCheckService.getFullHealth(stellarService);
+  const httpStatus = health.status === 'unhealthy' ? 503 : 200;
+  return res.status(httpStatus).json(health);
+});
+
+// Liveness probe — returns 200 as long as the process is running
+app.get('/health/live', (req, res) => {
+  return res.status(200).json(HealthCheckService.getLiveness());
+});
+
+// Readiness probe — returns 200 only when all dependencies are healthy
+app.get('/health/ready', async (req, res) => {
+  const readiness = await HealthCheckService.getReadiness(stellarService);
+  const httpStatus = readiness.ready ? 200 : 503;
+  return res.status(httpStatus).json(readiness);
 });
 
 // Abuse detection stats endpoint (admin only)

--- a/src/services/HealthCheckService.js
+++ b/src/services/HealthCheckService.js
@@ -1,0 +1,152 @@
+/**
+ * Health Check Service - Dependency Status Layer
+ *
+ * RESPONSIBILITY: Checks the health of all critical dependencies
+ * OWNER: Backend Team
+ * DEPENDENCIES: Database, StellarService, IdempotencyService
+ *
+ * Performs bounded-time checks against each dependency and aggregates
+ * results into a structured health report used by the health endpoints.
+ */
+
+const Database = require('../utils/database');
+
+/** Maximum time (ms) allowed for any single dependency check */
+const DEPENDENCY_TIMEOUT_MS = 2000;
+
+/**
+ * Run a single dependency check with a hard 2-second timeout.
+ *
+ * @param {string} name - Human-readable dependency name (used in logs)
+ * @param {Function} checkFn - Async function that resolves on success
+ * @returns {Promise<{status: string, responseTime: number, error?: string}>}
+ */
+async function runCheck(name, checkFn) {
+  const start = Date.now();
+  try {
+    await Promise.race([
+      checkFn(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(`${name} check timed out after ${DEPENDENCY_TIMEOUT_MS}ms`)), DEPENDENCY_TIMEOUT_MS)
+      ),
+    ]);
+    return { status: 'healthy', responseTime: Date.now() - start };
+  } catch (err) {
+    return { status: 'unhealthy', responseTime: Date.now() - start, error: err.message };
+  }
+}
+
+/**
+ * Check SQLite database connectivity by running a lightweight query.
+ *
+ * @returns {Promise<{status: string, responseTime: number, error?: string}>}
+ */
+async function checkDatabase() {
+  return runCheck('database', () => Database.get('SELECT 1 as ok'));
+}
+
+/**
+ * Check Stellar Horizon reachability.
+ * Uses the stellarService instance to verify the network is reachable.
+ * In mock mode this always resolves immediately.
+ *
+ * @param {Object} stellarService - StellarService or MockStellarService instance
+ * @returns {Promise<{status: string, responseTime: number, network?: string, horizonUrl?: string, error?: string}>}
+ */
+async function checkStellar(stellarService) {
+  const result = await runCheck('stellar', async () => {
+    // Both real and mock services expose getNetwork() and getHorizonUrl()
+    // For the real service we do a lightweight server root fetch via the SDK server object;
+    // for the mock we just confirm the service is instantiated.
+    if (stellarService.server && typeof stellarService.server.root === 'function') {
+      await stellarService.server.root();
+    }
+    // MockStellarService has no .server.root — presence of getNetwork() is enough
+  });
+
+  return {
+    ...result,
+    network: stellarService.getNetwork ? stellarService.getNetwork() : undefined,
+    horizonUrl: stellarService.getHorizonUrl ? stellarService.getHorizonUrl() : undefined,
+  };
+}
+
+/**
+ * Check idempotency service by verifying the idempotency_keys table is accessible.
+ * Uses a lightweight query to avoid schema-version dependencies.
+ *
+ * @returns {Promise<{status: string, responseTime: number, error?: string}>}
+ */
+async function checkIdempotency() {
+  return runCheck('idempotency', () =>
+    Database.get('SELECT COUNT(*) as count FROM idempotency_keys')
+  );
+}
+
+/**
+ * Aggregate all dependency checks and compute an overall status.
+ *
+ * Overall rules:
+ *  - "healthy"   → all dependencies healthy
+ *  - "degraded"  → some dependencies unhealthy (non-critical)
+ *  - "unhealthy" → database is unhealthy (critical dependency)
+ *
+ * @param {Object} stellarService - StellarService or MockStellarService instance
+ * @returns {Promise<{status: string, dependencies: Object, timestamp: string}>}
+ */
+async function getFullHealth(stellarService) {
+  // Call through module.exports so Jest spies can intercept individual checks
+  const self = module.exports;
+  const [database, stellar, idempotency] = await Promise.all([
+    self.checkDatabase(),
+    self.checkStellar(stellarService),
+    self.checkIdempotency(),
+  ]);
+
+  const dependencies = { database, stellar, idempotency };
+
+  let status;
+  if (database.status === 'unhealthy') {
+    status = 'unhealthy';
+  } else if (stellar.status === 'unhealthy' || idempotency.status === 'unhealthy') {
+    status = 'degraded';
+  } else {
+    status = 'healthy';
+  }
+
+  return { status, dependencies, timestamp: new Date().toISOString() };
+}
+
+/**
+ * Liveness check — confirms the process is alive.
+ * Never checks external dependencies; always returns healthy.
+ *
+ * @returns {{status: string, timestamp: string}}
+ */
+function getLiveness() {
+  return { status: 'alive', timestamp: new Date().toISOString() };
+}
+
+/**
+ * Readiness check — confirms all dependencies are reachable.
+ * Returns the same shape as getFullHealth but is used specifically
+ * to signal whether the instance should receive traffic.
+ *
+ * @param {Object} stellarService
+ * @returns {Promise<{ready: boolean, status: string, dependencies: Object, timestamp: string}>}
+ */
+async function getReadiness(stellarService) {
+  const health = await getFullHealth(stellarService);
+  const ready = health.status === 'healthy';
+  return { ready, ...health };
+}
+
+module.exports = {
+  checkDatabase,
+  checkStellar,
+  checkIdempotency,
+  getFullHealth,
+  getLiveness,
+  getReadiness,
+  DEPENDENCY_TIMEOUT_MS,
+};

--- a/tests/add-health-check-endpoint-with-dependency-status.test.js
+++ b/tests/add-health-check-endpoint-with-dependency-status.test.js
@@ -1,0 +1,301 @@
+/**
+ * Tests: Enhanced Health Check Endpoints
+ *
+ * Covers GET /health, GET /health/live, GET /health/ready
+ * Uses MockStellarService — no live Stellar network required.
+ */
+
+const request = require('supertest');
+const app = require('../src/routes/app');
+const HealthCheckService = require('../src/services/HealthCheckService');
+const Database = require('../src/utils/database');
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** Make Database.get reject to simulate a DB outage */
+function breakDatabase() {
+  jest.spyOn(Database, 'get').mockRejectedValue(new Error('SQLITE_CANTOPEN: unable to open database file'));
+}
+
+/** Restore all mocks */
+function restoreAll() {
+  jest.restoreAllMocks();
+}
+
+// ─── GET /health ─────────────────────────────────────────────────────────────
+
+describe('GET /health', () => {
+  afterEach(restoreAll);
+
+  it('returns 200 with status "healthy" when all dependencies are up', async () => {
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('healthy');
+    expect(res.body).toHaveProperty('timestamp');
+    expect(res.body).toHaveProperty('dependencies');
+  });
+
+  it('includes database, stellar, and idempotency in dependencies', async () => {
+    const res = await request(app).get('/health');
+
+    const { dependencies } = res.body;
+    expect(dependencies).toHaveProperty('database');
+    expect(dependencies).toHaveProperty('stellar');
+    expect(dependencies).toHaveProperty('idempotency');
+  });
+
+  it('each dependency entry has status and responseTime', async () => {
+    const res = await request(app).get('/health');
+
+    for (const dep of Object.values(res.body.dependencies)) {
+      expect(dep).toHaveProperty('status');
+      expect(dep).toHaveProperty('responseTime');
+      expect(typeof dep.responseTime).toBe('number');
+    }
+  });
+
+  it('returns 503 with status "unhealthy" when database is down', async () => {
+    breakDatabase();
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unhealthy');
+    expect(res.body.dependencies.database.status).toBe('unhealthy');
+    expect(res.body.dependencies.database).toHaveProperty('error');
+  });
+
+  it('returns 200 with status "degraded" when only stellar is unhealthy', async () => {
+    // Spy on checkStellar to simulate Horizon being unreachable
+    jest.spyOn(HealthCheckService, 'checkStellar').mockResolvedValue({
+      status: 'unhealthy',
+      responseTime: 2001,
+      error: 'stellar check timed out after 2000ms',
+    });
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('degraded');
+    expect(res.body.dependencies.stellar.status).toBe('unhealthy');
+  });
+
+  it('returns 200 with status "degraded" when only idempotency is unhealthy', async () => {
+    jest.spyOn(HealthCheckService, 'checkIdempotency').mockResolvedValue({
+      status: 'unhealthy',
+      responseTime: 50,
+      error: 'idempotency table missing',
+    });
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('degraded');
+    expect(res.body.dependencies.idempotency.status).toBe('unhealthy');
+  });
+
+  it('stellar dependency includes network and horizonUrl fields', async () => {
+    const res = await request(app).get('/health');
+
+    const { stellar } = res.body.dependencies;
+    expect(stellar).toHaveProperty('network');
+    expect(stellar).toHaveProperty('horizonUrl');
+  });
+});
+
+// ─── GET /health/live ────────────────────────────────────────────────────────
+
+describe('GET /health/live', () => {
+  it('returns 200 with status "alive"', async () => {
+    const res = await request(app).get('/health/live');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('alive');
+    expect(res.body).toHaveProperty('timestamp');
+  });
+
+  it('returns 200 even when database is down', async () => {
+    breakDatabase();
+
+    const res = await request(app).get('/health/live');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('alive');
+
+    restoreAll();
+  });
+});
+
+// ─── GET /health/ready ───────────────────────────────────────────────────────
+
+describe('GET /health/ready', () => {
+  afterEach(restoreAll);
+
+  it('returns 200 with ready:true when all dependencies are healthy', async () => {
+    const res = await request(app).get('/health/ready');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ready).toBe(true);
+    expect(res.body.status).toBe('healthy');
+  });
+
+  it('returns 503 with ready:false when database is down', async () => {
+    breakDatabase();
+
+    const res = await request(app).get('/health/ready');
+
+    expect(res.status).toBe(503);
+    expect(res.body.ready).toBe(false);
+  });
+
+  it('returns 503 with ready:false when status is degraded', async () => {
+    jest.spyOn(HealthCheckService, 'checkStellar').mockResolvedValue({
+      status: 'unhealthy',
+      responseTime: 2001,
+      error: 'timed out',
+    });
+
+    const res = await request(app).get('/health/ready');
+
+    // degraded means not ready
+    expect(res.status).toBe(503);
+    expect(res.body.ready).toBe(false);
+  });
+
+  it('includes dependencies in readiness response', async () => {
+    const res = await request(app).get('/health/ready');
+
+    expect(res.body).toHaveProperty('dependencies');
+    expect(res.body.dependencies).toHaveProperty('database');
+    expect(res.body.dependencies).toHaveProperty('stellar');
+    expect(res.body.dependencies).toHaveProperty('idempotency');
+  });
+});
+
+// ─── HealthCheckService unit tests ───────────────────────────────────────────
+
+describe('HealthCheckService unit tests', () => {
+  afterEach(restoreAll);
+
+  describe('checkDatabase', () => {
+    it('returns healthy when DB responds', async () => {
+      const result = await HealthCheckService.checkDatabase();
+      expect(result.status).toBe('healthy');
+      expect(result.responseTime).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns unhealthy when DB throws', async () => {
+      jest.spyOn(Database, 'get').mockRejectedValue(new Error('DB down'));
+      const result = await HealthCheckService.checkDatabase();
+      expect(result.status).toBe('unhealthy');
+      expect(result.error).toContain('DB down');
+    });
+  });
+
+  describe('checkStellar', () => {
+    it('returns healthy for MockStellarService', async () => {
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.checkStellar(mock);
+      expect(result.status).toBe('healthy');
+      expect(result.network).toBe('testnet');
+      expect(result.horizonUrl).toBeDefined();
+    });
+
+    it('returns unhealthy when stellar check times out', async () => {
+      const slowService = {
+        getNetwork: () => 'testnet',
+        getHorizonUrl: () => 'https://horizon-testnet.stellar.org',
+        server: {
+          root: () => new Promise(resolve => setTimeout(resolve, 5000)), // 5s > 2s limit
+        },
+      };
+      const result = await HealthCheckService.checkStellar(slowService);
+      expect(result.status).toBe('unhealthy');
+      expect(result.error).toMatch(/timed out/i);
+    }, 10000);
+  });
+
+  describe('checkIdempotency', () => {
+    it('returns healthy when idempotency table is accessible', async () => {
+      const result = await HealthCheckService.checkIdempotency();
+      expect(result.status).toBe('healthy');
+    });
+
+    it('returns unhealthy when idempotency table query fails', async () => {
+      jest.spyOn(Database, 'get').mockRejectedValue(new Error('table missing'));
+      const result = await HealthCheckService.checkIdempotency();
+      expect(result.status).toBe('unhealthy');
+      expect(result.error).toContain('table missing');
+    });
+  });
+
+  describe('getLiveness', () => {
+    it('always returns alive with a timestamp', () => {
+      const result = HealthCheckService.getLiveness();
+      expect(result.status).toBe('alive');
+      expect(result.timestamp).toBeDefined();
+    });
+  });
+
+  describe('getFullHealth', () => {
+    it('returns healthy when all checks pass', async () => {
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.getFullHealth(mock);
+      expect(result.status).toBe('healthy');
+    });
+
+    it('returns unhealthy when database is down', async () => {
+      jest.spyOn(Database, 'get').mockRejectedValue(new Error('DB down'));
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.getFullHealth(mock);
+      expect(result.status).toBe('unhealthy');
+    });
+
+    it('returns degraded when stellar is down but DB is up', async () => {
+      jest.spyOn(HealthCheckService, 'checkStellar').mockResolvedValue({
+        status: 'unhealthy', responseTime: 2001, error: 'timed out',
+      });
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.getFullHealth(mock);
+      expect(result.status).toBe('degraded');
+    });
+  });
+
+  describe('getReadiness', () => {
+    it('returns ready:true when healthy', async () => {
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.getReadiness(mock);
+      expect(result.ready).toBe(true);
+    });
+
+    it('returns ready:false when unhealthy', async () => {
+      jest.spyOn(Database, 'get').mockRejectedValue(new Error('DB down'));
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.getReadiness(mock);
+      expect(result.ready).toBe(false);
+    });
+
+    it('returns ready:false when degraded', async () => {
+      jest.spyOn(HealthCheckService, 'checkStellar').mockResolvedValue({
+        status: 'unhealthy', responseTime: 50, error: 'timed out',
+      });
+      const MockStellarService = require('../src/services/MockStellarService');
+      const mock = new MockStellarService();
+      const result = await HealthCheckService.getReadiness(mock);
+      expect(result.ready).toBe(false);
+    });
+  });
+
+  describe('DEPENDENCY_TIMEOUT_MS', () => {
+    it('is set to 2000ms', () => {
+      expect(HealthCheckService.DEPENDENCY_TIMEOUT_MS).toBe(2000);
+    });
+  });
+});


### PR DESCRIPTION
closes #316    feat: add health check endpoint with dependency status
{} package-lock.json Stellar-Micro-Donation-API
IMPLEMENT_CONFIGURABLE_DONATION_LIMITS_PER_WALLET.md Stellar-Micro-Donation-API\docs\features
JS donation.js Stellar-Micro-Donation-API\src\routes
JS wallet.js Stellar-Micro-Donation-APNsrc\routes
JS transaction.js Stellar-Micro-Donation-API\src\routes\models
JS DonationService.js Stellar-Micro-Donation-AP/\src\services
JS LimitService.js Stellar-Micro-Donation-API\src\services
JS database.js Stellar-Micro-Donation-APIsrc\utils
JS globalSetup.js Stellar-Micro-Donation-AP/\tests
JS implement-configurable-donation-limits-per-wallet.test.js Stellar-Micro-Donation-APNtests