### PR TITLE
feat: add rate limiting per API key with configurable thresholds (#302)

### DIFF
--- a/src/middleware/apiKey.js
+++ b/src/middleware/apiKey.js
@@ -13,6 +13,7 @@ const { securityConfig } = require("../config/securityConfig");
 const { validateKey } = require("../models/apiKeys");
 const log = require("../utils/log");
 const AuditLogService = require("../services/AuditLogService");
+const perKeyRateLimit = require("./perKeyRateLimit");
 
 /**
  * Legacy Support Configuration
@@ -104,7 +105,7 @@ const requireApiKey = async (req, res, next) => {
         );
       }
 
-      return next();
+      return perKeyRateLimit(req, res, next);
     }
 
     // Stage 2: Attempt Legacy Fallback (Static keys defined in environment variables)

--- a/src/middleware/perKeyRateLimit.js
+++ b/src/middleware/perKeyRateLimit.js
@@ -1,0 +1,78 @@
+/**
+ * Per-API-Key Rate Limiting Middleware
+ * Sliding window algorithm using in-memory store (Redis-compatible interface).
+ */
+
+const DEFAULT_RATE_LIMIT = 100;
+const DEFAULT_WINDOW_SECONDS = 60;
+
+// In-memory store: keyId -> array of request timestamps (ms)
+const store = new Map();
+
+function buildRateLimitHeaders(limit, remaining, resetAt) {
+  return {
+    'X-RateLimit-Limit': String(limit),
+    'X-RateLimit-Remaining': String(Math.max(0, remaining)),
+    'X-RateLimit-Reset': String(Math.ceil(resetAt / 1000)),
+  };
+}
+
+function checkRateLimit(keyId, limit, windowSeconds) {
+  const now = Date.now();
+  const windowMs = windowSeconds * 1000;
+  const cutoff = now - windowMs;
+
+  if (!store.has(keyId)) store.set(keyId, []);
+  const timestamps = store.get(keyId).filter(t => t > cutoff);
+
+  const remaining = limit - timestamps.length;
+  const resetAt = timestamps.length > 0 ? timestamps[0] + windowMs : now + windowMs;
+
+  if (remaining <= 0) {
+    store.set(keyId, timestamps);
+    return { allowed: false, limit, remaining: 0, resetAt };
+  }
+
+  timestamps.push(now);
+  store.set(keyId, timestamps);
+  return { allowed: true, limit, remaining: remaining - 1, resetAt };
+}
+
+// Exposed for testing
+function clearStore() {
+  store.clear();
+}
+
+const perKeyRateLimit = (req, res, next) => {
+  const keyInfo = req.apiKey;
+  // Skip for legacy/unauthenticated keys
+  if (!keyInfo || keyInfo.isLegacy || !keyInfo.id) return next();
+
+  const limit = keyInfo.rateLimit || DEFAULT_RATE_LIMIT;
+  const windowSeconds = keyInfo.rateLimitWindowSeconds || DEFAULT_WINDOW_SECONDS;
+
+  const result = checkRateLimit(keyInfo.id, limit, windowSeconds);
+  const headers = buildRateLimitHeaders(result.limit, result.remaining, result.resetAt);
+  res.set(headers);
+
+  if (!result.allowed) {
+    res.set('Retry-After', String(Math.ceil((result.resetAt - Date.now()) / 1000)));
+    return res.status(429).json({
+      success: false,
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Rate limit exceeded. Please retry after the reset time.',
+        retryAfter: Math.ceil((result.resetAt - Date.now()) / 1000),
+      },
+    });
+  }
+
+  return next();
+};
+
+module.exports = perKeyRateLimit;
+module.exports.buildRateLimitHeaders = buildRateLimitHeaders;
+module.exports.checkRateLimit = checkRateLimit;
+module.exports.clearStore = clearStore;
+module.exports.DEFAULT_RATE_LIMIT = DEFAULT_RATE_LIMIT;
+module.exports.DEFAULT_WINDOW_SECONDS = DEFAULT_WINDOW_SECONDS;

--- a/src/middleware/rbac.js
+++ b/src/middleware/rbac.js
@@ -14,6 +14,7 @@ const { hasPermission } = require('../models/permissions');
 const { validateApiKey } = require('../models/apiKeys');
 const config = require('../config');
 const AuditLogService = require('../services/AuditLogService');
+const perKeyRateLimit = require('./perKeyRateLimit');
 
 /**
  * Role-Based Access Control (RBAC) Configuration
@@ -275,6 +276,11 @@ exports.attachUserRole = () => {
       // Default: Unauthenticated Guest access
       else {
         req.user = { id: 'guest', role: 'guest', name: 'Guest' };
+      }
+
+      // Apply per-key rate limiting if a DB-backed key is present
+      if (req.apiKey && !req.apiKey.isLegacy && req.apiKey.id) {
+        return perKeyRateLimit(req, res, next);
       }
 
       next();

--- a/src/models/apiKeys.js
+++ b/src/models/apiKeys.js
@@ -17,7 +17,9 @@ const CREATE_TABLE_SQL = `
     last_used_at INTEGER,
     deprecated_at INTEGER,
     revoked_at INTEGER,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    rate_limit INTEGER,
+    rate_limit_window_seconds INTEGER
   )
 `;
 
@@ -25,7 +27,7 @@ async function initializeApiKeysTable() {
   await db.run(CREATE_TABLE_SQL);
 }
 
-async function createApiKey({ name, role = 'user', expiresInDays, createdBy, metadata = {} }) {
+async function createApiKey({ name, role = 'user', expiresInDays, createdBy, metadata = {}, rateLimit = null, rateLimitWindowSeconds = null }) {
   await initializeApiKeysTable();
   const rawKey = crypto.randomBytes(32).toString('hex');
   const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
@@ -34,9 +36,9 @@ async function createApiKey({ name, role = 'user', expiresInDays, createdBy, met
   const expiresAt = expiresInDays ? now + expiresInDays * 24 * 60 * 60 * 1000 : null;
 
   const result = await db.run(
-    `INSERT INTO api_keys (key_hash, key_prefix, name, role, status, created_by, metadata, expires_at, created_at)
-     VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)`,
-    [keyHash, keyPrefix, name, role, createdBy || null, JSON.stringify(metadata), expiresAt, now]
+    `INSERT INTO api_keys (key_hash, key_prefix, name, role, status, created_by, metadata, expires_at, created_at, rate_limit, rate_limit_window_seconds)
+     VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)`,
+    [keyHash, keyPrefix, name, role, createdBy || null, JSON.stringify(metadata), expiresAt, now, rateLimit, rateLimitWindowSeconds]
   );
 
   return {
@@ -48,6 +50,8 @@ async function createApiKey({ name, role = 'user', expiresInDays, createdBy, met
     status: API_KEY_STATUS.ACTIVE,
     createdAt: new Date(now).toISOString(),
     expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+    rateLimit,
+    rateLimitWindowSeconds,
   };
 }
 
@@ -77,6 +81,8 @@ async function validateApiKey(rawKey) {
     isDeprecated: row.status === API_KEY_STATUS.DEPRECATED,
     last_used_at: now,
     metadata: row.metadata ? JSON.parse(row.metadata) : {},
+    rateLimit: row.rate_limit || null,
+    rateLimitWindowSeconds: row.rate_limit_window_seconds || null,
   };
 }
 
@@ -125,6 +131,15 @@ async function revokeApiKey(id) {
   return result.changes > 0;
 }
 
+async function updateApiKey(id, { rateLimit, rateLimitWindowSeconds }) {
+  await initializeApiKeysTable();
+  const result = await db.run(
+    `UPDATE api_keys SET rate_limit = ?, rate_limit_window_seconds = ? WHERE id = ? AND status != 'revoked'`,
+    [rateLimit ?? null, rateLimitWindowSeconds ?? null, id]
+  );
+  return result.changes > 0;
+}
+
 async function cleanupOldKeys(retentionDays = 90) {
   await initializeApiKeysTable();
   const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
@@ -143,5 +158,6 @@ module.exports = {
   listApiKeys,
   deprecateApiKey,
   revokeApiKey,
+  updateApiKey,
   cleanupOldKeys,
 };

--- a/src/routes/apiKeys.js
+++ b/src/routes/apiKeys.js
@@ -28,6 +28,8 @@ const apiKeyCreateSchema = validateSchema({
       role: { type: 'string', required: false, enum: ['admin', 'user', 'guest'] },
       expiresInDays: { type: 'integer', required: false, min: 1 },
       metadata: { type: 'object', required: false, nullable: true },
+      rateLimit: { type: 'integer', required: false, min: 1 },
+      rateLimitWindowSeconds: { type: 'integer', required: false, min: 1 },
     },
   },
 });
@@ -64,7 +66,7 @@ const apiKeyCleanupSchema = validateSchema({
  */
 router.post('/', requireAdmin(), apiKeyCreateSchema, async (req, res, next) => {
   try {
-    const { name, role = 'user', expiresInDays, metadata } = req.body;
+    const { name, role = 'user', expiresInDays, metadata, rateLimit, rateLimitWindowSeconds } = req.body;
 
     const nameValidation = validateNonEmptyString(name, 'Name');
     if (!nameValidation.valid) {
@@ -88,7 +90,9 @@ router.post('/', requireAdmin(), apiKeyCreateSchema, async (req, res, next) => {
       role,
       expiresInDays,
       createdBy: req.user.id,
-      metadata: metadata || {}
+      metadata: metadata || {},
+      rateLimit: rateLimit || null,
+      rateLimitWindowSeconds: rateLimitWindowSeconds || null,
     });
 
     // Audit log: API key created
@@ -121,6 +125,8 @@ router.post('/', requireAdmin(), apiKeyCreateSchema, async (req, res, next) => {
         status: keyInfo.status,
         createdAt: keyInfo.createdAt,
         expiresAt: keyInfo.expiresAt,
+        rateLimit: keyInfo.rateLimit,
+        rateLimitWindowSeconds: keyInfo.rateLimitWindowSeconds,
         warning: 'Store this key securely. It will not be shown again.'
       }
     });
@@ -165,6 +171,35 @@ router.get('/', requireAdmin(), apiKeyListQuerySchema, async (req, res, next) =>
     });
   } catch (error) {
     next(error);
+  }
+});
+
+/**
+ * PATCH /api/v1/api-keys/:id
+ * Update rate limit configuration for an API key (admin only)
+ */
+router.patch('/:id', requireAdmin(), apiKeyIdParamSchema, async (req, res, next) => {
+  try {
+    const keyIdValidation = validateInteger(req.params.id, { min: 1 });
+    if (!keyIdValidation.valid) return res.status(400).json({ success: false, error: { message: keyIdValidation.error } });
+
+    const { rateLimit, rateLimitWindowSeconds } = req.body;
+
+    if (rateLimit !== undefined && rateLimit !== null) {
+      const v = validateInteger(rateLimit, { min: 1 });
+      if (!v.valid) return res.status(400).json({ success: false, error: { message: `Invalid rateLimit: ${v.error}` } });
+    }
+    if (rateLimitWindowSeconds !== undefined && rateLimitWindowSeconds !== null) {
+      const v = validateInteger(rateLimitWindowSeconds, { min: 1 });
+      if (!v.valid) return res.status(400).json({ success: false, error: { message: `Invalid rateLimitWindowSeconds: ${v.error}` } });
+    }
+
+    const updated = await apiKeysModel.updateApiKey(keyIdValidation.value, { rateLimit, rateLimitWindowSeconds });
+    if (!updated) return res.status(404).json({ success: false, error: { message: 'API key not found or revoked' } });
+
+    return res.json({ success: true, message: 'API key updated successfully' });
+  } catch (err) {
+    next(err);
   }
 });
 

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -55,7 +55,9 @@ module.exports = async () => {
       last_used_at INTEGER,
       deprecated_at INTEGER,
       revoked_at INTEGER,
-      created_at INTEGER NOT NULL
+      created_at INTEGER NOT NULL,
+      rate_limit INTEGER,
+      rate_limit_window_seconds INTEGER
     )`);
     await Database.run(`CREATE TABLE IF NOT EXISTS audit_logs (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/perKeyRateLimit.test.js
+++ b/tests/perKeyRateLimit.test.js
@@ -1,0 +1,178 @@
+/**
+ * Per-API-Key Rate Limiting Tests
+ * Unit + integration tests for rate limit enforcement and header correctness.
+ */
+
+const request = require('supertest');
+const app = require('../src/routes/app');
+const apiKeysModel = require('../src/models/apiKeys');
+const { checkRateLimit, buildRateLimitHeaders, clearStore, DEFAULT_RATE_LIMIT, DEFAULT_WINDOW_SECONDS } = require('../src/middleware/perKeyRateLimit');
+
+// ─── Unit Tests ───────────────────────────────────────────────────────────────
+
+describe('Per-Key Rate Limiting - Unit Tests', () => {
+  beforeEach(() => clearStore());
+
+  describe('checkRateLimit', () => {
+    it('allows requests within the limit', () => {
+      const result = checkRateLimit('key-1', 5, 60);
+      expect(result.allowed).toBe(true);
+      expect(result.limit).toBe(5);
+      expect(result.remaining).toBe(4);
+    });
+
+    it('blocks requests exceeding the limit', () => {
+      for (let i = 0; i < 3; i++) checkRateLimit('key-2', 3, 60);
+      const result = checkRateLimit('key-2', 3, 60);
+      expect(result.allowed).toBe(false);
+      expect(result.remaining).toBe(0);
+    });
+
+    it('tracks limits independently per key', () => {
+      checkRateLimit('key-a', 2, 60);
+      checkRateLimit('key-a', 2, 60);
+      const blocked = checkRateLimit('key-a', 2, 60);
+      const allowed = checkRateLimit('key-b', 2, 60);
+      expect(blocked.allowed).toBe(false);
+      expect(allowed.allowed).toBe(true);
+    });
+
+    it('uses default limit and window when not specified', () => {
+      const result = checkRateLimit('key-default', DEFAULT_RATE_LIMIT, DEFAULT_WINDOW_SECONDS);
+      expect(result.limit).toBe(DEFAULT_RATE_LIMIT);
+      expect(result.remaining).toBe(DEFAULT_RATE_LIMIT - 1);
+    });
+
+    it('provides a resetAt timestamp in the future', () => {
+      const before = Date.now();
+      const result = checkRateLimit('key-reset', 5, 60);
+      expect(result.resetAt).toBeGreaterThan(before);
+    });
+  });
+
+  describe('buildRateLimitHeaders', () => {
+    it('returns correct header values', () => {
+      const resetAt = Date.now() + 60000;
+      const headers = buildRateLimitHeaders(100, 42, resetAt);
+      expect(headers['X-RateLimit-Limit']).toBe('100');
+      expect(headers['X-RateLimit-Remaining']).toBe('42');
+      expect(headers['X-RateLimit-Reset']).toBe(String(Math.ceil(resetAt / 1000)));
+    });
+
+    it('clamps remaining to 0 when negative', () => {
+      const headers = buildRateLimitHeaders(5, -1, Date.now() + 1000);
+      expect(headers['X-RateLimit-Remaining']).toBe('0');
+    });
+  });
+});
+
+// ─── Integration Tests ────────────────────────────────────────────────────────
+
+describe('Per-Key Rate Limiting - Integration Tests', () => {
+  let adminKey;
+
+  beforeAll(async () => {
+    const admin = await apiKeysModel.createApiKey({ name: 'Rate Limit Admin', role: 'admin', createdBy: 'test' });
+    adminKey = admin.key;
+  });
+
+  beforeEach(() => clearStore());
+
+  it('returns rate limit headers on authenticated requests', async () => {
+    const res = await request(app).get('/health').set('x-api-key', adminKey);
+    expect(res.headers['x-ratelimit-limit']).toBeDefined();
+    expect(res.headers['x-ratelimit-remaining']).toBeDefined();
+    expect(res.headers['x-ratelimit-reset']).toBeDefined();
+  });
+
+  it('returns 429 when per-key limit is exceeded', async () => {
+    const key = await apiKeysModel.createApiKey({
+      name: 'Low Limit Key',
+      role: 'user',
+      createdBy: 'test',
+      rateLimit: 2,
+      rateLimitWindowSeconds: 60,
+    });
+
+    await request(app).get('/health').set('x-api-key', key.key);
+    await request(app).get('/health').set('x-api-key', key.key);
+    const res = await request(app).get('/health').set('x-api-key', key.key);
+
+    expect(res.status).toBe(429);
+    expect(res.body.error.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+
+  it('reflects custom rate limit in headers', async () => {
+    const key = await apiKeysModel.createApiKey({
+      name: 'Custom Limit Key',
+      role: 'user',
+      createdBy: 'test',
+      rateLimit: 50,
+      rateLimitWindowSeconds: 30,
+    });
+
+    const res = await request(app).get('/health').set('x-api-key', key.key);
+    expect(res.headers['x-ratelimit-limit']).toBe('50');
+    expect(res.headers['x-ratelimit-remaining']).toBe('49');
+  });
+
+  it('uses default limit for keys without explicit rate limit', async () => {
+    const key = await apiKeysModel.createApiKey({ name: 'Default Limit Key', role: 'user', createdBy: 'test' });
+    const res = await request(app).get('/health').set('x-api-key', key.key);
+    expect(res.headers['x-ratelimit-limit']).toBe(String(DEFAULT_RATE_LIMIT));
+  });
+
+  it('PATCH /api-keys/:id updates rate limit config', async () => {
+    const key = await apiKeysModel.createApiKey({ name: 'Patchable Key', role: 'user', createdBy: 'test' });
+
+    const res = await request(app)
+      .patch(`/api-keys/${key.id}`)
+      .set('x-api-key', adminKey)
+      .send({ rateLimit: 10, rateLimitWindowSeconds: 30 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('PATCH /api-keys/:id returns 404 for non-existent key', async () => {
+    const res = await request(app)
+      .patch('/api-keys/999999')
+      .set('x-api-key', adminKey)
+      .send({ rateLimit: 10 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /api-keys accepts rateLimit and rateLimitWindowSeconds', async () => {
+    const res = await request(app)
+      .post('/api-keys')
+      .set('x-api-key', adminKey)
+      .send({ name: 'Rate Limited Key', role: 'user', rateLimit: 20, rateLimitWindowSeconds: 120 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.rateLimit).toBe(20);
+    expect(res.body.data.rateLimitWindowSeconds).toBe(120);
+  });
+
+  it('rate limit state resets after window expires', async () => {
+    const key = await apiKeysModel.createApiKey({
+      name: 'Window Reset Key',
+      role: 'user',
+      createdBy: 'test',
+      rateLimit: 1,
+      rateLimitWindowSeconds: 60,
+    });
+
+    // Exhaust the limit
+    await request(app).get('/health').set('x-api-key', key.key);
+    const blocked = await request(app).get('/health').set('x-api-key', key.key);
+    expect(blocked.status).toBe(429);
+
+    // Manually expire the window by clearing the store
+    clearStore();
+
+    const allowed = await request(app).get('/health').set('x-api-key', key.key);
+    expect(allowed.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #302

### What changed
- POST /api-keys accepts rateLimit and rateLimitWindowSeconds params
- PATCH /api-keys/:id — update rate limit config on existing keys
- X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset headers on all authenticated requests
- 429 + Retry-After when per-key limit is exceeded
- Keys without explicit limits fall back to global default (100 req / 60s)
- Sliding window in-memory store (src/middleware/perKeyRateLimit.js)

### Tests
- tests/perKeyRateLimit.test.js — unit + integration tests