### PR TITLE
feat: add webhook system for real-time transaction state notifications

### DIFF
--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -19,6 +19,7 @@ const streamRoutes = require('./stream');
 const transactionRoutes = require('./transaction');
 const apiKeysRoutes = require('./apiKeys');
 const feesRoutes = require('./fees');
+const webhooksRoutes = require('./webhooks');
 const { errorHandler, notFoundHandler } = require('../middleware/errorHandler');
 const logger = require('../middleware/logger');
 const { attachUserRole } = require('../middleware/rbac');
@@ -27,6 +28,7 @@ const replayDetectionMiddleware = require('../middleware/replayDetection');
 const Database = require('../utils/database');
 const HealthCheckService = require('../services/HealthCheckService');
 const { initializeApiKeysTable } = require('../models/apiKeys');
+const WebhookService = require('../services/WebhookService');
 const { validateRBAC } = require('../utils/rbacValidator');
 const log = require('../utils/log');
 const requestId = require('../middleware/requestId');
@@ -83,6 +85,7 @@ app.use('/stream', streamRoutes);
 app.use('/transactions', transactionRoutes);
 app.use('/api-keys', apiKeysRoutes);
 app.use('/fees', feesRoutes);
+app.use('/webhooks', webhooksRoutes);
 
 // Health check endpoints
 app.get('/health', async (req, res) => {
@@ -295,6 +298,7 @@ async function startServer() {
     await logStartupDiagnostics();
     await Database.initialize();
     await initializeApiKeysTable();
+    await WebhookService.initTable();
     await validateRBAC();
 
     const server = app.listen(PORT, () => {

--- a/src/routes/webhooks.js
+++ b/src/routes/webhooks.js
@@ -1,0 +1,61 @@
+/**
+ * Webhook Routes
+ * POST /webhooks   - Register a webhook
+ * GET  /webhooks   - List webhooks
+ * DELETE /webhooks/:id - Remove a webhook
+ */
+
+const express = require('express');
+const router = express.Router();
+const requireApiKey = require('../middleware/apiKey');
+const WebhookService = require('../services/WebhookService');
+
+/**
+ * POST /webhooks
+ * Register a new webhook endpoint.
+ * Body: { url, events: string[], secret? }
+ */
+router.post('/', requireApiKey, async (req, res, next) => {
+  try {
+    const { url, events, secret } = req.body;
+    const webhook = await WebhookService.register({
+      url,
+      events,
+      secret,
+      apiKeyId: req.apiKeyId || null,
+    });
+    res.status(201).json({ success: true, data: webhook });
+  } catch (err) {
+    if (err.status === 400) return res.status(400).json({ success: false, error: { message: err.message } });
+    next(err);
+  }
+});
+
+/**
+ * GET /webhooks
+ * List all registered webhooks (secrets omitted).
+ */
+router.get('/', requireApiKey, async (req, res, next) => {
+  try {
+    const webhooks = await WebhookService.list();
+    res.json({ success: true, data: webhooks, count: webhooks.length });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * DELETE /webhooks/:id
+ * Remove a webhook by ID.
+ */
+router.delete('/:id', requireApiKey, async (req, res, next) => {
+  try {
+    await WebhookService.remove(parseInt(req.params.id, 10));
+    res.json({ success: true });
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ success: false, error: { message: err.message } });
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/src/services/TransactionReconciliationService.js
+++ b/src/services/TransactionReconciliationService.js
@@ -18,6 +18,7 @@ const Database = require('../utils/database');
 const Transaction = require('../routes/models/transaction');
 const { TRANSACTION_STATES } = require('../utils/transactionStateMachine');
 const log = require('../utils/log');
+const WebhookService = require('./WebhookService');
 
 /** Orphan count threshold that triggers an alert */
 const ORPHAN_ALERT_THRESHOLD = parseInt(process.env.ORPHAN_ALERT_THRESHOLD || '1', 10);
@@ -173,6 +174,16 @@ class TransactionReconciliationService {
           stellarTxId: tx.stellarTxId,
           previousStatus: tx.status,
         });
+
+        // Deliver webhook for state change
+        WebhookService.deliver('transaction.confirmed', {
+          id: tx.id,
+          stellarTxId: tx.stellarTxId,
+          previousStatus: tx.status,
+          status: TRANSACTION_STATES.CONFIRMED,
+          ledger: result.transaction && result.transaction.ledger,
+          confirmedAt: new Date().toISOString(),
+        }).catch(err => log.warn('RECONCILIATION', 'Webhook delivery error', { error: err.message }));
 
         return true;
       }

--- a/src/services/WebhookService.js
+++ b/src/services/WebhookService.js
@@ -1,0 +1,231 @@
+/**
+ * WebhookService - Webhook Registration and Delivery
+ *
+ * RESPONSIBILITY: Register webhook endpoints, deliver signed payloads,
+ *                 retry failed deliveries with exponential backoff, and
+ *                 auto-disable webhooks after 5 consecutive failures.
+ */
+
+const crypto = require('crypto');
+const https = require('https');
+const http = require('http');
+const Database = require('../utils/database');
+const log = require('../utils/log');
+
+const MAX_RETRIES = 5;
+const BASE_BACKOFF_MS = 1000; // 1s, 2s, 4s, 8s, 16s
+const MAX_CONSECUTIVE_FAILURES = 5;
+const DELIVERY_TIMEOUT_MS = 5000;
+
+class WebhookService {
+  /**
+   * Create the webhooks table if it doesn't exist.
+   */
+  static async initTable() {
+    await Database.run(`
+      CREATE TABLE IF NOT EXISTS webhooks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url TEXT NOT NULL,
+        events TEXT NOT NULL,
+        secret TEXT NOT NULL,
+        api_key_id TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        is_active INTEGER NOT NULL DEFAULT 1,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+  }
+
+  /**
+   * Register a new webhook.
+   * @param {object} params
+   * @param {string} params.url - HTTPS URL to deliver events to
+   * @param {string[]} params.events - Event types e.g. ['transaction.confirmed']
+   * @param {string} [params.secret] - HMAC secret; auto-generated if omitted
+   * @param {string} [params.apiKeyId]
+   * @returns {Promise<object>} Created webhook record
+   */
+  static async register({ url, events, secret, apiKeyId }) {
+    if (!url || !events || !Array.isArray(events) || events.length === 0) {
+      throw Object.assign(new Error('url and events[] are required'), { status: 400 });
+    }
+
+    try { new URL(url); } catch {
+      throw Object.assign(new Error('Invalid webhook URL'), { status: 400 });
+    }
+
+    const webhookSecret = secret || crypto.randomBytes(32).toString('hex');
+    const eventsJson = JSON.stringify(events);
+
+    const result = await Database.run(
+      `INSERT INTO webhooks (url, events, secret, api_key_id) VALUES (?, ?, ?, ?)`,
+      [url, eventsJson, webhookSecret, apiKeyId || null]
+    );
+
+    return {
+      id: result.id,
+      url,
+      events,
+      secret: webhookSecret,
+      apiKeyId: apiKeyId || null,
+      isActive: true,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * List all active webhooks.
+   * @returns {Promise<object[]>}
+   */
+  static async list() {
+    const rows = await Database.query(
+      `SELECT id, url, events, api_key_id, created_at, is_active FROM webhooks ORDER BY created_at DESC`
+    );
+    return rows.map(r => ({
+      id: r.id,
+      url: r.url,
+      events: JSON.parse(r.events),
+      apiKeyId: r.api_key_id,
+      createdAt: r.created_at,
+      isActive: Boolean(r.is_active),
+    }));
+  }
+
+  /**
+   * Delete (hard-delete) a webhook by ID.
+   * @param {number} id
+   */
+  static async remove(id) {
+    const result = await Database.run(`DELETE FROM webhooks WHERE id = ?`, [id]);
+    if (result.changes === 0) {
+      throw Object.assign(new Error('Webhook not found'), { status: 404 });
+    }
+  }
+
+  /**
+   * Deliver an event to all active webhooks subscribed to it.
+   * Fires-and-forgets retries; does not block the caller.
+   * @param {string} event - Event type e.g. 'transaction.confirmed'
+   * @param {object} payload - Event data
+   */
+  static async deliver(event, payload) {
+    let webhooks;
+    try {
+      webhooks = await Database.query(
+        `SELECT * FROM webhooks WHERE is_active = 1`
+      );
+    } catch (err) {
+      log.error('WEBHOOK', 'Failed to query webhooks', { error: err.message });
+      return;
+    }
+
+    const interested = webhooks.filter(w => {
+      try {
+        const events = JSON.parse(w.events);
+        return events.includes(event) || events.includes('*');
+      } catch { return false; }
+    });
+
+    for (const webhook of interested) {
+      // Fire-and-forget with retry
+      this._deliverWithRetry(webhook, event, payload, 0).catch(() => {});
+    }
+  }
+
+  /**
+   * Attempt delivery with exponential backoff retry.
+   * @private
+   */
+  static async _deliverWithRetry(webhook, event, payload, attempt) {
+    const body = JSON.stringify({ event, data: payload, timestamp: new Date().toISOString() });
+    const signature = this._sign(body, webhook.secret);
+
+    try {
+      await this._httpPost(webhook.url, body, signature);
+      // Reset failure counter on success
+      await Database.run(
+        `UPDATE webhooks SET consecutive_failures = 0 WHERE id = ?`,
+        [webhook.id]
+      ).catch(() => {});
+      log.debug('WEBHOOK', 'Delivered', { id: webhook.id, event, attempt });
+    } catch (err) {
+      const failures = (webhook.consecutive_failures || 0) + 1;
+      log.warn('WEBHOOK', 'Delivery failed', { id: webhook.id, event, attempt, error: err.message });
+
+      if (failures >= MAX_CONSECUTIVE_FAILURES) {
+        await Database.run(
+          `UPDATE webhooks SET is_active = 0, consecutive_failures = ? WHERE id = ?`,
+          [failures, webhook.id]
+        ).catch(() => {});
+        log.warn('WEBHOOK', 'Webhook auto-disabled after consecutive failures', { id: webhook.id });
+        return;
+      }
+
+      await Database.run(
+        `UPDATE webhooks SET consecutive_failures = ? WHERE id = ?`,
+        [failures, webhook.id]
+      ).catch(() => {});
+
+      // Update local copy for next retry check
+      webhook.consecutive_failures = failures;
+
+      if (attempt < MAX_RETRIES - 1) {
+        const delay = BASE_BACKOFF_MS * Math.pow(2, attempt);
+        await new Promise(r => setTimeout(r, delay));
+        return this._deliverWithRetry(webhook, event, payload, attempt + 1);
+      }
+    }
+  }
+
+  /**
+   * Compute HMAC-SHA256 signature for a payload.
+   * @param {string} body - Raw JSON string
+   * @param {string} secret - Webhook secret
+   * @returns {string} hex digest
+   */
+  static _sign(body, secret) {
+    return crypto.createHmac('sha256', secret).update(body).digest('hex');
+  }
+
+  /**
+   * POST a JSON body to a URL with a timeout.
+   * @private
+   */
+  static _httpPost(url, body, signature) {
+    return new Promise((resolve, reject) => {
+      const parsed = new URL(url);
+      const lib = parsed.protocol === 'https:' ? https : http;
+      const options = {
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          'X-Webhook-Signature': `sha256=${signature}`,
+        },
+        timeout: DELIVERY_TIMEOUT_MS,
+      };
+
+      const req = lib.request(options, (res) => {
+        // Drain response body
+        res.resume();
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(res.statusCode);
+          } else {
+            reject(new Error(`HTTP ${res.statusCode}`));
+          }
+        });
+      });
+
+      req.on('timeout', () => { req.destroy(new Error('Request timed out')); });
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+  }
+}
+
+module.exports = WebhookService;

--- a/tests/webhooks.test.js
+++ b/tests/webhooks.test.js
@@ -1,0 +1,317 @@
+/**
+ * Webhook Tests
+ * Tests for WebhookService (registration, delivery, retry, HMAC signing, auto-disable)
+ * and the /webhooks HTTP endpoints.
+ */
+
+// Mock broken modules with duplicate declarations (pre-existing issue)
+jest.mock('../src/models/apiKeys', () => ({
+  initializeApiKeysTable: jest.fn().mockResolvedValue(undefined),
+  createApiKey: jest.fn(),
+  listApiKeys: jest.fn(),
+  getApiKeyByValue: jest.fn().mockResolvedValue({ id: 1, role: 'admin', status: 'active', key_hash: 'x' }),
+  rotateApiKey: jest.fn(),
+  deprecateApiKey: jest.fn(),
+  revokeApiKey: jest.fn(),
+  revokeExpiredDeprecatedKeys: jest.fn().mockResolvedValue(0),
+}));
+
+jest.mock('../src/services/RecurringDonationScheduler', () => ({
+  Class: class { start() {} stop() {} },
+}));
+
+// Database mock — store lives inside the factory to satisfy Jest's scope rules
+jest.mock('../src/utils/database', () => {
+  const mockStore = { rows: [], nextId: 1 };
+
+  const run = jest.fn().mockImplementation(async (sql, params) => {
+    if (sql.includes('CREATE TABLE')) return {};
+    if (sql.includes('INSERT INTO webhooks')) {
+      const id = mockStore.nextId++;
+      mockStore.rows.push({
+        id, url: params[0], events: params[1], secret: params[2],
+        api_key_id: params[3], created_at: new Date().toISOString(),
+        is_active: 1, consecutive_failures: 0,
+      });
+      return { id, changes: 1 };
+    }
+    if (sql.includes('DELETE FROM webhooks')) {
+      const id = params[0];
+      const idx = mockStore.rows.findIndex(w => w.id === id);
+      if (idx === -1) return { changes: 0 };
+      mockStore.rows.splice(idx, 1);
+      return { changes: 1 };
+    }
+    if (sql.includes('UPDATE webhooks')) {
+      const id = params[params.length - 1];
+      const w = mockStore.rows.find(h => h.id === id);
+      if (w) {
+        if (sql.includes('is_active = 0')) { w.is_active = 0; w.consecutive_failures = params[0]; }
+        else if (sql.includes('consecutive_failures = 0')) { w.consecutive_failures = 0; }
+        else { w.consecutive_failures = params[0]; }
+      }
+      return { changes: 1 };
+    }
+    return { changes: 0 };
+  });
+
+  const query = jest.fn().mockImplementation(async (sql) => {
+    if (sql.includes('FROM webhooks')) return [...mockStore.rows];
+    return [];
+  });
+
+  return {
+    initialize: jest.fn().mockResolvedValue(undefined),
+    run,
+    query,
+    get: jest.fn().mockResolvedValue(null),
+    close: jest.fn().mockResolvedValue(undefined),
+    _store: mockStore, // expose for test assertions
+  };
+});
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-key-1';
+
+const crypto = require('crypto');
+const request = require('supertest');
+const express = require('express');
+const WebhookService = require('../src/services/WebhookService');
+const db = require('../src/utils/database');
+
+// Reset store before each test
+beforeEach(() => {
+  db._store.rows.length = 0;
+  db._store.nextId = 1;
+});
+
+// ── WebhookService unit tests ─────────────────────────────────────────────────
+
+describe('WebhookService.register()', () => {
+  it('registers a webhook and returns it with a secret', async () => {
+    const wh = await WebhookService.register({
+      url: 'https://example.com/hook',
+      events: ['transaction.confirmed'],
+    });
+
+    expect(wh.id).toBe(1);
+    expect(wh.url).toBe('https://example.com/hook');
+    expect(wh.events).toEqual(['transaction.confirmed']);
+    expect(typeof wh.secret).toBe('string');
+    expect(wh.secret.length).toBeGreaterThan(0);
+    expect(wh.isActive).toBe(true);
+  });
+
+  it('uses provided secret when given', async () => {
+    const wh = await WebhookService.register({
+      url: 'https://example.com/hook',
+      events: ['transaction.confirmed'],
+      secret: 'my-secret',
+    });
+    expect(wh.secret).toBe('my-secret');
+  });
+
+  it('throws 400 for missing url', async () => {
+    await expect(WebhookService.register({ events: ['transaction.confirmed'] }))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  it('throws 400 for empty events array', async () => {
+    await expect(WebhookService.register({ url: 'https://example.com/hook', events: [] }))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  it('throws 400 for invalid URL', async () => {
+    await expect(WebhookService.register({ url: 'not-a-url', events: ['transaction.confirmed'] }))
+      .rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('WebhookService.list()', () => {
+  it('returns empty array when no webhooks registered', async () => {
+    const list = await WebhookService.list();
+    expect(list).toEqual([]);
+  });
+
+  it('returns registered webhooks without secret', async () => {
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.confirmed'] });
+    const list = await WebhookService.list();
+
+    expect(list).toHaveLength(1);
+    expect(list[0].url).toBe('https://a.com/hook');
+    expect(list[0].secret).toBeUndefined();
+  });
+});
+
+describe('WebhookService.remove()', () => {
+  it('removes a registered webhook', async () => {
+    const wh = await WebhookService.register({ url: 'https://a.com/hook', events: ['*'] });
+    await WebhookService.remove(wh.id);
+    expect(db._store.rows).toHaveLength(0);
+  });
+
+  it('throws 404 for unknown id', async () => {
+    await expect(WebhookService.remove(999)).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('WebhookService HMAC signing', () => {
+  it('_sign produces consistent HMAC-SHA256 hex', () => {
+    const body = '{"event":"transaction.confirmed"}';
+    const secret = 'test-secret';
+    const sig = WebhookService._sign(body, secret);
+    const expected = crypto.createHmac('sha256', secret).update(body).digest('hex');
+    expect(sig).toBe(expected);
+  });
+
+  it('different secrets produce different signatures', () => {
+    const body = '{"event":"test"}';
+    expect(WebhookService._sign(body, 'secret-a')).not.toBe(WebhookService._sign(body, 'secret-b'));
+  });
+});
+
+describe('WebhookService.deliver()', () => {
+  it('skips delivery when no webhooks match the event', async () => {
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.failed'] });
+    await expect(WebhookService.deliver('transaction.confirmed', { id: '1' })).resolves.toBeUndefined();
+  });
+
+  it('delivers to wildcard (*) subscribed webhooks', async () => {
+    const spy = jest.spyOn(WebhookService, '_deliverWithRetry').mockResolvedValue(undefined);
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['*'] });
+    await WebhookService.deliver('transaction.confirmed', { id: '1' });
+    await new Promise(r => setImmediate(r));
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('delivers to matching event subscribers', async () => {
+    const spy = jest.spyOn(WebhookService, '_deliverWithRetry').mockResolvedValue(undefined);
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.confirmed'] });
+    await WebhookService.deliver('transaction.confirmed', { id: '1' });
+    await new Promise(r => setImmediate(r));
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('does not deliver to non-matching event subscribers', async () => {
+    const spy = jest.spyOn(WebhookService, '_deliverWithRetry').mockResolvedValue(undefined);
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.failed'] });
+    await WebhookService.deliver('transaction.confirmed', { id: '1' });
+    await new Promise(r => setImmediate(r));
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('WebhookService retry and auto-disable', () => {
+  it('auto-disables webhook after 5 consecutive failures', async () => {
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.confirmed'] });
+    db._store.rows[0].consecutive_failures = 4;
+
+    jest.spyOn(WebhookService, '_httpPost').mockRejectedValue(new Error('connection refused'));
+
+    await WebhookService._deliverWithRetry(db._store.rows[0], 'transaction.confirmed', {}, 0);
+
+    expect(db._store.rows[0].is_active).toBe(0);
+    jest.restoreAllMocks();
+  });
+
+  it('resets consecutive_failures counter on successful delivery', async () => {
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.confirmed'] });
+    db._store.rows[0].consecutive_failures = 2;
+
+    jest.spyOn(WebhookService, '_httpPost').mockResolvedValue(200);
+
+    await WebhookService._deliverWithRetry(db._store.rows[0], 'transaction.confirmed', {}, 0);
+
+    expect(db._store.rows[0].consecutive_failures).toBe(0);
+    jest.restoreAllMocks();
+  });
+
+  it('increments consecutive_failures on each failed attempt', async () => {
+    await WebhookService.register({ url: 'https://a.com/hook', events: ['transaction.confirmed'] });
+    db._store.rows[0].consecutive_failures = 1;
+
+    // Fail once then succeed to stop the chain
+    jest.spyOn(WebhookService, '_httpPost')
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue(200);
+
+    await WebhookService._deliverWithRetry(db._store.rows[0], 'transaction.confirmed', {}, 0);
+
+    // After retry succeeds, failures reset to 0
+    expect(db._store.rows[0].consecutive_failures).toBe(0);
+    jest.restoreAllMocks();
+  });
+});
+
+// ── HTTP endpoint tests ───────────────────────────────────────────────────────
+
+describe('Webhook HTTP endpoints', () => {
+  let app;
+
+  beforeAll(() => {
+    const webhooksRouter = require('../src/routes/webhooks');
+    app = express();
+    app.use(express.json());
+    app.use('/webhooks', webhooksRouter);
+    app.use((err, req, res, next) => {
+      void next;
+      res.status(err.status || 500).json({ success: false, error: { message: err.message } });
+    });
+  });
+
+  it('POST /webhooks registers a webhook', async () => {
+    const res = await request(app)
+      .post('/webhooks')
+      .set('X-API-Key', 'test-key-1')
+      .send({ url: 'https://example.com/hook', events: ['transaction.confirmed'] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.url).toBe('https://example.com/hook');
+    expect(res.body.data.events).toEqual(['transaction.confirmed']);
+    expect(res.body.data.secret).toBeDefined();
+  });
+
+  it('POST /webhooks returns 400 for missing url', async () => {
+    const res = await request(app)
+      .post('/webhooks')
+      .set('X-API-Key', 'test-key-1')
+      .send({ events: ['transaction.confirmed'] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /webhooks lists registered webhooks', async () => {
+    await WebhookService.register({ url: 'https://list-test.com/hook', events: ['*'] });
+
+    const res = await request(app)
+      .get('/webhooks')
+      .set('X-API-Key', 'test-key-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('DELETE /webhooks/:id removes a webhook', async () => {
+    const wh = await WebhookService.register({ url: 'https://del-test.com/hook', events: ['*'] });
+
+    const res = await request(app)
+      .delete(`/webhooks/${wh.id}`)
+      .set('X-API-Key', 'test-key-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('DELETE /webhooks/:id returns 404 for unknown id', async () => {
+    const res = await request(app)
+      .delete('/webhooks/9999')
+      .set('X-API-Key', 'test-key-1');
+
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
- Add WebhookService with register, list, remove, deliver, and retry methods
- Webhooks table: id, url, events, secret, api_key_id, created_at, is_active, consecutive_failures
- HMAC-SHA256 payload signing via X-Webhook-Signature header
- Exponential backoff retry (max 5 attempts: 1s, 2s, 4s, 8s, 16s)
- Auto-disable webhooks after 5 consecutive delivery failures
- Support wildcard (*) and specific event subscriptions
- Add POST /webhooks, GET /webhooks, DELETE /webhooks/:id endpoints
- Integrate webhook delivery into TransactionReconciliationService on transaction.confirmed
- Initialize webhooks table at server startup
- Add 23 tests covering registration, listing, deletion, HMAC signing, delivery routing, retry logic, auto-disable, and HTTP endpoints
- closes #305