### PR TITLE
feat: implement transaction search and filtering

### DIFF
--- a/docs/features/IMPLEMENT_TRANSACTION_SEARCH_AND_FILTERING.md
+++ b/docs/features/IMPLEMENT_TRANSACTION_SEARCH_AND_FILTERING.md
@@ -1,0 +1,87 @@
+# Transaction Search and Filtering
+
+## Overview
+
+`GET /donations` supports filtering, full-text search, and sorting via query parameters. All parameters are optional and combinable.
+
+## Query Parameters
+
+| Parameter   | Type   | Description |
+|-------------|--------|-------------|
+| `startDate` | string | ISO date — include donations on or after this date |
+| `endDate`   | string | ISO date — include donations on or before this date |
+| `minAmount` | number | Minimum donation amount (inclusive) |
+| `maxAmount` | number | Maximum donation amount (inclusive) |
+| `status`    | string | Exact status: `pending` \| `submitted` \| `confirmed` \| `failed` |
+| `donor`     | string | Case-insensitive substring match on donor field |
+| `recipient` | string | Case-insensitive substring match on recipient field |
+| `memo`      | string | Case-insensitive full-text search on memo field |
+| `sortBy`    | string | Sort field: `timestamp` (default) \| `amount` \| `status` |
+| `order`     | string | Sort order: `desc` (default) \| `asc` |
+| `cursor`    | string | Cursor for pagination (see pagination docs) |
+| `limit`     | number | Page size (default: 20, max: 100) |
+| `direction` | string | Pagination direction: `next` \| `prev` |
+
+## Response
+
+```json
+{
+  "success": true,
+  "data": [...],
+  "count": 2,
+  "resultCount": 2,
+  "filters": { "status": "confirmed", "donor": "alice" },
+  "meta": {
+    "limit": 20,
+    "direction": "next",
+    "next_cursor": null,
+    "prev_cursor": null
+  }
+}
+```
+
+- `filters` — the active filters applied to this request
+- `resultCount` — total matching records (before pagination)
+- `X-Total-Count` response header also reflects the filtered count
+
+## Examples
+
+```bash
+# Filter by status
+GET /donations?status=confirmed
+
+# Date range
+GET /donations?startDate=2024-01-01&endDate=2024-03-31
+
+# Amount range
+GET /donations?minAmount=10&maxAmount=100
+
+# Full-text memo search
+GET /donations?memo=birthday
+
+# Combine filters
+GET /donations?donor=alice&status=confirmed&sortBy=amount&order=desc
+
+# Paginate filtered results
+GET /donations?status=confirmed&limit=10
+```
+
+## Validation
+
+Invalid parameter values return `400 Bad Request`:
+
+- `status` must be one of `pending`, `submitted`, `confirmed`, `failed`
+- `sortBy` must be one of `timestamp`, `amount`, `status`
+- `order` must be one of `asc`, `desc`
+- `startDate` / `endDate` must be valid ISO date strings
+- `startDate` must not be after `endDate`
+- `minAmount` / `maxAmount` must be valid numbers
+- `minAmount` must not be greater than `maxAmount`
+
+## Implementation
+
+- **Route**: `GET /donations` in `src/routes/donation.js`
+- **Service method**: `DonationService.applyFilters(transactions, filters)` — pure filtering/sorting logic
+- **Service method**: `DonationService.getPaginatedDonations(pagination, filters)` — combines filtering with cursor pagination
+- Filtering is applied in-memory before pagination, so `resultCount` reflects the filtered total
+- When `sortBy` is set, the custom sort is preserved on the returned page

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -342,8 +342,7 @@ router.post('/batch', payloadSizeLimiter(ENDPOINT_LIMITS.batchDonation), batchRa
  */
 router.post('/', payloadSizeLimiter(ENDPOINT_LIMITS.singleDonation), donationRateLimiter, requireApiKey, requireIdempotency, createDonationSchema, async (req, res, next) => {
   try {
-    const { amount, donor, recipient, memo, memoType } = req.body;
-    const { amount, currency, donor, recipient, memo } = req.body;
+    const { amount, currency, donor, recipient, memo, memoType } = req.body;
 
     // Basic validation
     if (!amount || !recipient) {
@@ -461,27 +460,64 @@ router.get('/fee-estimate', checkPermission(PERMISSIONS.DONATIONS_READ), async (
   }
 });
 
+const listDonationsQuerySchema = validateSchema({
+  query: {
+    allowUnknown: true,
+    fields: {
+      startDate:  { type: 'string',  required: false, nullable: true },
+      endDate:    { type: 'string',  required: false, nullable: true },
+      minAmount:  { type: 'string',  required: false, nullable: true },
+      maxAmount:  { type: 'string',  required: false, nullable: true },
+      status:     { type: 'string',  required: false, nullable: true, enum: ['pending', 'submitted', 'confirmed', 'failed'] },
+      donor:      { type: 'string',  required: false, nullable: true, maxLength: 255 },
+      recipient:  { type: 'string',  required: false, nullable: true, maxLength: 255 },
+      memo:       { type: 'string',  required: false, nullable: true, maxLength: 255 },
+      sortBy:     { type: 'string',  required: false, nullable: true, enum: ['timestamp', 'amount', 'status'] },
+      order:      { type: 'string',  required: false, nullable: true, enum: ['asc', 'desc'] },
+    },
+  },
+});
+
 /**
  * GET /donations
- * Get all donations
+ * Get all donations with optional filtering and search.
+ *
+ * Query parameters:
+ *   - startDate {string}  ISO date; include donations on or after this date
+ *   - endDate   {string}  ISO date; include donations on or before this date
+ *   - minAmount {number}  Minimum donation amount (inclusive)
+ *   - maxAmount {number}  Maximum donation amount (inclusive)
+ *   - status    {string}  Exact status: pending | submitted | confirmed | failed
+ *   - donor     {string}  Case-insensitive substring match on donor
+ *   - recipient {string}  Case-insensitive substring match on recipient
+ *   - memo      {string}  Case-insensitive full-text search on memo
+ *   - sortBy    {string}  Sort field: timestamp (default) | amount | status
+ *   - order     {string}  Sort order: desc (default) | asc
+ *   - cursor, limit, direction  Cursor pagination (see pagination docs)
  */
-router.get('/', checkPermission(PERMISSIONS.DONATIONS_READ), (req, res, next) => {
+router.get('/', checkPermission(PERMISSIONS.DONATIONS_READ), listDonationsQuerySchema, (req, res, next) => {
   try {
     const pagination = parseCursorPaginationQuery(req.query);
-    const result = donationService.getPaginatedDonations(pagination);
-    
+
+    const { startDate, endDate, minAmount, maxAmount, status, donor, recipient, memo, sortBy, order } = req.query;
+    const filters = { startDate, endDate, minAmount, maxAmount, status, donor, recipient, memo, sortBy, order };
+
+    const result = donationService.getPaginatedDonations(pagination, filters);
+
     // Mark processing complete
     if (req.markLifecycleStage) {
       req.markLifecycleStage(LIFECYCLE_STAGES.PROCESSED);
     }
 
     res.setHeader('X-Total-Count', String(result.totalCount));
-    
+
     res.json({
       success: true,
       data: result.data,
       count: result.data.length,
-      meta: result.meta
+      meta: result.meta,
+      filters: result.appliedFilters,
+      resultCount: result.resultCount,
     });
   } catch (error) {
     next(error);

--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -23,6 +23,7 @@ const log = require('../utils/log');
 const priceOracle = require('./PriceOracleService');
 const { buildOverpaymentRecord } = require('../utils/overpaymentDetector');
 const memoCollisionDetector = require('../utils/memoCollisionDetector');
+const { paginateCollection } = require('../utils/pagination');
 
 class DonationService {
   constructor(stellarService) {
@@ -362,8 +363,7 @@ class DonationService {
    * @param {string} params.idempotencyKey - Idempotency key
    * @returns {Object} Created transaction
    */
-  async createDonationRecord({ amount, donor, recipient, memo, memoType = 'text', idempotencyKey, receivedAmount, sessionId }) {
-  async createDonationRecord({ amount, currency = 'XLM', donor, recipient, memo, idempotencyKey, receivedAmount, sessionId }) {
+  async createDonationRecord({ amount, currency = 'XLM', donor, recipient, memo, memoType = 'text', idempotencyKey, receivedAmount, sessionId }) {
     // Sanitize identifiers
     const sanitizedDonor = donor ? sanitizeIdentifier(donor) : 'Anonymous';
     const sanitizedRecipient = sanitizeIdentifier(recipient);
@@ -564,19 +564,159 @@ class DonationService {
   }
 
   /**
-   * Get donations using cursor-based pagination.
+   * Apply search/filter criteria to a list of transactions.
+   * All parameters are optional and combinable.
+   *
+   * @param {Object[]} transactions - Source transaction array.
+   * @param {Object} filters - Filter options.
+   * @param {string} [filters.startDate] - ISO date string; include transactions on or after this date.
+   * @param {string} [filters.endDate] - ISO date string; include transactions on or before this date.
+   * @param {number} [filters.minAmount] - Minimum donation amount (inclusive).
+   * @param {number} [filters.maxAmount] - Maximum donation amount (inclusive).
+   * @param {string} [filters.status] - Exact status match.
+   * @param {string} [filters.donor] - Case-insensitive substring match on donor field.
+   * @param {string} [filters.recipient] - Case-insensitive substring match on recipient field.
+   * @param {string} [filters.memo] - Case-insensitive full-text search on memo field.
+   * @param {string} [filters.sortBy='timestamp'] - Field to sort by: 'timestamp', 'amount', or 'status'.
+   * @param {string} [filters.order='desc'] - Sort order: 'asc' or 'desc'.
+   * @returns {Object[]} Filtered and sorted transactions.
+   */
+  applyFilters(transactions, filters = {}) {
+    const {
+      startDate, endDate,
+      minAmount, maxAmount,
+      status, donor, recipient, memo,
+      sortBy = 'timestamp', order = 'desc',
+    } = filters;
+
+    const VALID_SORT_FIELDS = ['timestamp', 'amount', 'status'];
+    const VALID_ORDERS = ['asc', 'desc'];
+
+    if (sortBy && !VALID_SORT_FIELDS.includes(sortBy)) {
+      throw new ValidationError(
+        `Invalid sortBy value. Must be one of: ${VALID_SORT_FIELDS.join(', ')}`,
+        null,
+        ERROR_CODES.INVALID_REQUEST
+      );
+    }
+    if (order && !VALID_ORDERS.includes(order)) {
+      throw new ValidationError(
+        `Invalid order value. Must be one of: ${VALID_ORDERS.join(', ')}`,
+        null,
+        ERROR_CODES.INVALID_REQUEST
+      );
+    }
+
+    let start = startDate ? new Date(startDate) : null;
+    let end = endDate ? new Date(endDate) : null;
+
+    if (start && isNaN(start.getTime())) {
+      throw new ValidationError('Invalid startDate', null, ERROR_CODES.INVALID_REQUEST);
+    }
+    if (end && isNaN(end.getTime())) {
+      throw new ValidationError('Invalid endDate', null, ERROR_CODES.INVALID_REQUEST);
+    }
+    if (start && end && start > end) {
+      throw new ValidationError('startDate must not be after endDate', null, ERROR_CODES.INVALID_REQUEST);
+    }
+
+    const minAmt = minAmount !== undefined ? parseFloat(minAmount) : null;
+    const maxAmt = maxAmount !== undefined ? parseFloat(maxAmount) : null;
+
+    if (minAmt !== null && isNaN(minAmt)) {
+      throw new ValidationError('Invalid minAmount', null, ERROR_CODES.INVALID_REQUEST);
+    }
+    if (maxAmt !== null && isNaN(maxAmt)) {
+      throw new ValidationError('Invalid maxAmount', null, ERROR_CODES.INVALID_REQUEST);
+    }
+    if (minAmt !== null && maxAmt !== null && minAmt > maxAmt) {
+      throw new ValidationError('minAmount must not be greater than maxAmount', null, ERROR_CODES.INVALID_REQUEST);
+    }
+
+    const donorLower = donor ? donor.toLowerCase() : null;
+    const recipientLower = recipient ? recipient.toLowerCase() : null;
+    const memoLower = memo ? memo.toLowerCase() : null;
+
+    let result = transactions.filter(tx => {
+      if (start && new Date(tx.timestamp) < start) return false;
+      if (end && new Date(tx.timestamp) > end) return false;
+      if (minAmt !== null && tx.amount < minAmt) return false;
+      if (maxAmt !== null && tx.amount > maxAmt) return false;
+      if (status && tx.status !== status) return false;
+      if (donorLower && !(tx.donor || '').toLowerCase().includes(donorLower)) return false;
+      if (recipientLower && !(tx.recipient || '').toLowerCase().includes(recipientLower)) return false;
+      if (memoLower && !(tx.memo || '').toLowerCase().includes(memoLower)) return false;
+      return true;
+    });
+
+    result.sort((a, b) => {
+      let aVal = a[sortBy];
+      let bVal = b[sortBy];
+      if (sortBy === 'timestamp') {
+        aVal = new Date(aVal).getTime();
+        bVal = new Date(bVal).getTime();
+      } else if (sortBy === 'amount') {
+        aVal = Number(aVal);
+        bVal = Number(bVal);
+      } else {
+        aVal = String(aVal || '');
+        bVal = String(bVal || '');
+      }
+      if (aVal < bVal) return order === 'asc' ? -1 : 1;
+      if (aVal > bVal) return order === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+    return result;
+  }
+
+  /**
+   * Get donations using cursor-based pagination with optional filtering.
    * @param {Object} pagination - Pagination options.
    * @param {{ timestamp: string, id: string }|null} pagination.cursor - Decoded cursor.
    * @param {number} pagination.limit - Page size.
    * @param {string} pagination.direction - Pagination direction.
-   * @returns {{ data: Array, totalCount: number, meta: Object }} Paginated donations.
+   * @param {Object} [filters={}] - Filter/search options (see applyFilters).
+   * @returns {{ data: Array, totalCount: number, meta: Object, appliedFilters: Object }} Paginated donations.
    */
-  getPaginatedDonations(pagination) {
-    return paginateCollection(Transaction.getAll(), {
+  getPaginatedDonations(pagination, filters = {}) {
+    const { sortBy, order, ...filterParams } = filters;
+    const hasFilters = Object.values(filters).some(v => v !== undefined && v !== null && v !== '');
+
+    const allTransactions = Transaction.getAll();
+    const filtered = hasFilters
+      ? this.applyFilters(allTransactions, filters)
+      : allTransactions;
+
+    // When a custom sort is applied, preserve that order through pagination
+    // by using the first item's sort field as the pagination timestamp field.
+    const useCustomSort = sortBy && sortBy !== 'timestamp';
+    const result = paginateCollection(filtered, {
       ...pagination,
       timestampField: 'timestamp',
       idField: 'id',
+      // If custom sort was applied, disable paginateCollection's re-sort
+      // by passing a pre-sorted flag via a stable secondary sort on id only.
+      ...(useCustomSort && { _presorted: true }),
     });
+
+    // paginateCollection always re-sorts by timestamp; re-apply custom sort to the page
+    if (useCustomSort) {
+      result.data = this.applyFilters(result.data, { sortBy, order: order || 'desc' });
+    }
+
+    const appliedFilters = {};
+    for (const [key, val] of Object.entries(filters)) {
+      if (val !== undefined && val !== null && val !== '') {
+        appliedFilters[key] = val;
+      }
+    }
+
+    return {
+      ...result,
+      appliedFilters,
+      resultCount: result.totalCount,
+    };
   }
 
   /**

--- a/tests/implement-transaction-search-and-filtering.test.js
+++ b/tests/implement-transaction-search-and-filtering.test.js
@@ -1,0 +1,380 @@
+/**
+ * Transaction Search and Filtering Tests
+ *
+ * Tests for GET /donations filter/search query parameters.
+ * No live Stellar network required (uses MockStellarService via MOCK_STELLAR=true).
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-key-1';
+
+const request = require('supertest');
+const express = require('express');
+const donationRouter = require('../src/routes/donation');
+const Transaction = require('../src/routes/models/transaction');
+const { attachUserRole } = require('../src/middleware/rbac');
+const DonationService = require('../src/services/DonationService');
+const { ValidationError } = require('../src/utils/errors');
+
+// ─── Test App ────────────────────────────────────────────────────────────────
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(attachUserRole());
+  app.use('/donations', donationRouter);
+  app.use((err, req, res, next) => {
+    void next;
+    res.status(err.status || err.statusCode || 500).json({
+      success: false,
+      error: { code: err.code || 'INTERNAL_ERROR', message: err.message || 'Internal server error' },
+    });
+  });
+  return app;
+}
+
+// ─── Seed Helpers ─────────────────────────────────────────────────────────────
+
+function seed(overrides = {}) {
+  return Transaction.create({
+    amount: 10,
+    donor: 'alice',
+    recipient: 'bob',
+    memo: 'birthday gift',
+    status: 'pending',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  });
+}
+
+// ─── DonationService.applyFilters unit tests ──────────────────────────────────
+
+describe('DonationService.applyFilters', () => {
+  const svc = new DonationService({});
+
+  const base = [
+    { id: '1', amount: 5,  donor: 'alice',   recipient: 'bob',     memo: 'hello world', status: 'pending',   timestamp: '2024-01-01T00:00:00.000Z' },
+    { id: '2', amount: 20, donor: 'bob',     recipient: 'charlie', memo: 'donation',    status: 'confirmed', timestamp: '2024-02-01T00:00:00.000Z' },
+    { id: '3', amount: 50, donor: 'charlie', recipient: 'alice',   memo: 'thanks',      status: 'failed',    timestamp: '2024-03-01T00:00:00.000Z' },
+    { id: '4', amount: 10, donor: 'alice',   recipient: 'charlie', memo: 'hello again', status: 'confirmed', timestamp: '2024-04-01T00:00:00.000Z' },
+  ];
+
+  test('returns all when no filters', () => {
+    expect(svc.applyFilters(base, {}).length).toBe(4);
+  });
+
+  test('filters by startDate', () => {
+    const result = svc.applyFilters(base, { startDate: '2024-02-01' });
+    expect(result.every(t => new Date(t.timestamp) >= new Date('2024-02-01'))).toBe(true);
+    expect(result.length).toBe(3);
+  });
+
+  test('filters by endDate', () => {
+    const result = svc.applyFilters(base, { endDate: '2024-02-28' });
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by startDate and endDate range', () => {
+    const result = svc.applyFilters(base, { startDate: '2024-02-01', endDate: '2024-03-31' });
+    expect(result.length).toBe(2);
+    expect(result.map(t => t.id)).toEqual(expect.arrayContaining(['2', '3']));
+  });
+
+  test('filters by minAmount', () => {
+    const result = svc.applyFilters(base, { minAmount: 20 });
+    expect(result.every(t => t.amount >= 20)).toBe(true);
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by maxAmount', () => {
+    const result = svc.applyFilters(base, { maxAmount: 10 });
+    expect(result.every(t => t.amount <= 10)).toBe(true);
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by minAmount and maxAmount range', () => {
+    const result = svc.applyFilters(base, { minAmount: 10, maxAmount: 20 });
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by exact status', () => {
+    const result = svc.applyFilters(base, { status: 'confirmed' });
+    expect(result.every(t => t.status === 'confirmed')).toBe(true);
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by donor substring (case-insensitive)', () => {
+    const result = svc.applyFilters(base, { donor: 'ALICE' });
+    expect(result.every(t => t.donor.toLowerCase().includes('alice'))).toBe(true);
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by recipient substring (case-insensitive)', () => {
+    const result = svc.applyFilters(base, { recipient: 'Charlie' });
+    expect(result.length).toBe(2);
+  });
+
+  test('filters by memo full-text search (case-insensitive)', () => {
+    const result = svc.applyFilters(base, { memo: 'hello' });
+    expect(result.length).toBe(2);
+    expect(result.map(t => t.id)).toEqual(expect.arrayContaining(['1', '4']));
+  });
+
+  test('combines multiple filters', () => {
+    const result = svc.applyFilters(base, { donor: 'alice', status: 'confirmed' });
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe('4');
+  });
+
+  test('returns empty array when no matches', () => {
+    expect(svc.applyFilters(base, { donor: 'nobody' })).toEqual([]);
+  });
+
+  // Sorting
+  test('sorts by amount asc', () => {
+    const result = svc.applyFilters(base, { sortBy: 'amount', order: 'asc' });
+    expect(result.map(t => t.amount)).toEqual([5, 10, 20, 50]);
+  });
+
+  test('sorts by amount desc', () => {
+    const result = svc.applyFilters(base, { sortBy: 'amount', order: 'desc' });
+    expect(result.map(t => t.amount)).toEqual([50, 20, 10, 5]);
+  });
+
+  test('sorts by timestamp asc', () => {
+    const result = svc.applyFilters(base, { sortBy: 'timestamp', order: 'asc' });
+    expect(result[0].id).toBe('1');
+    expect(result[3].id).toBe('4');
+  });
+
+  test('sorts by status asc', () => {
+    const result = svc.applyFilters(base, { sortBy: 'status', order: 'asc' });
+    expect(result[0].status <= result[result.length - 1].status).toBe(true);
+  });
+
+  // Validation errors
+  test('throws on invalid startDate', () => {
+    expect(() => svc.applyFilters(base, { startDate: 'not-a-date' })).toThrow(ValidationError);
+  });
+
+  test('throws on invalid endDate', () => {
+    expect(() => svc.applyFilters(base, { endDate: 'bad' })).toThrow(ValidationError);
+  });
+
+  test('throws when startDate is after endDate', () => {
+    expect(() => svc.applyFilters(base, { startDate: '2024-12-01', endDate: '2024-01-01' })).toThrow(ValidationError);
+  });
+
+  test('throws on invalid minAmount', () => {
+    expect(() => svc.applyFilters(base, { minAmount: 'abc' })).toThrow(ValidationError);
+  });
+
+  test('throws on invalid maxAmount', () => {
+    expect(() => svc.applyFilters(base, { maxAmount: 'abc' })).toThrow(ValidationError);
+  });
+
+  test('throws when minAmount > maxAmount', () => {
+    expect(() => svc.applyFilters(base, { minAmount: 100, maxAmount: 10 })).toThrow(ValidationError);
+  });
+
+  test('throws on invalid sortBy', () => {
+    expect(() => svc.applyFilters(base, { sortBy: 'invalid' })).toThrow(ValidationError);
+  });
+
+  test('throws on invalid order', () => {
+    expect(() => svc.applyFilters(base, { order: 'sideways' })).toThrow(ValidationError);
+  });
+});
+
+// ─── GET /donations HTTP integration tests ────────────────────────────────────
+
+describe('GET /donations – search and filtering', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  beforeEach(() => {
+    Transaction._clearAllData();
+  });
+
+  function get(query = '') {
+    return request(app).get(`/donations${query}`);
+  }
+
+  test('returns all donations when no filters', async () => {
+    seed({ amount: 5 });
+    seed({ amount: 10 });
+    const res = await get();
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.length).toBe(2);
+  });
+
+  test('response includes filters and resultCount metadata', async () => {
+    seed({ status: 'confirmed' });
+    seed({ status: 'pending' });
+    const res = await get('?status=confirmed');
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toEqual({ status: 'confirmed' });
+    expect(res.body.resultCount).toBe(1);
+  });
+
+  test('filters by status=confirmed', async () => {
+    seed({ status: 'confirmed' });
+    seed({ status: 'pending' });
+    const res = await get('?status=confirmed');
+    expect(res.body.data.every(d => d.status === 'confirmed')).toBe(true);
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('filters by minAmount', async () => {
+    seed({ amount: 5 });
+    seed({ amount: 50 });
+    const res = await get('?minAmount=10');
+    expect(res.body.data.every(d => d.amount >= 10)).toBe(true);
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('filters by maxAmount', async () => {
+    seed({ amount: 5 });
+    seed({ amount: 50 });
+    const res = await get('?maxAmount=10');
+    expect(res.body.data.every(d => d.amount <= 10)).toBe(true);
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('filters by donor substring', async () => {
+    seed({ donor: 'alice' });
+    seed({ donor: 'bob' });
+    const res = await get('?donor=alice');
+    expect(res.body.data.every(d => d.donor.includes('alice'))).toBe(true);
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('filters by recipient substring', async () => {
+    seed({ recipient: 'charlie' });
+    seed({ recipient: 'dave' });
+    const res = await get('?recipient=charlie');
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('filters by memo full-text search', async () => {
+    seed({ memo: 'birthday gift' });
+    seed({ memo: 'monthly donation' });
+    const res = await get('?memo=birthday');
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].memo).toBe('birthday gift');
+  });
+
+  test('memo search is case-insensitive', async () => {
+    seed({ memo: 'Birthday Gift' });
+    const res = await get('?memo=birthday');
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('filters by date range', async () => {
+    seed({ timestamp: '2024-01-15T00:00:00.000Z' });
+    seed({ timestamp: '2024-06-15T00:00:00.000Z' });
+    const res = await get('?startDate=2024-01-01&endDate=2024-03-31');
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('combines multiple filters', async () => {
+    seed({ donor: 'alice', status: 'confirmed', amount: 20 });
+    seed({ donor: 'alice', status: 'pending',   amount: 5  });
+    seed({ donor: 'bob',   status: 'confirmed', amount: 20 });
+    const res = await get('?donor=alice&status=confirmed');
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.data[0].donor).toBe('alice');
+    expect(res.body.data[0].status).toBe('confirmed');
+  });
+
+  test('returns empty data array when no matches', async () => {
+    seed({ donor: 'alice' });
+    const res = await get('?donor=nobody');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.resultCount).toBe(0);
+  });
+
+  test('sorts by amount asc', async () => {
+    seed({ amount: 30 });
+    seed({ amount: 10 });
+    seed({ amount: 20 });
+    const res = await get('?sortBy=amount&order=asc');
+    const amounts = res.body.data.map(d => d.amount);
+    expect(amounts).toEqual([...amounts].sort((a, b) => a - b));
+  });
+
+  test('sorts by amount desc', async () => {
+    seed({ amount: 30 });
+    seed({ amount: 10 });
+    seed({ amount: 20 });
+    const res = await get('?sortBy=amount&order=desc');
+    const amounts = res.body.data.map(d => d.amount);
+    expect(amounts).toEqual([...amounts].sort((a, b) => b - a));
+  });
+
+  test('X-Total-Count header reflects filtered count', async () => {
+    seed({ status: 'confirmed' });
+    seed({ status: 'confirmed' });
+    seed({ status: 'pending' });
+    const res = await get('?status=confirmed');
+    expect(res.headers['x-total-count']).toBe('2');
+  });
+
+  // Validation error responses
+  test('returns 400 for invalid status value', async () => {
+    const res = await get('?status=invalid');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 for invalid sortBy value', async () => {
+    const res = await get('?sortBy=invalid');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 for invalid order value', async () => {
+    const res = await get('?order=sideways');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 when startDate is after endDate', async () => {
+    const res = await get('?startDate=2024-12-01&endDate=2024-01-01');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 when minAmount > maxAmount', async () => {
+    const res = await get('?minAmount=100&maxAmount=10');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 for invalid minAmount', async () => {
+    const res = await get('?minAmount=abc');
+    expect(res.status).toBe(400);
+  });
+
+  // Edge cases
+  test('handles empty database gracefully', async () => {
+    const res = await get('?status=confirmed');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  test('filters object is empty when no filters applied', async () => {
+    seed();
+    const res = await get();
+    expect(res.body.filters).toEqual({});
+  });
+
+  test('pagination still works with filters applied', async () => {
+    for (let i = 0; i < 5; i++) seed({ status: 'confirmed', amount: i + 1 });
+    seed({ status: 'pending' });
+    const res = await get('?status=confirmed&limit=3');
+    expect(res.body.data.length).toBe(3);
+    expect(res.body.resultCount).toBe(5);
+    expect(res.body.meta.next_cursor).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #345

---

- Add query params to GET /donations: startDate, endDate, minAmount, maxAmount, status, donor, recipient, memo, sortBy, order
- Add DonationService.applyFilters() for in-memory filtering and sorting
- Update getPaginatedDonations() to accept and apply filters before pagination
- Return appliedFilters and resultCount metadata in response
- Add listDonationsQuerySchema for input validation (400 on bad values)
- Fix pre-existing duplicate declarations in donation.js and DonationService.js
- 49 tests covering all filter combinations, sorting, validation errors, edge cases, and pagination with filters
Closes ##345