### PR TITLE
#400 Implement request replay protection using nonces

### DIFF
--- a/docs/features/NONCE_REPLAY_PROTECTION.md
+++ b/docs/features/NONCE_REPLAY_PROTECTION.md
@@ -1,0 +1,117 @@
+# Nonce-Based Request Replay Protection
+
+## Overview
+
+Even with HMAC-SHA256 request signing and a 5-minute validity window, a captured
+signed request could be replayed by an attacker within that window. Nonce-based
+replay protection closes this gap: every signed request must carry a unique
+`X-Nonce` header, and the server rejects any request whose nonce has been seen
+before.
+
+## How It Works
+
+```
+Client                                  Server
+  │                                       │
+  │  Generate random nonce (≥ 16 bytes)   │
+  │  Sign request (HMAC-SHA256)           │
+  │──── POST /donations ────────────────► │
+  │     X-Timestamp: <unix-ts>            │  1. Verify signature (requestSigner)
+  │     X-Signature: <hmac>               │  2. Check X-Nonce present
+  │     X-Nonce:     <random-hex>         │  3. nonceStore.check(nonce)
+  │                                       │     ├─ seen=false → record & continue
+  │◄─── 200 OK ────────────────────────── │     └─ seen=true  → 409 Conflict
+  │                                       │
+  │  Replay same request                  │
+  │──── POST /donations ────────────────► │
+  │     (same headers)                    │  nonceStore.check(nonce) → seen=true
+  │◄─── 409 Conflict ─────────────────── │
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/utils/nonceStore.js` | Bounded in-memory nonce store with expiry and metrics |
+| `src/middleware/apiKey.js` | Enforces `X-Nonce` for signed requests (updated) |
+| `tests/nonce-replay.test.js` | Full test suite |
+
+## Client Usage
+
+Generate a cryptographically random nonce per request and include it alongside
+the existing signing headers:
+
+```js
+const crypto = require('crypto');
+
+const nonce = crypto.randomBytes(16).toString('hex'); // 32-char hex
+const timestamp = String(Math.floor(Date.now() / 1000));
+
+// Sign as before, then add X-Nonce
+headers['X-Timestamp'] = timestamp;
+headers['X-Signature'] = sign({ secret, method, path, timestamp, body });
+headers['X-Nonce']     = nonce;
+```
+
+## Error Responses
+
+| Condition | Status | Code |
+|-----------|--------|------|
+| `X-Nonce` header absent | `401` | `MISSING_NONCE` |
+| Nonce already seen (replay) | `409` | `NONCE_REPLAYED` |
+
+### 409 Example
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "NONCE_REPLAYED",
+    "message": "This request has already been processed. Use a unique nonce per request.",
+    "requestId": "req-abc123",
+    "timestamp": "2026-03-25T13:00:00.000Z"
+  }
+}
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `NONCE_STORE_MAX_SIZE` | `10000` | Maximum nonces held in memory at once |
+
+The expiry window is tied to `SIGNATURE_MAX_AGE_MS` (5 minutes) so nonces are
+automatically eligible for cleanup after the signing window closes.
+
+## Security Assumptions
+
+- **Nonce entropy**: Clients must use at least 16 random bytes (128 bits). Shorter
+  or predictable nonces reduce security. The server does not enforce a minimum
+  length but the requirement is documented here.
+- **Clock skew**: The request signer already rejects timestamps more than 30 s in
+  the future or older than 5 minutes. Nonce expiry is aligned to the same window,
+  so a nonce cannot be replayed after it expires.
+- **Memory-only store**: Nonces are not persisted. A server restart clears the
+  store. In a multi-instance deployment, use a shared store (e.g. Redis) instead
+  of the default in-memory implementation.
+- **Bounded size**: When the store reaches `NONCE_STORE_MAX_SIZE`, the oldest
+  entry is evicted (FIFO). This prevents memory exhaustion at the cost of
+  theoretically allowing a replay of a very old evicted nonce. The signing window
+  makes such a replay invalid anyway.
+
+## Metrics
+
+`nonceStore.getMetrics()` returns:
+
+```js
+{
+  size:      number,  // current entries in store
+  maxSize:   number,  // configured cap
+  hits:      number,  // replay attempts blocked
+  misses:    number,  // new nonces accepted
+  hitRate:   number,  // hits / (hits + misses)
+  evictions: number   // entries dropped due to size cap
+}
+```
+
+Expose these via your health/metrics endpoint to monitor replay activity.

--- a/src/middleware/apiKey.js
+++ b/src/middleware/apiKey.js
@@ -15,6 +15,7 @@ const log = require("../utils/log");
 const AuditLogService = require("../services/AuditLogService");
 const perKeyRateLimit = require("./perKeyRateLimit");
 const { verify: verifySignature } = require("../utils/requestSigner");
+const { defaultStore: nonceStore } = require("../utils/nonceStore");
 
 /**
  * Legacy Support Configuration
@@ -116,6 +117,38 @@ const requireApiKey = async (req, res, next) => {
             },
           });
         }
+
+        // --- Nonce Replay Protection ---
+        const nonce = req.get('x-nonce');
+        if (!nonce) {
+          return res.status(401).json({
+            success: false,
+            error: {
+              code: 'MISSING_NONCE',
+              message: 'X-Nonce header is required for signed requests',
+              requestId: req.id,
+              timestamp: new Date().toISOString(),
+            },
+          });
+        }
+
+        const { seen } = nonceStore.check(nonce);
+        if (seen) {
+          log.warn('API_KEY_AUTH', 'Replayed nonce rejected', {
+            path: req.path,
+            keyPrefix: keyInfo.keyPrefix,
+          });
+          return res.status(409).json({
+            success: false,
+            error: {
+              code: 'NONCE_REPLAYED',
+              message: 'This request has already been processed. Use a unique nonce per request.',
+              requestId: req.id,
+              timestamp: new Date().toISOString(),
+            },
+          });
+        }
+        // --- End Nonce Replay Protection ---
       }
       // --- End Request Signing Verification ---
 

--- a/src/utils/nonceStore.js
+++ b/src/utils/nonceStore.js
@@ -1,0 +1,154 @@
+/**
+ * Nonce Store - Request Replay Protection
+ *
+ * Tracks used nonces to ensure each signed request can only be used once.
+ * Nonces are automatically expired after the signing window (default: 5 minutes).
+ * Store size is bounded to prevent memory exhaustion.
+ *
+ * Security assumptions:
+ * - Nonces must have sufficient entropy (>= 16 random bytes / 32 hex chars).
+ * - Clock skew between client and server should be < 30 seconds (enforced by
+ *   the request signer's timestamp check).
+ * - The nonce window matches the signature validity window (SIGNATURE_MAX_AGE_MS).
+ */
+
+const { SIGNATURE_MAX_AGE_MS } = require('./requestSigner');
+
+/** Maximum number of nonces retained in memory at any time. */
+const MAX_STORE_SIZE = parseInt(process.env.NONCE_STORE_MAX_SIZE, 10) || 10000;
+
+/** How often the cleanup sweep runs (ms). Defaults to half the signing window. */
+const CLEANUP_INTERVAL_MS = Math.floor(SIGNATURE_MAX_AGE_MS / 2);
+
+/**
+ * @typedef {Object} NonceEntry
+ * @property {number} expiresAt - Unix ms timestamp after which the nonce is expired.
+ */
+
+/**
+ * NonceStore - bounded in-memory store for used nonces.
+ *
+ * Internally uses a Map (nonce -> expiresAt) plus a FIFO insertion-order queue
+ * so that when the store is full the oldest entry is evicted first.
+ */
+class NonceStore {
+  constructor({ windowMs = SIGNATURE_MAX_AGE_MS, maxSize = MAX_STORE_SIZE } = {}) {
+    /** @type {Map<string, number>} nonce -> expiresAt (ms) */
+    this._store = new Map();
+    this._windowMs = windowMs;
+    this._maxSize = maxSize;
+
+    // Metrics
+    this._hits = 0;   // replay attempts blocked
+    this._misses = 0; // new (valid) nonces accepted
+    this._evictions = 0;
+
+    this._cleanupTimer = null;
+  }
+
+  /**
+   * Check whether a nonce has already been used, then record it.
+   *
+   * @param {string} nonce - The nonce value from the X-Nonce header.
+   * @returns {{ seen: boolean }} `seen: true` means the nonce was already used (replay).
+   */
+  check(nonce) {
+    const now = Date.now();
+
+    // Treat an expired entry as unseen (it's past the signing window anyway).
+    const existing = this._store.get(nonce);
+    if (existing !== undefined && existing > now) {
+      this._hits++;
+      return { seen: true };
+    }
+
+    // Enforce size bound before inserting.
+    if (this._store.size >= this._maxSize) {
+      this._evictOldest();
+    }
+
+    this._store.set(nonce, now + this._windowMs);
+    this._misses++;
+    return { seen: false };
+  }
+
+  /**
+   * Remove all nonces whose expiry has passed.
+   *
+   * @returns {{ removed: number }} Number of entries removed.
+   */
+  cleanup() {
+    const now = Date.now();
+    let removed = 0;
+    for (const [nonce, expiresAt] of this._store) {
+      if (expiresAt <= now) {
+        this._store.delete(nonce);
+        removed++;
+      }
+    }
+    return { removed };
+  }
+
+  /**
+   * Start the background cleanup timer.
+   * Safe to call multiple times — only one timer runs at a time.
+   *
+   * @returns {this}
+   */
+  startCleanup() {
+    if (this._cleanupTimer) return this;
+    this._cleanupTimer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS);
+    /* istanbul ignore next */
+    if (this._cleanupTimer.unref) this._cleanupTimer.unref();
+    return this;
+  }
+
+  /**
+   * Stop the background cleanup timer.
+   *
+   * @returns {this}
+   */
+  stopCleanup() {
+    if (this._cleanupTimer) {
+      clearInterval(this._cleanupTimer);
+      this._cleanupTimer = null;
+    }
+    return this;
+  }
+
+  /**
+   * Return store metrics.
+   *
+   * @returns {{ size: number, maxSize: number, hits: number, misses: number, hitRate: number, evictions: number }}
+   */
+  getMetrics() {
+    const total = this._hits + this._misses;
+    return {
+      size: this._store.size,
+      maxSize: this._maxSize,
+      hits: this._hits,
+      misses: this._misses,
+      hitRate: total === 0 ? 0 : this._hits / total,
+      evictions: this._evictions,
+    };
+  }
+
+  /**
+   * Evict the oldest (first-inserted) entry from the store.
+   * Map iteration order is insertion order in V8.
+   *
+   * @private
+   */
+  _evictOldest() {
+    const firstKey = this._store.keys().next().value;
+    if (firstKey !== undefined) {
+      this._store.delete(firstKey);
+      this._evictions++;
+    }
+  }
+}
+
+/** Singleton instance used by the middleware. */
+const defaultStore = new NonceStore().startCleanup();
+
+module.exports = { NonceStore, defaultStore, CLEANUP_INTERVAL_MS };

--- a/tests/nonce-replay.test.js
+++ b/tests/nonce-replay.test.js
@@ -1,0 +1,354 @@
+'use strict';
+
+/**
+ * tests/nonce-replay.test.js
+ *
+ * Tests for nonce-based request replay protection (issue #400).
+ * Covers:
+ *  - Replayed nonce rejected with 409
+ *  - New nonce accepted
+ *  - Nonces expire after the signing window
+ *  - Store size is bounded (eviction)
+ *  - Metrics track hit rate correctly
+ *  - Missing X-Nonce on signed requests returns 401
+ */
+
+const { NonceStore } = require('../src/utils/nonceStore');
+
+// ---------------------------------------------------------------------------
+// Helper: build a store with a custom window for time-travel tests
+// ---------------------------------------------------------------------------
+function makeStore(windowMs = 5 * 60 * 1000) {
+  return new NonceStore({ windowMs });
+}
+
+// ---------------------------------------------------------------------------
+// Core behaviour
+// ---------------------------------------------------------------------------
+describe('NonceStore – core behaviour', () => {
+  test('accepts a new nonce (seen: false)', () => {
+    const store = makeStore();
+    expect(store.check('nonce-abc').seen).toBe(false);
+  });
+
+  test('rejects a replayed nonce (seen: true)', () => {
+    const store = makeStore();
+    store.check('nonce-xyz');
+    expect(store.check('nonce-xyz').seen).toBe(true);
+  });
+
+  test('different nonces are independent', () => {
+    const store = makeStore();
+    store.check('nonce-1');
+    expect(store.check('nonce-2').seen).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expiry
+// ---------------------------------------------------------------------------
+describe('NonceStore – nonce expiry', () => {
+  test('nonce is treated as unseen after the window has elapsed', () => {
+    // Use a very short window so we can fake expiry without real timers.
+    const windowMs = 100;
+    const store = makeStore(windowMs);
+
+    // Record the nonce with a manually backdated expiry by reaching into internals.
+    store.check('expiring-nonce');
+
+    // Manually expire it by setting its expiry to the past.
+    store._store.set('expiring-nonce', Date.now() - 1);
+
+    // Should now be treated as unseen (expired).
+    expect(store.check('expiring-nonce').seen).toBe(false);
+  });
+
+  test('cleanup() removes expired entries and returns count', () => {
+    const store = makeStore(300_000);
+    store.check('n1');
+    store.check('n2');
+
+    // Expire both manually.
+    store._store.set('n1', Date.now() - 1);
+    store._store.set('n2', Date.now() - 1);
+
+    const { removed } = store.cleanup();
+    expect(removed).toBe(2);
+    expect(store._store.size).toBe(0);
+  });
+
+  test('cleanup() leaves unexpired entries intact', () => {
+    const store = makeStore(300_000);
+    store.check('keep');
+    store.check('expire-me');
+    store._store.set('expire-me', Date.now() - 1);
+
+    store.cleanup();
+    expect(store._store.has('keep')).toBe(true);
+    expect(store._store.has('expire-me')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bounded store size
+// ---------------------------------------------------------------------------
+describe('NonceStore – bounded size', () => {
+  test('store never exceeds maxSize', () => {
+    const maxSize = 5;
+    const store = new NonceStore({ maxSize });
+
+    for (let i = 0; i < maxSize + 3; i++) {
+      store.check(`nonce-${i}`);
+    }
+
+    expect(store._store.size).toBeLessThanOrEqual(maxSize);
+  });
+
+  test('oldest entry is evicted when store is full', () => {
+    const maxSize = 3;
+    const store = new NonceStore({ maxSize });
+
+    store.check('first');
+    store.check('second');
+    store.check('third');
+    // Store is now full; inserting 'fourth' should evict 'first'.
+    store.check('fourth');
+
+    expect(store._store.has('first')).toBe(false);
+    expect(store._store.has('fourth')).toBe(true);
+    expect(store._store.size).toBe(maxSize);
+  });
+
+  test('eviction counter increments', () => {
+    const store = new NonceStore({ maxSize: 2 });
+    store.check('a');
+    store.check('b');
+    store.check('c'); // triggers eviction
+
+    expect(store.getMetrics().evictions).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+describe('NonceStore – metrics', () => {
+  test('initial metrics are zeroed', () => {
+    const store = makeStore();
+    const m = store.getMetrics();
+    expect(m.hits).toBe(0);
+    expect(m.misses).toBe(0);
+    expect(m.hitRate).toBe(0);
+    expect(m.size).toBe(0);
+  });
+
+  test('misses increment on new nonces', () => {
+    const store = makeStore();
+    store.check('n1');
+    store.check('n2');
+    expect(store.getMetrics().misses).toBe(2);
+  });
+
+  test('hits increment on replayed nonces', () => {
+    const store = makeStore();
+    store.check('dup');
+    store.check('dup');
+    store.check('dup');
+    expect(store.getMetrics().hits).toBe(2);
+  });
+
+  test('hitRate is computed correctly', () => {
+    const store = makeStore();
+    store.check('unique');   // miss
+    store.check('unique');   // hit
+    // 1 hit / 2 total = 0.5
+    expect(store.getMetrics().hitRate).toBeCloseTo(0.5);
+  });
+
+  test('size reflects current store entries', () => {
+    const store = makeStore();
+    store.check('x');
+    store.check('y');
+    expect(store.getMetrics().size).toBe(2);
+  });
+
+  test('maxSize is reported in metrics', () => {
+    const store = new NonceStore({ maxSize: 42 });
+    expect(store.getMetrics().maxSize).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup timer lifecycle
+// ---------------------------------------------------------------------------
+describe('NonceStore – cleanup timer', () => {
+  test('startCleanup / stopCleanup do not throw', () => {
+    const store = makeStore();
+    expect(() => store.startCleanup()).not.toThrow();
+    expect(() => store.stopCleanup()).not.toThrow();
+  });
+
+  test('calling startCleanup twice does not create two timers', () => {
+    const store = makeStore();
+    store.startCleanup();
+    const timer1 = store._cleanupTimer;
+    store.startCleanup();
+    expect(store._cleanupTimer).toBe(timer1);
+    store.stopCleanup();
+  });
+
+  test('stopCleanup clears the timer reference', () => {
+    const store = makeStore();
+    store.startCleanup();
+    store.stopCleanup();
+    expect(store._cleanupTimer).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Middleware integration: X-Nonce enforcement in apiKey middleware
+// ---------------------------------------------------------------------------
+describe('apiKey middleware – nonce enforcement', () => {
+  let requireApiKey;
+  let mockValidateKey;
+  let mockNonceStore;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    // Stub validateKey to return a key that requires signing.
+    mockValidateKey = jest.fn().mockResolvedValue({
+      id: 1,
+      role: 'user',
+      signingRequired: true,
+      keySecret: 'test-secret',
+      keyPrefix: 'test1234',
+    });
+
+    // Stub the nonce store so we control seen/unseen.
+    mockNonceStore = { check: jest.fn().mockReturnValue({ seen: false }) };
+
+    jest.mock('../src/models/apiKeys', () => ({ validateKey: mockValidateKey }));
+    jest.mock('../src/utils/nonceStore', () => ({ defaultStore: mockNonceStore }));
+    jest.mock('../src/config/securityConfig', () => ({ securityConfig: { API_KEYS: [] } }));
+    jest.mock('../src/services/AuditLogService', () => ({ log: jest.fn().mockResolvedValue(undefined), CATEGORY: {}, ACTION: {}, SEVERITY: {} }));
+    jest.mock('../src/utils/log', () => ({ warn: jest.fn(), error: jest.fn(), info: jest.fn() }));
+
+    // Stub requestSigner to always return valid so we isolate nonce logic.
+    jest.mock('../src/utils/requestSigner', () => ({
+      verify: jest.fn().mockReturnValue({ valid: true }),
+      SIGNATURE_MAX_AGE_MS: 300_000,
+    }));
+
+    requireApiKey = require('../src/middleware/apiKey');
+  });
+
+  afterEach(() => jest.resetModules());
+
+  function makeReq(overrides = {}) {
+    return {
+      apiKey: null,
+      id: 'req-1',
+      ip: '127.0.0.1',
+      method: 'POST',
+      path: '/donations',
+      originalUrl: '/donations',
+      url: '/donations',
+      rawBody: '{}',
+      get: jest.fn((header) => {
+        const headers = {
+          'x-api-key': 'valid-key',
+          'x-timestamp': String(Math.floor(Date.now() / 1000)),
+          'x-signature': 'abc123',
+          'x-nonce': 'unique-nonce-001',
+          ...overrides.headers,
+        };
+        return headers[header.toLowerCase()] ?? null;
+      }),
+      ...overrides,
+    };
+  }
+
+  function makeRes() {
+    const res = { headers: {} };
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    res.setHeader = jest.fn((k, v) => { res.headers[k] = v; });
+    return res;
+  }
+
+  test('accepts request with valid new nonce', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalledWith(409);
+  });
+
+  test('rejects replayed nonce with 409', async () => {
+    mockNonceStore.check.mockReturnValue({ seen: true });
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ code: 'NONCE_REPLAYED' }),
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('rejects missing X-Nonce with 401', async () => {
+    const req = makeReq({ headers: { 'x-nonce': undefined } });
+    // Override get to return null for x-nonce
+    req.get = jest.fn((header) => {
+      if (header.toLowerCase() === 'x-nonce') return null;
+      const map = {
+        'x-api-key': 'valid-key',
+        'x-timestamp': String(Math.floor(Date.now() / 1000)),
+        'x-signature': 'abc123',
+      };
+      return map[header.toLowerCase()] ?? null;
+    });
+
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: 'MISSING_NONCE' }),
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('nonce check is skipped when signing is not required', async () => {
+    mockValidateKey.mockResolvedValue({
+      id: 2,
+      role: 'user',
+      signingRequired: false,
+      keyPrefix: 'test5678',
+    });
+
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireApiKey(req, res, next);
+
+    expect(mockNonceStore.check).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
pr close #400

- Add src/utils/nonceStore.js: bounded in-memory nonce store with TTL expiry, FIFO eviction, background cleanup timer, and hit-rate metrics
- Update src/middleware/apiKey.js: enforce X-Nonce header for signed requests; reject replays with 409 NONCE_REPLAYED, missing nonce with 401 MISSING_NONCE
- Add tests/nonce-replay.test.js: 22 tests covering replay rejection, expiry, bounded size, eviction, metrics, and middleware integration
- Add docs/features/NONCE_REPLAY_PROTECTION.md: full documentation including flow diagram, client usage, error responses, config, and security assumptions

Closes #400