### PR TITLE
feat: add request body schema versioning

### DIFF
--- a/docs/features/ADD_REQUEST_BODY_SCHEMA_VERSIONING.md
+++ b/docs/features/ADD_REQUEST_BODY_SCHEMA_VERSIONING.md
@@ -1,0 +1,73 @@
+# Request Body Schema Versioning
+
+## Overview
+As the Stellar Micro-Donation API evolves, request body schemas may change. Schema versioning allows the API to accept multiple schema versions simultaneously and provide clear upgrade paths for clients.
+
+## Key Features
+- **Version Negotiation**: Clients can specify the desired schema version using the `X-Schema-Version` request header (e.g., `1.0.0`).
+- **Default Versioning**: If no version is specified, the latest stable version is used.
+- **Deprecation Warnings**: Usage of older schemas triggers deprecation headers and standard warning messages.
+- **Migration Guides**: Clients using deprecated or invalid versions receive actionable migration guidance.
+
+## Header Support
+### Request Headers
+- `X-Schema-Version`: (Optional) The version of the schema to validate against (e.g., `1.0.0`).
+
+### Response Headers
+- `X-Schema-Version`: The version of the schema actually used.
+- `X-Schema-Version-Supported`: A list of all supported schema versions for the requested endpoint.
+- `X-Schema-Deprecated`: `true` if the requested version is deprecated.
+- `X-Schema-Migration-Guide`: A message describing how to migrate to the latest version.
+- `Warning`: A standard HTTP warning header (199) containing deprecation details.
+
+## Implementation Details
+
+### Registry
+Schemas are stored in a central `schemaRegistry.js` which manages versions, deprecation status, and migration guides.
+
+### Middleware
+The `schemaValidation.js` middleware handles the version negotiation and validation logic.
+
+#### Example Usage in Routes
+```javascript
+const { validateSchema } = require('../middleware/schemaValidation');
+
+const mySchemaVersions = {
+  '1.0.0': { 
+    body: { 
+      fields: { 
+        amount: { type: 'number', required: true } 
+      } 
+    } 
+  },
+  '2.0.0': { 
+    body: { 
+      fields: { 
+        amount: { type: 'number', required: true },
+        currency: { type: 'string', required: true }
+      } 
+    } 
+  }
+};
+
+const myOptions = {
+  deprecated: ['1.0.0'],
+  migrationGuides: {
+    '1.0.0': 'Upgrade to 2.0.0 to support multiple currencies.'
+  }
+};
+
+router.post('/my-endpoint', validateSchema('myEndpointName', mySchemaVersions, myOptions), (req, res) => {
+  // Handle request
+});
+```
+
+## Security Assumptions
+- Schema versioning is for structure validation only and does not bypass authentication or authorization.
+- Version negotiation is performed before processing sensitive data.
+
+## Error Handling
+When validation fails, or an unsupported version is requested, the API returns a `400 Bad Request` with:
+- `code`: `VALIDATION_ERROR` or `INVALID_SCHEMA_VERSION`
+- `supportedVersions`: List of valid versions for the endpoint
+- `migrationGuide`: Instructions on how to upgrade (if applicable)

--- a/src/middleware/schemaRegistry.js
+++ b/src/middleware/schemaRegistry.js
@@ -1,0 +1,72 @@
+/**
+ * Schema Version Registry
+ * 
+ * RESPONSIBILITY: Store and manage request body schemas, versions, and migration guides.
+ */
+
+const schemaRegistry = new Map();
+
+/**
+ * Register a schema with multiple versions in the central registry.
+ * 
+ * Sorts versions using a simple semver-like logic (major.minor.patch) to identify 'latest'.
+ * 
+ * @param {string} key Unique identifier for the schema (e.g., 'createDonation').
+ * @param {Object} versions Object mapping version strings (e.g. '1.0.0') to schema objects.
+ * @param {Object} options Configuration options.
+ * @param {string[]} [options.deprecated=[]] List of deprecated version strings.
+ * @param {Object} [options.migrationGuides={}] Object mapping version strings to migration guidance messages.
+ */
+function registerSchema(key, versions, options = {}) {
+  const { deprecated = [], migrationGuides = {} } = options;
+  
+  const sortedVersions = Object.keys(versions).sort((a, b) => {
+    // Simple semver-like sorting (major.minor.patch)
+    const pa = a.split('.').map(Number);
+    const pb = b.split('.').map(Number);
+    for (let i = 0; i < 3; i++) {
+      if ((pa[i] || 0) > (pb[i] || 0)) return -1;
+      if ((pa[i] || 0) < (pb[i] || 0)) return 1;
+    }
+    return 0;
+  });
+
+  schemaRegistry.set(key, {
+    versions,
+    latest: sortedVersions[0],
+    allVersions: sortedVersions,
+    deprecated,
+    migrationGuides
+  });
+}
+
+/**
+ * Retrieve a schema by key and version
+ * @param {string} key Schema identifier
+ * @param {string} version Requested version (optional, defaults to latest)
+ * @returns {Object|null} Schema information object or null if not found
+ */
+function getSchema(key, version) {
+  const entry = schemaRegistry.get(key);
+  if (!entry) return null;
+
+  const requestedVersion = version || entry.latest;
+  const schema = entry.versions[requestedVersion];
+
+  if (!schema) return null;
+
+  return {
+    schema,
+    version: requestedVersion,
+    isLatest: requestedVersion === entry.latest,
+    isDeprecated: entry.deprecated.includes(requestedVersion),
+    migrationGuide: entry.migrationGuides[requestedVersion] || null,
+    supportedVersions: entry.allVersions
+  };
+}
+
+module.exports = {
+  registerSchema,
+  getSchema,
+  registry: schemaRegistry
+};

--- a/src/middleware/schemaValidation.js
+++ b/src/middleware/schemaValidation.js
@@ -1,4 +1,6 @@
 const { ERROR_CODES } = require('../utils/errors');
+const schemaRegistry = require('./schemaRegistry');
+
 const {
   formatTypeError,
   formatEnumError,
@@ -216,24 +218,89 @@ function validateSegment(data, segmentSchema, segmentName) {
   return errors;
 }
 
-function validateSchema(schema) {
+/**
+ * Middleware factory for request schema validation with version support.
+ * 
+ * Supports both legacy single-schema objects and versioned schemas from the registry.
+ * Negotiates schema version using the 'X-Schema-Version' request header.
+ * 
+ * @param {Object|string} schemaOrKey A schema object (for legacy support) or a unique registry key.
+ * @param {Object} [versions] (Optional) An object mapping version strings to schemas for in-line registration.
+ * @param {Object} [options] (Optional) Configuration for versioning (deprecated versions, migration guides).
+ * @returns {Function} Express middleware function
+ */
+function validateSchema(schemaOrKey, versions, options) {
+
+  let schemaKey = null;
+
+  // In-line registration if versions are provided
+  if (typeof schemaOrKey === 'string' && versions) {
+    schemaKey = schemaOrKey;
+    schemaRegistry.registerSchema(schemaKey, versions, options);
+  } else if (typeof schemaOrKey === 'string') {
+    schemaKey = schemaOrKey;
+  }
+
   return (req, res, next) => {
+    let schemaToUse;
+    let versionInfo = null;
+
+    if (schemaKey) {
+      const requestedVersion = req.get('X-Schema-Version');
+      versionInfo = schemaRegistry.getSchema(schemaKey, requestedVersion);
+
+      if (!versionInfo) {
+        return res.status(400).json({
+          success: false,
+          error: {
+            code: ERROR_CODES.INVALID_SCHEMA_VERSION.code,
+            message: `Unsupported schema version: ${requestedVersion || 'latest'}`,
+            supportedVersions: schemaRegistry.registry.get(schemaKey)?.allVersions || [],
+            migrationGuide: 'Please consult the API documentation for supported schema versions.',
+            requestId: req.id,
+            timestamp: new Date().toISOString(),
+          },
+        });
+      }
+      schemaToUse = versionInfo.schema;
+    } else {
+      // Legacy support for direct schema objects
+      schemaToUse = schemaOrKey;
+    }
+
+    // Version headers
+    if (versionInfo) {
+      res.setHeader('X-Schema-Version', versionInfo.version);
+      res.setHeader('X-Schema-Version-Supported', versionInfo.supportedVersions.join(', '));
+
+      if (versionInfo.isDeprecated) {
+        res.setHeader('X-Schema-Deprecated', 'true');
+        if (versionInfo.migrationGuide) {
+          res.setHeader('X-Schema-Migration-Guide', versionInfo.migrationGuide);
+          // Add standard Warning header for deprecation
+          res.setHeader('Warning', `199 - "Schema version ${versionInfo.version} is deprecated. ${versionInfo.migrationGuide}"`);
+        } else {
+          res.setHeader('Warning', `199 - "Schema version ${versionInfo.version} is deprecated."`);
+        }
+      }
+    }
+
     const allErrors = [];
 
-    if (schema.body) {
-      allErrors.push(...validateSegment(req.body ?? {}, schema.body, 'body'));
+    if (schemaToUse.body) {
+      allErrors.push(...validateSegment(req.body ?? {}, schemaToUse.body, 'body'));
     }
 
-    if (schema.query) {
-      allErrors.push(...validateSegment(req.query ?? {}, schema.query, 'query'));
+    if (schemaToUse.query) {
+      allErrors.push(...validateSegment(req.query ?? {}, schemaToUse.query, 'query'));
     }
 
-    if (schema.params) {
-      allErrors.push(...validateSegment(req.params ?? {}, schema.params, 'params'));
+    if (schemaToUse.params) {
+      allErrors.push(...validateSegment(req.params ?? {}, schemaToUse.params, 'params'));
     }
 
     if (allErrors.length > 0) {
-      return res.status(400).json({
+      const errorResponse = {
         success: false,
         error: {
           code: ERROR_CODES.VALIDATION_ERROR.code,
@@ -242,7 +309,14 @@ function validateSchema(schema) {
           requestId: req.id,
           timestamp: new Date().toISOString(),
         },
-      });
+      };
+
+      // Include migration guide in error if version is deprecated
+      if (versionInfo?.isDeprecated && versionInfo?.migrationGuide) {
+        errorResponse.error.migrationGuide = versionInfo.migrationGuide;
+      }
+
+      return res.status(400).json(errorResponse);
     }
 
     return next();
@@ -252,3 +326,4 @@ function validateSchema(schema) {
 module.exports = {
   validateSchema,
 };
+

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -25,6 +25,7 @@ const ERROR_CODES = {
   INVALID_FREQUENCY:       { code: 'INVALID_FREQUENCY',       numeric: 1006 },
   MISSING_REQUIRED_FIELD:  { code: 'MISSING_REQUIRED_FIELD',  numeric: 1007 },
   IDEMPOTENCY_KEY_REQUIRED:{ code: 'IDEMPOTENCY_KEY_REQUIRED',numeric: 1008 },
+  INVALID_SCHEMA_VERSION:  { code: 'INVALID_SCHEMA_VERSION',  numeric: 1009 },
 
   // Authentication/Authorization errors (2000-2099)
   UNAUTHORIZED:             { code: 'UNAUTHORIZED',             numeric: 2000 },

--- a/tests/add-request-body-schema-versioning.test.js
+++ b/tests/add-request-body-schema-versioning.test.js
@@ -1,0 +1,152 @@
+const express = require('express');
+const request = require('supertest');
+const { validateSchema } = require('../src/middleware/schemaValidation');
+const schemaRegistry = require('../src/middleware/schemaRegistry');
+const { ERROR_CODES } = require('../src/utils/errors');
+
+describe('Request Body Schema Versioning', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    
+    // Clear registry before each test if possible, or just use unique keys
+    schemaRegistry.registry.clear();
+  });
+
+  const v1 = {
+    body: {
+      fields: {
+        amount: { type: 'number', required: true },
+        recipient: { type: 'string', required: true }
+      }
+    }
+  };
+
+  const v2 = {
+    body: {
+      fields: {
+        amount: { type: 'number', required: true },
+        recipient: { type: 'string', required: true },
+        currency: { type: 'string', required: true, enum: ['XLM', 'USDC'] }
+      }
+    }
+  };
+
+  test('uses latest version by default', async () => {
+    app.post('/test-default', validateSchema('testSchema', { '1.0.0': v1, '2.0.0': v2 }), (req, res) => {
+      res.status(200).json({ success: true, version: res.get('X-Schema-Version') });
+    });
+
+    const response = await request(app)
+      .post('/test-default')
+      .send({ amount: 10, recipient: 'ALICE', currency: 'XLM' });
+
+    expect(response.status).toBe(200);
+    expect(response.get('X-Schema-Version')).toBe('2.0.0');
+    expect(response.get('X-Schema-Version-Supported')).toBe('2.0.0, 1.0.0');
+  });
+
+  test('uses requested version via X-Schema-Version', async () => {
+    app.post('/test-version', validateSchema('testSchema', { '1.0.0': v1, '2.0.0': v2 }), (req, res) => {
+      res.status(200).json({ success: true, version: res.get('X-Schema-Version') });
+    });
+
+    const response = await request(app)
+      .post('/test-version')
+      .set('X-Schema-Version', '1.0.0')
+      .send({ amount: 10, recipient: 'ALICE' });
+
+    expect(response.status).toBe(200);
+    expect(response.get('X-Schema-Version')).toBe('1.0.0');
+    // Version 1.0.0 shouldn't require currency
+  });
+
+  test('rejects unsupported version with 400', async () => {
+    app.post('/test-unsupported', validateSchema('testSchema', { '1.0.0': v1 }), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    const response = await request(app)
+      .post('/test-unsupported')
+      .set('X-Schema-Version', '3.0.0')
+      .send({ amount: 10, recipient: 'ALICE' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe(ERROR_CODES.INVALID_SCHEMA_VERSION.code);
+    expect(response.body.error.supportedVersions).toContain('1.0.0');
+    expect(response.body.error.migrationGuide).toBeDefined();
+  });
+
+  test('provides deprecation warnings for old versions', async () => {
+    const migrationGuide = 'Upgrade to 2.0.0 for currency support';
+    app.post('/test-deprecated', 
+      validateSchema('testSchema', 
+        { '1.0.0': v1, '2.0.0': v2 }, 
+        { deprecated: ['1.0.0'], migrationGuides: { '1.0.0': migrationGuide } }
+      ), 
+      (req, res) => {
+        res.status(200).json({ success: true });
+    });
+
+    const response = await request(app)
+      .post('/test-deprecated')
+      .set('X-Schema-Version', '1.0.0')
+      .send({ amount: 10, recipient: 'ALICE' });
+
+    expect(response.status).toBe(200);
+    expect(response.get('X-Schema-Deprecated')).toBe('true');
+    expect(response.get('X-Schema-Migration-Guide')).toBe(migrationGuide);
+    expect(response.get('Warning')).toContain(migrationGuide);
+  });
+
+  test('includes migration guide in validation error for deprecated versions', async () => {
+    const migrationGuide = 'Upgrade to 2.0.0 for currency support';
+    app.post('/test-deprecated-error', 
+      validateSchema('testSchema', 
+        { '1.0.0': v1, '2.0.0': v2 }, 
+        { deprecated: ['1.0.0'], migrationGuides: { '1.0.0': migrationGuide } }
+      ), 
+      (req, res) => {
+        res.status(200).json({ success: true });
+    });
+
+    // Send invalid payload for version 1.0.0
+    const response = await request(app)
+      .post('/test-deprecated-error')
+      .set('X-Schema-Version', '1.0.0')
+      .send({ amount: 'invalid' }); // recipient missing and amount wrong type
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe(ERROR_CODES.VALIDATION_ERROR.code);
+    expect(response.body.error.migrationGuide).toBe(migrationGuide);
+    expect(response.get('X-Schema-Deprecated')).toBe('true');
+  });
+
+  test('maintains backward compatibility with legacy single schema objects', async () => {
+    app.post('/legacy', validateSchema(v1), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    const response = await request(app)
+      .post('/legacy')
+      .send({ amount: 10, recipient: 'ALICE' });
+
+    expect(response.status).toBe(200);
+    expect(response.get('X-Schema-Version')).toBeUndefined();
+  });
+
+  test('handles edge case: empty registry key', async () => {
+    app.post('/edge-case', validateSchema('nonExistent'), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    const response = await request(app)
+      .post('/edge-case')
+      .send({ amount: 10 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe(ERROR_CODES.INVALID_SCHEMA_VERSION.code);
+  });
+});


### PR DESCRIPTION
# Pull Request: Request Body Schema Versioning Implementation

This PR implements request body schema versioning for the API, allowing endpoints to support multiple schema versions simultaneously. This enables a smoother evolution of the API by providing clients with clear upgrade paths and migration guidance instead of cryptic validation errors.

**Closes #352**

## 🛡️ Core Infrastructure

*   **Schema Version Registry:** Introduced `src/middleware/schemaRegistry.js` to manage versioned schemas, identify 'latest' versions using semver-like sorting, and store deprecation metadata and migration guides.
*   **Version Negotiation Middleware:** Updated `src/middleware/schemaValidation.js` to automatically negotiate versions based on the `X-Schema-Version` request header.
*   **Standardized Headers:** Implemented injection of versioning metadata into response headers:
    *   `X-Schema-Version`: Confirms the version used for validation.
    *   `X-Schema-Version-Supported`: Lists all valid versions for the requested endpoint.
    *   `X-Schema-Deprecated`: Signals usage of a legacy schema.
    *   `X-Schema-Migration-Guide`: Provides instructions for upgrading to current schemas.
    *   **Warning:** Standard HTTP warning (199) for deprecation notices.

## 🛠️ Error Handling

*   Added `INVALID_SCHEMA_VERSION` (1009) error code to provide specific feedback when an unsupported version is requested.
*   Enhanced validation error responses to include migration guides when a deprecated version fails validation.

## 🧪 Quality Assurance

*   **Comprehensive Testing:** Added `tests/add-request-body-schema-versioning.test.js` covering:
    *   Default version resolution (latest stable).
    *   Explicit version negotiation.
    *   Rejection of unsupported versions.
    *   Deprecation and migration guide propagation.
    *   Backward compatibility for existing single-schema routes (legacy mode).
*   **Documentation:** Created `docs/features/ADD_REQUEST_BODY_SCHEMA_VERSIONING.md` with usage examples and implementation details.
*   **Documentation Standards:** Added full JSDoc comments to all new functions.

## 📊 Verification Results

### Automated Tests
Ran `npm test tests/add-request-body-schema-versioning.test.js` with 100% pass rate:

```text
PASS tests/add-request-body-schema-versioning.test.js
  Request Body Schema Versioning
    ✓ uses latest version by default
    ✓ uses requested version via X-Schema-Version
    ✓ rejects unsupported version with 400
    ✓ provides deprecation warnings for old versions
    ✓ includes migration guide in validation error for deprecated versions
    ✓ maintains backward compatibility with legacy single schema objects
    ✓ handles edge case: empty registry key