### PR TITLE
feat: add support for stellar offers and dex trading

### DIFF
--- a/docs/features/ADD_SUPPORT_FOR_STELLAR_OFFERS_AND_DEX_TRADING.md
+++ b/docs/features/ADD_SUPPORT_FOR_STELLAR_OFFERS_AND_DEX_TRADING.md
@@ -1,0 +1,172 @@
+# Stellar Offers and DEX Trading
+
+Enables the API to create, manage, and query offers on the Stellar Decentralised Exchange (DEX), allowing donation platforms to perform automatic asset conversion at market rates.
+
+## Overview
+
+The Stellar DEX lets accounts post offers to buy or sell any asset pair. This feature exposes that capability through four HTTP endpoints and three new service methods.
+
+## Service Methods
+
+### `StellarService` / `MockStellarService`
+
+#### `createOffer({ sourceSecret, sellingAsset, buyingAsset, amount, price, offerId? })`
+
+Creates (or updates) a sell offer on the Stellar DEX using `manageSellOffer`.
+
+| Param | Type | Description |
+|---|---|---|
+| `sourceSecret` | string | Seller's Stellar secret key |
+| `sellingAsset` | string | Asset to sell: `'XLM'` or `'CODE:ISSUER'` |
+| `buyingAsset` | string | Asset to buy: `'XLM'` or `'CODE:ISSUER'` |
+| `amount` | string | Amount of selling asset |
+| `price` | string | Price as `'n/d'` ratio or decimal string |
+| `offerId` | number | `0` to create new; existing ID to update (optional, default `0`) |
+
+Returns `{ offerId, transactionId, ledger }`.
+
+#### `cancelOffer({ sourceSecret, sellingAsset, buyingAsset, offerId })`
+
+Cancels an existing offer by submitting `manageSellOffer` with `amount = '0'`.
+
+Returns `{ transactionId, ledger }`.
+
+#### `getOrderBook(sellingAsset, buyingAsset, limit?)`
+
+Queries the Horizon order book for a trading pair.
+
+| Param | Type | Description |
+|---|---|---|
+| `sellingAsset` | string | Base asset |
+| `buyingAsset` | string | Counter asset |
+| `limit` | number | Max bids/asks to return (default `20`) |
+
+Returns `{ bids, asks, base, counter }`.
+
+## HTTP Endpoints
+
+### `POST /offers`
+
+Create a new DEX sell offer.
+
+**Auth:** `x-api-key` header required.
+
+**Request body:**
+```json
+{
+  "sourceSecret": "S...",
+  "sellingAsset": "XLM",
+  "buyingAsset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  "amount": "100",
+  "price": "0.25"
+}
+```
+
+**Response `201`:**
+```json
+{
+  "success": true,
+  "data": { "offerId": 1711234567890, "transactionId": "abc123...", "ledger": 1234567 }
+}
+```
+
+---
+
+### `GET /offers`
+
+List all active offers tracked by this API instance.
+
+**Auth:** `x-api-key` header required.
+
+**Response `200`:**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1711234567890,
+      "sellingAsset": "XLM",
+      "buyingAsset": "USDC:GBBD47...",
+      "amount": "100",
+      "price": "0.25",
+      "status": "active",
+      "createdAt": "2026-03-24T20:00:00.000Z"
+    }
+  ]
+}
+```
+
+---
+
+### `DELETE /offers/:id`
+
+Cancel an existing offer.
+
+**Auth:** `x-api-key` header required.
+
+**Request body:**
+```json
+{
+  "sourceSecret": "S...",
+  "sellingAsset": "XLM",
+  "buyingAsset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+}
+```
+
+**Response `200`:**
+```json
+{
+  "success": true,
+  "data": { "transactionId": "def456...", "ledger": 1234568 }
+}
+```
+
+---
+
+### `GET /orderbook/:baseAsset/:counterAsset`
+
+Query the DEX order book for a trading pair. Asset parameters must be URL-encoded when they contain a colon (e.g. `USDC%3AGBBD47...`).
+
+**Auth:** `x-api-key` header required.
+
+**Query params:**
+- `limit` – max bids/asks per side (default `20`, max `200`)
+
+**Example:**
+```
+GET /orderbook/XLM/USDC%3AGBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5?limit=10
+```
+
+**Response `200`:**
+```json
+{
+  "success": true,
+  "data": {
+    "bids": [{ "price": "0.24", "amount": "500.0000000", "price_r": { "n": 6, "d": 25 } }],
+    "asks": [{ "price": "0.25", "amount": "100.0000000", "price_r": { "n": 1, "d": 4 } }],
+    "base": { "asset_type": "native" },
+    "counter": { "asset_type": "credit_alphanum4", "asset_code": "USDC", "asset_issuer": "GBBD47..." }
+  }
+}
+```
+
+## Asset Format
+
+| Value | Meaning |
+|---|---|
+| `XLM` or `native` | Stellar's native asset (case-insensitive) |
+| `CODE:ISSUER` | Custom asset, e.g. `USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` |
+
+## Security Notes
+
+- `sourceSecret` is never logged or stored; it is used only to sign the transaction in-process.
+- All endpoints require a valid API key.
+- The offer store is in-memory; a production deployment should persist offer metadata to the database.
+
+## Testing
+
+```bash
+npm test tests/add-support-for-stellar-offers-and-dex-trading.test.js
+```
+
+No live Stellar network is required. All tests use `MockStellarService`.

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -22,6 +22,7 @@ const feesRoutes = require('./fees');
 const featureFlagsAdminRoutes = require('./admin/featureFlags');
 const networkRoutes = require('./network');
 const webhooksRoutes = require('./webhooks');
+const offersRoutes = require('./offers');
 const { errorHandler, notFoundHandler } = require('../middleware/errorHandler');
 const logger = require('../middleware/logger');
 const { attachUserRole } = require('../middleware/rbac');
@@ -96,6 +97,7 @@ app.use('/fees', feesRoutes);
 app.use('/admin/feature-flags', featureFlagsAdminRoutes);
 app.use('/network', networkRoutes);
 app.use('/webhooks', webhooksRoutes);
+app.use('/offers', offersRoutes);
 
 // Exchange rates endpoint
 app.get('/exchange-rates', async (req, res) => {

--- a/src/routes/offers.js
+++ b/src/routes/offers.js
@@ -1,0 +1,163 @@
+/**
+ * Offers Routes - Stellar DEX Integration
+ *
+ * RESPONSIBILITY: HTTP request handling for DEX offer management and order book queries
+ * OWNER: Backend Team
+ * DEPENDENCIES: StellarService, middleware (auth, rbac)
+ *
+ * Exposes endpoints for creating, listing, and cancelling Stellar DEX offers,
+ * as well as querying the order book for any trading pair.
+ */
+
+const express = require('express');
+const router = express.Router();
+const requireApiKey = require('../middleware/apiKey');
+const { checkPermission } = require('../middleware/rbac');
+const { PERMISSIONS } = require('../utils/permissions');
+const { ValidationError, NotFoundError, ERROR_CODES } = require('../utils/errors');
+const { getStellarService } = require('../config/stellar');
+
+const stellarService = getStellarService();
+
+// In-memory offer store (maps offerId -> offer metadata for listing)
+// In production this would be persisted to the database.
+const offerStore = new Map();
+
+/**
+ * Parse asset string into a normalised form.
+ * Accepts 'XLM', 'native', or 'CODE:ISSUER'.
+ * @param {string} asset
+ * @returns {string}
+ */
+function normaliseAsset(asset) {
+  if (!asset || typeof asset !== 'string') throw new ValidationError('Asset must be a non-empty string');
+  const upper = asset.trim().toUpperCase();
+  if (upper === 'XLM' || upper === 'NATIVE') return 'XLM';
+  if (!upper.includes(':')) throw new ValidationError(`Invalid asset format "${asset}". Use 'XLM' or 'CODE:ISSUER'`);
+  const [code, issuer] = upper.split(':');
+  if (!code || !issuer) throw new ValidationError(`Invalid asset format "${asset}". Use 'CODE:ISSUER'`);
+  return `${code}:${issuer}`;
+}
+
+/**
+ * POST /offers
+ * Create a new DEX sell offer.
+ *
+ * Body:
+ *   sourceSecret  {string} - Seller's Stellar secret key
+ *   sellingAsset  {string} - Asset to sell ('XLM' or 'CODE:ISSUER')
+ *   buyingAsset   {string} - Asset to buy  ('XLM' or 'CODE:ISSUER')
+ *   amount        {string} - Amount of selling asset
+ *   price         {string} - Price ratio ('n/d') or decimal
+ */
+router.post('/', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_CREATE), async (req, res) => {
+  try {
+    const { sourceSecret, sellingAsset, buyingAsset, amount, price } = req.body;
+
+    if (!sourceSecret) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'sourceSecret is required' } });
+    if (!amount) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'amount is required' } });
+    if (!price) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'price is required' } });
+
+    const normSelling = normaliseAsset(sellingAsset);
+    const normBuying = normaliseAsset(buyingAsset);
+
+    const result = await stellarService.createOffer({
+      sourceSecret,
+      sellingAsset: normSelling,
+      buyingAsset: normBuying,
+      amount: amount.toString(),
+      price: price.toString(),
+      offerId: 0,
+    });
+
+    // Persist metadata for listing
+    offerStore.set(result.offerId, {
+      id: result.offerId,
+      sellingAsset: normSelling,
+      buyingAsset: normBuying,
+      amount: amount.toString(),
+      price: price.toString(),
+      transactionId: result.transactionId,
+      ledger: result.ledger,
+      createdAt: new Date().toISOString(),
+      status: 'active',
+    });
+
+    return res.status(201).json({ success: true, data: result });
+  } catch (err) {
+    const status = err.statusCode || err.status || 400;
+    return res.status(status).json({ success: false, error: { code: err.errorCode || 'OFFER_CREATE_FAILED', message: err.message } });
+  }
+});
+
+/**
+ * GET /offers
+ * List all active offers (from in-memory store).
+ */
+router.get('/', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_READ), (req, res) => {
+  const offers = Array.from(offerStore.values()).filter(o => o.status === 'active');
+  return res.status(200).json({ success: true, data: offers });
+});
+
+/**
+ * DELETE /offers/:id
+ * Cancel an existing DEX offer.
+ *
+ * Body:
+ *   sourceSecret  {string} - Seller's Stellar secret key
+ *   sellingAsset  {string} - Asset being sold in the offer
+ *   buyingAsset   {string} - Asset being bought in the offer
+ */
+router.delete('/:id', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_CREATE), async (req, res) => {
+  try {
+    const offerId = parseInt(req.params.id, 10);
+    if (isNaN(offerId)) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'Offer ID must be an integer' } });
+
+    const { sourceSecret, sellingAsset, buyingAsset } = req.body;
+    if (!sourceSecret) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'sourceSecret is required' } });
+
+    const normSelling = normaliseAsset(sellingAsset);
+    const normBuying = normaliseAsset(buyingAsset);
+
+    const result = await stellarService.cancelOffer({ sourceSecret, sellingAsset: normSelling, buyingAsset: normBuying, offerId });
+
+    const stored = offerStore.get(offerId);
+    if (stored) stored.status = 'cancelled';
+
+    return res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    const status = err.statusCode || err.status || 400;
+    return res.status(status).json({ success: false, error: { code: err.errorCode || 'OFFER_CANCEL_FAILED', message: err.message } });
+  }
+});
+
+/**
+ * GET /orderbook/:baseAsset/:counterAsset
+ * Query the Stellar DEX order book for a trading pair.
+ *
+ * Params:
+ *   baseAsset    - Selling asset ('XLM' or 'CODE:ISSUER', URL-encoded)
+ *   counterAsset - Buying asset  ('XLM' or 'CODE:ISSUER', URL-encoded)
+ *
+ * Query:
+ *   limit {number} - Max bids/asks to return (default 20, max 200)
+ */
+router.get('/orderbook/:baseAsset/:counterAsset', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_READ), async (req, res) => {
+  try {
+    const normBase = normaliseAsset(decodeURIComponent(req.params.baseAsset));
+    const normCounter = normaliseAsset(decodeURIComponent(req.params.counterAsset));
+
+    const limit = Math.min(parseInt(req.query.limit, 10) || 20, 200);
+
+    const result = await stellarService.getOrderBook(normBase, normCounter, limit);
+    return res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    const status = err.statusCode || err.status || 400;
+    return res.status(status).json({ success: false, error: { code: err.errorCode || 'ORDERBOOK_FAILED', message: err.message } });
+  }
+});
+
+// Expose store for testing
+router._offerStore = offerStore;
+
+module.exports = router;

--- a/src/services/MockStellarService.js
+++ b/src/services/MockStellarService.js
@@ -917,6 +917,7 @@ class MockStellarService extends StellarServiceInterface {
     this.transactions.clear();
     this.streamListeners.clear();
     if (this.claimableBalances) this.claimableBalances.clear();
+    if (this.offers) this.offers.clear();
   }
 
   /**
@@ -1126,6 +1127,124 @@ class MockStellarService extends StellarServiceInterface {
       baseFee: BASE_FEE_STROOPS,
       surgeProtection,
       surgeMultiplier: parseFloat(multiplier.toFixed(2)),
+    };
+  }
+
+  /**
+   * Create a mock DEX offer.
+   *
+   * @param {Object} params
+   * @param {string} params.sourceSecret - Source account secret key
+   * @param {string} params.sellingAsset - Asset being sold ('XLM' or 'CODE:ISSUER')
+   * @param {string} params.buyingAsset  - Asset being bought ('XLM' or 'CODE:ISSUER')
+   * @param {string} params.amount       - Amount of selling asset
+   * @param {string} params.price        - Price ratio 'n/d' or decimal string
+   * @param {number} [params.offerId=0]  - 0 to create; existing ID to update/cancel
+   * @returns {Promise<{offerId: number, transactionId: string, ledger: number}>}
+   */
+  async createOffer({ sourceSecret, sellingAsset, buyingAsset, amount, price, offerId = 0 }) {
+    await this._simulateNetworkDelay();
+    this._checkRateLimit();
+    this._simulateFailure();
+    this._validateSecretKey(sourceSecret);
+
+    if (!sellingAsset || !buyingAsset) throw new ValidationError('sellingAsset and buyingAsset are required');
+    if (sellingAsset === buyingAsset) throw new ValidationError('sellingAsset and buyingAsset must be different');
+
+    const amountNum = parseFloat(amount);
+    if (isNaN(amountNum) || amountNum < 0) throw new ValidationError('amount must be a non-negative number');
+
+    const priceNum = typeof price === 'string' && price.includes('/')
+      ? parseInt(price.split('/')[0], 10) / parseInt(price.split('/')[1], 10)
+      : parseFloat(price);
+    if (isNaN(priceNum) || priceNum <= 0) throw new ValidationError('price must be a positive number');
+
+    const sourcePublic = this._secretToPublic(sourceSecret);
+    const wallet = this.wallets.get(sourcePublic);
+    if (!wallet) throw new NotFoundError('Source account not found', ERROR_CODES.WALLET_NOT_FOUND);
+
+    if (!this.offers) this.offers = new Map();
+
+    // Cancel (amount=0) or update existing offer
+    if (offerId !== 0) {
+      const existing = this.offers.get(offerId);
+      if (!existing) throw new NotFoundError(`Offer ${offerId} not found`, ERROR_CODES.NOT_FOUND);
+      if (existing.seller !== sourcePublic) throw new BusinessLogicError(ERROR_CODES.TRANSACTION_FAILED, 'Not the offer owner');
+      if (amountNum === 0) {
+        this.offers.delete(offerId);
+      } else {
+        existing.amount = amountNum.toFixed(7);
+        existing.price = priceNum.toFixed(7);
+      }
+      const txId = crypto.randomBytes(32).toString('hex');
+      const ledger = Math.floor(Math.random() * 1000000) + 1000000;
+      return { offerId, transactionId: txId, ledger };
+    }
+
+    // Create new offer
+    const newOfferId = Date.now() * 1000 + (this._offerCounter = ((this._offerCounter || 0) + 1) % 1000);
+    this.offers.set(newOfferId, {
+      id: newOfferId,
+      seller: sourcePublic,
+      sellingAsset,
+      buyingAsset,
+      amount: amountNum.toFixed(7),
+      price: priceNum.toFixed(7),
+      createdAt: new Date().toISOString(),
+    });
+
+    const txId = crypto.randomBytes(32).toString('hex');
+    const ledger = Math.floor(Math.random() * 1000000) + 1000000;
+    return { offerId: newOfferId, transactionId: txId, ledger };
+  }
+
+  /**
+   * Cancel a mock DEX offer.
+   *
+   * @param {Object} params
+   * @param {string} params.sourceSecret - Source account secret key
+   * @param {string} params.sellingAsset - Asset being sold in the offer
+   * @param {string} params.buyingAsset  - Asset being bought in the offer
+   * @param {number} params.offerId      - ID of the offer to cancel
+   * @returns {Promise<{transactionId: string, ledger: number}>}
+   */
+  async cancelOffer({ sourceSecret, sellingAsset, buyingAsset, offerId }) {
+    const result = await this.createOffer({ sourceSecret, sellingAsset, buyingAsset, amount: '0', price: '1', offerId });
+    return { transactionId: result.transactionId, ledger: result.ledger };
+  }
+
+  /**
+   * Get the mock order book for a trading pair.
+   *
+   * @param {string} sellingAsset - Base asset ('XLM' or 'CODE:ISSUER')
+   * @param {string} buyingAsset  - Counter asset ('XLM' or 'CODE:ISSUER')
+   * @param {number} [limit=20]   - Max entries per side
+   * @returns {Promise<{bids: Array, asks: Array, base: Object, counter: Object}>}
+   */
+  async getOrderBook(sellingAsset, buyingAsset, limit = 20) {
+    await this._simulateNetworkDelay();
+    this._checkRateLimit();
+    this._simulateFailure();
+
+    if (!sellingAsset || !buyingAsset) throw new ValidationError('sellingAsset and buyingAsset are required');
+
+    if (!this.offers) this.offers = new Map();
+
+    const asks = Array.from(this.offers.values())
+      .filter(o => o.sellingAsset === sellingAsset && o.buyingAsset === buyingAsset)
+      .slice(0, limit)
+      .map(o => ({ price: o.price, amount: o.amount, price_r: { n: 1, d: 1 } }));
+
+    const bids = Array.from(this.offers.values())
+      .filter(o => o.sellingAsset === buyingAsset && o.buyingAsset === sellingAsset)
+      .slice(0, limit)
+      .map(o => ({ price: o.price, amount: o.amount, price_r: { n: 1, d: 1 } }));
+
+    return {
+      bids,
+      asks,
+      base: { asset_type: sellingAsset === 'XLM' ? 'native' : 'credit_alphanum4', asset_code: sellingAsset },
+      counter: { asset_type: buyingAsset === 'XLM' ? 'native' : 'credit_alphanum4', asset_code: buyingAsset },
     };
   }
 

--- a/src/services/StellarService.js
+++ b/src/services/StellarService.js
@@ -660,6 +660,122 @@ class StellarService extends StellarServiceInterface {
   }
 
   /**
+   * Create a DEX offer to buy or sell an asset on the Stellar network.
+   *
+   * @param {Object} params
+   * @param {string} params.sourceSecret - Source account secret key
+   * @param {string} params.sellingAsset - Asset being sold ('XLM' or 'CODE:ISSUER')
+   * @param {string} params.buyingAsset  - Asset being bought ('XLM' or 'CODE:ISSUER')
+   * @param {string} params.amount       - Amount of selling asset to offer
+   * @param {string} params.price        - Price as a ratio string 'n/d' or decimal string
+   * @param {number} [params.offerId=0]  - 0 to create new offer; existing ID to update
+   * @returns {Promise<{offerId: number, transactionId: string, ledger: number}>}
+   */
+  async createOffer({ sourceSecret, sellingAsset, buyingAsset, amount, price, offerId = 0 }) {
+    return StellarErrorHandler.wrap(async () => {
+      const sourceKeypair = StellarSdk.Keypair.fromSecret(sourceSecret);
+      const sourceAccount = await this._executeWithRetry(
+        () => this.server.loadAccount(sourceKeypair.publicKey()),
+        'loadAccountForOffer'
+      );
+
+      const parseAsset = (assetStr) => {
+        if (assetStr === 'XLM' || assetStr === 'native') return StellarSdk.Asset.native();
+        const [code, issuer] = assetStr.split(':');
+        if (!issuer) throw new Error(`Invalid asset format: ${assetStr}. Use 'XLM' or 'CODE:ISSUER'`);
+        return new StellarSdk.Asset(code, issuer);
+      };
+
+      const parsePrice = (p) => {
+        if (typeof p === 'string' && p.includes('/')) {
+          const [n, d] = p.split('/');
+          return { n: parseInt(n, 10), d: parseInt(d, 10) };
+        }
+        // Convert decimal to fraction
+        const dec = parseFloat(p);
+        return { n: Math.round(dec * 10000000), d: 10000000 };
+      };
+
+      const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+        fee: this.baseFee,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(StellarSdk.Operation.manageSellOffer({
+          selling: parseAsset(sellingAsset),
+          buying: parseAsset(buyingAsset),
+          amount: amount.toString(),
+          price: parsePrice(price),
+          offerId: offerId.toString(),
+        }))
+        .setTimeout(30)
+        .build();
+
+      tx.sign(sourceKeypair);
+      const result = await this._submitTransactionWithNetworkSafety(tx);
+
+      // Extract offer ID from result
+      let newOfferId = offerId;
+      try {
+        const meta = StellarSdk.xdr.TransactionMeta.fromXDR(result.result_meta_xdr, 'base64');
+        const ops = meta.v2().operations();
+        if (ops && ops[0]) {
+          const inner = ops[0].result().tr().manageSellOfferResult().success().offer();
+          if (inner.switch().name === 'manageSellOfferCreated') {
+            newOfferId = inner.offer().offerID().toNumber();
+          }
+        }
+      } catch (_) { /* offerId stays as provided if XDR parsing fails */ }
+
+      return { offerId: newOfferId, transactionId: result.hash, ledger: result.ledger };
+    }, 'createOffer');
+  }
+
+  /**
+   * Cancel an existing DEX offer.
+   *
+   * @param {Object} params
+   * @param {string} params.sourceSecret - Source account secret key
+   * @param {string} params.sellingAsset - Asset being sold in the offer
+   * @param {string} params.buyingAsset  - Asset being bought in the offer
+   * @param {number} params.offerId      - ID of the offer to cancel
+   * @returns {Promise<{transactionId: string, ledger: number}>}
+   */
+  async cancelOffer({ sourceSecret, sellingAsset, buyingAsset, offerId }) {
+    return this.createOffer({ sourceSecret, sellingAsset, buyingAsset, amount: '0', price: '1', offerId });
+  }
+
+  /**
+   * Get the order book for a trading pair from Horizon.
+   *
+   * @param {string} sellingAsset - Base asset ('XLM' or 'CODE:ISSUER')
+   * @param {string} buyingAsset  - Counter asset ('XLM' or 'CODE:ISSUER')
+   * @param {number} [limit=20]   - Max number of bids/asks to return
+   * @returns {Promise<{bids: Array, asks: Array, base: Object, counter: Object}>}
+   */
+  async getOrderBook(sellingAsset, buyingAsset, limit = 20) {
+    return StellarErrorHandler.wrap(async () => {
+      const parseAsset = (assetStr) => {
+        if (assetStr === 'XLM' || assetStr === 'native') return StellarSdk.Asset.native();
+        const [code, issuer] = assetStr.split(':');
+        if (!issuer) throw new Error(`Invalid asset format: ${assetStr}. Use 'XLM' or 'CODE:ISSUER'`);
+        return new StellarSdk.Asset(code, issuer);
+      };
+
+      const result = await this._executeWithRetry(
+        () => this.server.orderbook(parseAsset(sellingAsset), parseAsset(buyingAsset)).limit(limit).call(),
+        'getOrderBook'
+      );
+
+      return {
+        bids: result.bids,
+        asks: result.asks,
+        base: result.base,
+        counter: result.counter,
+      };
+    }, 'getOrderBook');
+  }
+
+  /**
    * Claim a claimable balance.
    *
    * @param {Object} params

--- a/tests/add-support-for-stellar-offers-and-dex-trading.test.js
+++ b/tests/add-support-for-stellar-offers-and-dex-trading.test.js
@@ -1,0 +1,495 @@
+/**
+ * Tests: Stellar Offers and DEX Trading
+ *
+ * Covers createOffer, cancelOffer, getOrderBook on MockStellarService
+ * and all four HTTP endpoints on the offers router.
+ * No live Stellar network required.
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-key-dex';
+
+const request = require('supertest');
+const express = require('express');
+const offersRouter = require('../src/routes/offers');
+const { attachUserRole } = require('../src/middleware/rbac');
+const MockStellarService = require('../src/services/MockStellarService');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(attachUserRole());
+  app.use('/offers', offersRouter);
+  app.use((err, req, res, next) => {
+    void next;
+    res.status(err.status || 500).json({ success: false, error: { code: err.code || 'INTERNAL_ERROR', message: err.message } });
+  });
+  return app;
+}
+
+async function makeWallet(svc) {
+  const kp = await svc.createWallet();
+  await svc.fundTestnetWallet(kp.publicKey);
+  return kp;
+}
+
+// ─── MockStellarService unit tests ──────────────────────────────────────────
+
+describe('MockStellarService – DEX methods', () => {
+  let svc;
+  let seller;
+  let buyer;
+
+  beforeEach(async () => {
+    svc = new MockStellarService();
+    seller = await makeWallet(svc);
+    buyer = await makeWallet(svc);
+  });
+
+  // createOffer ──────────────────────────────────────────────────────────────
+
+  describe('createOffer', () => {
+    test('creates a new offer and returns offerId, transactionId, ledger', async () => {
+      const result = await svc.createOffer({
+        sourceSecret: seller.secretKey,
+        sellingAsset: 'XLM',
+        buyingAsset: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+        amount: '100',
+        price: '0.25',
+      });
+
+      expect(result.offerId).toBeDefined();
+      expect(typeof result.offerId).toBe('number');
+      expect(result.transactionId).toMatch(/^[0-9a-f]{64}$/);
+      expect(typeof result.ledger).toBe('number');
+    });
+
+    test('stores the offer so getOrderBook can find it', async () => {
+      const buyingAsset = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+      await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '50', price: '0.5' });
+
+      const book = await svc.getOrderBook('XLM', buyingAsset);
+      expect(book.asks.length).toBe(1);
+      expect(book.asks[0].amount).toBe('50.0000000');
+    });
+
+    test('supports price as n/d ratio string', async () => {
+      const result = await svc.createOffer({
+        sourceSecret: seller.secretKey,
+        sellingAsset: 'XLM',
+        buyingAsset: 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+        amount: '10',
+        price: '1/4',
+      });
+      expect(result.offerId).toBeDefined();
+    });
+
+    test('updates an existing offer when offerId is provided', async () => {
+      const buyingAsset = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+      const { offerId } = await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '100', price: '0.25' });
+
+      await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '200', price: '0.30', offerId });
+
+      const book = await svc.getOrderBook('XLM', buyingAsset);
+      expect(book.asks[0].amount).toBe('200.0000000');
+    });
+
+    test('throws ValidationError for missing sellingAsset', async () => {
+      await expect(svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: '', buyingAsset: 'XLM', amount: '10', price: '1' }))
+        .rejects.toThrow('sellingAsset and buyingAsset are required');
+    });
+
+    test('throws ValidationError when sellingAsset equals buyingAsset', async () => {
+      await expect(svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'XLM', amount: '10', price: '1' }))
+        .rejects.toThrow('sellingAsset and buyingAsset must be different');
+    });
+
+    test('throws ValidationError for negative amount', async () => {
+      await expect(svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'USDC:ISSUER', amount: '-5', price: '1' }))
+        .rejects.toThrow('amount must be a non-negative number');
+    });
+
+    test('throws ValidationError for zero price', async () => {
+      await expect(svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'USDC:ISSUER', amount: '10', price: '0' }))
+        .rejects.toThrow('price must be a positive number');
+    });
+
+    test('throws NotFoundError for unknown source account', async () => {
+      const unknown = new MockStellarService();
+      const kp = await unknown.createWallet(); // not funded, not in svc
+      await expect(svc.createOffer({ sourceSecret: kp.secretKey, sellingAsset: 'XLM', buyingAsset: 'USDC:ISSUER', amount: '10', price: '1' }))
+        .rejects.toThrow('Source account not found');
+    });
+
+    test('throws NotFoundError when updating non-existent offerId', async () => {
+      await expect(svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'USDC:ISSUER', amount: '10', price: '1', offerId: 999999 }))
+        .rejects.toThrow('not found');
+    });
+
+    test('throws error when non-owner tries to update offer', async () => {
+      const buyingAsset = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+      const { offerId } = await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '10', price: '1' });
+
+      await expect(svc.createOffer({ sourceSecret: buyer.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '5', price: '1', offerId }))
+        .rejects.toThrow('Not the offer owner');
+    });
+
+    test('propagates failure simulation', async () => {
+      svc.enableFailureSimulation('network_error', 1.0);
+      await expect(svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'USDC:ISSUER', amount: '10', price: '1' }))
+        .rejects.toThrow();
+      svc.disableFailureSimulation();
+    });
+  });
+
+  // cancelOffer ──────────────────────────────────────────────────────────────
+
+  describe('cancelOffer', () => {
+    test('cancels an existing offer and removes it from order book', async () => {
+      const buyingAsset = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+      const { offerId } = await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '100', price: '0.25' });
+
+      const result = await svc.cancelOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, offerId });
+
+      expect(result.transactionId).toBeDefined();
+      const book = await svc.getOrderBook('XLM', buyingAsset);
+      expect(book.asks.length).toBe(0);
+    });
+
+    test('throws NotFoundError when cancelling non-existent offer', async () => {
+      await expect(svc.cancelOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'USDC:ISSUER', offerId: 999 }))
+        .rejects.toThrow('not found');
+    });
+  });
+
+  // getOrderBook ─────────────────────────────────────────────────────────────
+
+  describe('getOrderBook', () => {
+    const buyingAsset = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+    test('returns empty bids and asks when no offers exist', async () => {
+      const book = await svc.getOrderBook('XLM', buyingAsset);
+      expect(book.bids).toEqual([]);
+      expect(book.asks).toEqual([]);
+      expect(book.base).toBeDefined();
+      expect(book.counter).toBeDefined();
+    });
+
+    test('returns asks for matching sell offers', async () => {
+      await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '50', price: '0.5' });
+      await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '30', price: '0.6' });
+
+      const book = await svc.getOrderBook('XLM', buyingAsset);
+      expect(book.asks.length).toBe(2);
+    });
+
+    test('returns bids for reverse offers', async () => {
+      await svc.createOffer({ sourceSecret: buyer.secretKey, sellingAsset: buyingAsset, buyingAsset: 'XLM', amount: '25', price: '2' });
+
+      const book = await svc.getOrderBook('XLM', buyingAsset);
+      expect(book.bids.length).toBe(1);
+    });
+
+    test('respects limit parameter', async () => {
+      for (let i = 0; i < 5; i++) {
+        await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: String(i + 1), price: '0.5' });
+      }
+      const book = await svc.getOrderBook('XLM', buyingAsset, 3);
+      expect(book.asks.length).toBeLessThanOrEqual(3);
+    });
+
+    test('throws ValidationError for missing assets', async () => {
+      await expect(svc.getOrderBook('', buyingAsset)).rejects.toThrow('sellingAsset and buyingAsset are required');
+    });
+
+    test('propagates failure simulation', async () => {
+      svc.enableFailureSimulation('timeout', 1.0);
+      await expect(svc.getOrderBook('XLM', buyingAsset)).rejects.toThrow();
+      svc.disableFailureSimulation();
+    });
+  });
+
+  // _clearAllData ────────────────────────────────────────────────────────────
+
+  test('_clearAllData clears offers', async () => {
+    const buyingAsset = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+    await svc.createOffer({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset, amount: '10', price: '1' });
+    svc._clearAllData();
+    const book = await svc.getOrderBook('XLM', buyingAsset);
+    expect(book.asks.length).toBe(0);
+  });
+});
+
+// ─── HTTP endpoint integration tests ────────────────────────────────────────
+
+describe('Offers HTTP endpoints', () => {
+  let app;
+  let svc;
+  let seller;
+  const BUYING = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+  beforeAll(async () => {
+    // The router already captured the container's stellar service at require-time.
+    // Since MOCK_STELLAR=true, that service is a MockStellarService — grab it directly.
+    const { getStellarService } = require('../src/config/stellar');
+    svc = getStellarService();
+
+    app = createTestApp();
+    seller = await makeWallet(svc);
+  });
+
+  beforeEach(() => {
+    // Clear offer store and mock offers between tests
+    offersRouter._offerStore.clear();
+    if (svc.offers) svc.offers.clear();
+  });
+
+  afterAll(() => {
+    if (svc._clearAllData) svc._clearAllData();
+  });
+
+  // POST /offers ─────────────────────────────────────────────────────────────
+
+  describe('POST /offers', () => {
+    test('201 – creates offer with valid payload', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '100', price: '0.25' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.offerId).toBeDefined();
+      expect(res.body.data.transactionId).toBeDefined();
+    });
+
+    test('400 – missing sourceSecret', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sellingAsset: 'XLM', buyingAsset: BUYING, amount: '100', price: '0.25' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    test('400 – missing amount', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, price: '0.25' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('400 – missing price', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '100' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('400 – invalid asset format', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'BADFORMAT', buyingAsset: BUYING, amount: '100', price: '0.25' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('400 – same selling and buying asset', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: 'XLM', amount: '100', price: '1' });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('401 – missing API key', async () => {
+      const res = await request(app)
+        .post('/offers')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '100', price: '0.25' });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // GET /offers ──────────────────────────────────────────────────────────────
+
+  describe('GET /offers', () => {
+    test('200 – returns empty array when no offers', async () => {
+      const res = await request(app)
+        .get('/offers')
+        .set('x-api-key', 'test-key-dex');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBe(0);
+    });
+
+    test('200 – lists created offers', async () => {
+      await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '50', price: '0.5' });
+
+      const res = await request(app)
+        .get('/offers')
+        .set('x-api-key', 'test-key-dex');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.data[0].sellingAsset).toBe('XLM');
+    });
+
+    test('401 – missing API key', async () => {
+      const res = await request(app).get('/offers');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // DELETE /offers/:id ───────────────────────────────────────────────────────
+
+  describe('DELETE /offers/:id', () => {
+    test('200 – cancels an existing offer', async () => {
+      const createRes = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '100', price: '0.25' });
+
+      const offerId = createRes.body.data.offerId;
+
+      const delRes = await request(app)
+        .delete(`/offers/${offerId}`)
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING });
+
+      expect(delRes.status).toBe(200);
+      expect(delRes.body.success).toBe(true);
+    });
+
+    test('cancelled offer no longer appears in GET /offers', async () => {
+      const createRes = await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '100', price: '0.25' });
+
+      const offerId = createRes.body.data.offerId;
+
+      await request(app)
+        .delete(`/offers/${offerId}`)
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING });
+
+      const listRes = await request(app)
+        .get('/offers')
+        .set('x-api-key', 'test-key-dex');
+
+      expect(listRes.body.data.length).toBe(0);
+    });
+
+    test('400 – non-integer offer ID', async () => {
+      const res = await request(app)
+        .delete('/offers/abc')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('400 – missing sourceSecret', async () => {
+      const res = await request(app)
+        .delete('/offers/12345')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sellingAsset: 'XLM', buyingAsset: BUYING });
+
+      expect(res.status).toBe(400);
+    });
+
+    test('404 – cancelling non-existent offer', async () => {
+      const res = await request(app)
+        .delete('/offers/999999')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING });
+
+      expect(res.status).toBe(404);
+    });
+
+    test('401 – missing API key', async () => {
+      const res = await request(app)
+        .delete('/offers/1')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // GET /orderbook/:baseAsset/:counterAsset ──────────────────────────────────
+
+  describe('GET /orderbook/:baseAsset/:counterAsset', () => {
+    test('200 – returns order book structure', async () => {
+      const res = await request(app)
+        .get(`/offers/orderbook/XLM/${encodeURIComponent(BUYING)}`)
+        .set('x-api-key', 'test-key-dex');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data.bids)).toBe(true);
+      expect(Array.isArray(res.body.data.asks)).toBe(true);
+      expect(res.body.data.base).toBeDefined();
+      expect(res.body.data.counter).toBeDefined();
+    });
+
+    test('200 – order book reflects created offers', async () => {
+      await request(app)
+        .post('/offers')
+        .set('x-api-key', 'test-key-dex')
+        .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: '75', price: '0.4' });
+
+      const res = await request(app)
+        .get(`/offers/orderbook/XLM/${encodeURIComponent(BUYING)}`)
+        .set('x-api-key', 'test-key-dex');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.asks.length).toBe(1);
+    });
+
+    test('200 – respects limit query param', async () => {
+      for (let i = 0; i < 5; i++) {
+        await request(app)
+          .post('/offers')
+          .set('x-api-key', 'test-key-dex')
+          .send({ sourceSecret: seller.secretKey, sellingAsset: 'XLM', buyingAsset: BUYING, amount: String(i + 1), price: '0.5' });
+      }
+
+      const res = await request(app)
+        .get(`/offers/orderbook/XLM/${encodeURIComponent(BUYING)}?limit=2`)
+        .set('x-api-key', 'test-key-dex');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.asks.length).toBeLessThanOrEqual(2);
+    });
+
+    test('400 – invalid base asset format', async () => {
+      const res = await request(app)
+        .get(`/offers/orderbook/BADFORMAT/${encodeURIComponent(BUYING)}`)
+        .set('x-api-key', 'test-key-dex');
+
+      expect(res.status).toBe(400);
+    });
+
+    test('401 – missing API key', async () => {
+      const res = await request(app)
+        .get(`/offers/orderbook/XLM/${encodeURIComponent(BUYING)}`);
+
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
- Add createOffer, cancelOffer, getOrderBook to StellarService and MockStellarService
- Create POST /offers, GET /offers, DELETE /offers/:id endpoints
- Add GET /offers/orderbook/:baseAsset/:counterAsset endpoint
- Register /offers routes in app.js
- MockStellarService simulates DEX operations with in-memory offer store
- 42 tests covering all success and failure scenarios (no live network required)
- Add docs/features/ADD_SUPPORT_FOR_STELLAR_OFFERS_AND_DEX_TRADING.md
Closes #373 