### PR TITLE
feat: add stellar transaction sequence number management

### DIFF
--- a/docs/ADD_STELLAR_TRANSACTION_SEQUENCE_NUMBER_MANAGEMENT.md
+++ b/docs/ADD_STELLAR_TRANSACTION_SEQUENCE_NUMBER_MANAGEMENT.md
@@ -1,0 +1,361 @@
+# Stellar Transaction Sequence Number Management
+
+**Feature branch:** `feature/add-stellar-transaction-sequence-number-management`  
+**Issue:** [#377](https://github.com/Manuel1234477/Stellar-Micro-Donation-API/issues/377)  
+**Module:** `src/utils/sequenceManager.js`
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#problem-statement)
+2. [Solution Overview](#solution-overview)
+3. [Architecture](#architecture)
+4. [API Reference](#api-reference)
+5. [Usage Examples](#usage-examples)
+6. [Configuration](#configuration)
+7. [Metrics](#metrics)
+8. [Security Assumptions](#security-assumptions)
+9. [Testing](#testing)
+10. [Edge Cases and Limitations](#edge-cases-and-limitations)
+
+---
+
+## Problem Statement
+
+Stellar transactions require a **strictly incrementing sequence number** — each
+transaction must use a value exactly one greater than the account's last-committed
+sequence number. Under concurrent load two or more pending transactions from the
+same account will share the same starting sequence number, causing all but one to
+fail with a `tx_bad_seq` error.
+
+```
+Account sequence on-chain: 100
+
+Tx A submitted → uses 101  ✓
+Tx B submitted → uses 101  ✗ tx_bad_seq (101 already used)
+Tx C submitted → uses 101  ✗ tx_bad_seq
+```
+
+Without coordination this produces a thundering-herd of failures that are both
+wasteful (each failed submission still costs an API round-trip) and confusing to
+end users.
+
+---
+
+## Solution Overview
+
+`sequenceManager.js` solves this with three complementary mechanisms:
+
+| Mechanism | What it does |
+|-----------|-------------|
+| **Per-account async mutex** | Serialises all transactions from the same account so only one is in-flight at a time |
+| **Sequence number cache** | Stores the last known sequence number in memory; avoids a Horizon `loadAccount` call for every transaction |
+| **Optimistic retry with cache invalidation** | On `tx_bad_seq` the cache is cleared and the transaction is retried up to `maxRetries` times using exponential back-off |
+
+---
+
+## Architecture
+
+```
+Concurrent callers (same account)
+        │   │   │
+        ▼   ▼   ▼
+┌────────────────────────────────┐
+│       withAccountLock()        │  ← per-account Promise chain (mutex)
+│                                │
+│  ┌──────────────────────────┐  │
+│  │   executeWithRetry()     │  │  ← retry loop (max N attempts)
+│  │                          │  │
+│  │  getSequenceNumber()     │  │  ← cache-first; falls back to Horizon
+│  │  transactionFn(attempt)  │  │  ← caller's build+submit logic
+│  │                          │  │
+│  │  on tx_bad_seq:          │  │
+│  │    invalidateCache()     │  │  ← forces fresh Horizon fetch
+│  │    sleep(backoff)        │  │
+│  │    retry ...             │  │
+│  └──────────────────────────┘  │
+└────────────────────────────────┘
+        │
+        ▼
+   Horizon API
+```
+
+### Key data structures
+
+```
+lockMap      Map<accountId, Promise>  — tail of each account's lock chain
+sequenceCache Map<accountId, { sequenceNumber, cachedAt }>
+metrics       { conflicts, retries, cacheHits, cacheMisses, lockWaits }
+```
+
+---
+
+## API Reference
+
+### `createSequenceManager([config])` → `SequenceManager`
+
+Factory function. Use this in tests and wherever you need an isolated instance.
+
+```js
+const { createSequenceManager } = require('./src/utils/sequenceManager');
+const mgr = createSequenceManager({ maxRetries: 3, retryDelayMs: 50 });
+```
+
+---
+
+### `mgr.withAccountLock(accountId, fn)` → `Promise<T>`
+
+Acquires an exclusive per-account lock and runs `fn` inside it.
+All callers for the same `accountId` are queued and run serially.
+
+```js
+await mgr.withAccountLock(senderPublicKey, async () => {
+  // only one caller runs here at a time per account
+});
+```
+
+---
+
+### `mgr.getSequenceNumber(accountId, horizonClient)` → `Promise<string>`
+
+Returns the current sequence number for `accountId`.
+
+- **Cache hit** (entry exists and is within TTL): returns cached value,
+  increments the cache optimistically, counts a cache hit.
+- **Cache miss** (no entry or expired): calls `horizonClient.loadAccount(accountId)`,
+  stores the result, counts a cache miss.
+
+```js
+const seq = await mgr.getSequenceNumber(publicKey, server);
+```
+
+---
+
+### `mgr.executeWithRetry(accountId, transactionFn)` → `Promise<T>`
+
+High-level helper. Wraps `transactionFn` inside an account lock with automatic
+retry on `tx_bad_seq`.
+
+```js
+const result = await mgr.executeWithRetry(senderKey, async (attempt) => {
+  const seq = await mgr.getSequenceNumber(senderKey, server);
+  const tx = buildTransaction(senderKey, recipientKey, amount, seq);
+  return server.submitTransaction(tx);
+});
+```
+
+`transactionFn` receives the zero-based **attempt index** so callers can
+adjust behaviour (e.g. logging) on retries.
+
+---
+
+### `mgr.invalidateCache(accountId)` → `void`
+
+Removes `accountId` from the sequence cache. Called automatically inside
+`executeWithRetry` before each retry.
+
+---
+
+### `mgr.clearCache([accountId])` → `void`
+
+Clears the cache for a specific account (if `accountId` is provided) or for
+all accounts (no argument).
+
+---
+
+### `mgr.getMetrics()` → `SequenceMetrics`
+
+Returns a snapshot of the current metrics counters.
+
+```ts
+{
+  conflicts:   number,  // total tx_bad_seq errors encountered
+  retries:     number,  // total retry attempts made
+  cacheHits:   number,  // times a valid cached entry was used
+  cacheMisses: number,  // times the cache was cold or stale
+  lockWaits:   number,  // times a task waited for an account lock
+}
+```
+
+---
+
+### `mgr.resetMetrics()` → `void`
+
+Zeros all counters. Useful between monitoring windows or test runs.
+
+---
+
+### `mgr.activeLockCount()` → `number`
+
+Returns how many accounts currently have an active lock. Useful for health checks.
+
+---
+
+## Usage Examples
+
+### Basic one-time donation
+
+```js
+const { createSequenceManager } = require('./src/utils/sequenceManager');
+const StellarSdk = require('stellar-sdk');
+
+const seqMgr = createSequenceManager();
+const server  = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+async function submitDonation(senderSecret, recipientKey, amount) {
+  const senderKeypair = StellarSdk.Keypair.fromSecret(senderSecret);
+  const senderKey     = senderKeypair.publicKey();
+
+  return seqMgr.executeWithRetry(senderKey, async (attempt) => {
+    if (attempt > 0) {
+      console.log(`Retrying donation (attempt ${attempt + 1}) …`);
+    }
+
+    const seq     = await seqMgr.getSequenceNumber(senderKey, server);
+    const account = new StellarSdk.Account(senderKey, seq);
+
+    const tx = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: StellarSdk.Networks.TESTNET,
+    })
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination: recipientKey,
+          asset:       StellarSdk.Asset.native(),
+          amount:      amount.toString(),
+        })
+      )
+      .setTimeout(30)
+      .build();
+
+    tx.sign(senderKeypair);
+    return server.submitTransaction(tx);
+  });
+}
+```
+
+### Recurring donation scheduler integration
+
+```js
+// In RecurringDonationScheduler.js
+const { defaultManager } = require('../utils/sequenceManager');
+
+async function executeDue(schedule) {
+  return defaultManager.executeWithRetry(
+    schedule.donorPublicKey,
+    async () => submitScheduledPayment(schedule)
+  );
+}
+```
+
+### Monitoring metrics
+
+```js
+setInterval(() => {
+  const m = seqMgr.getMetrics();
+  console.log(
+    `[seq-mgr] conflicts=${m.conflicts} retries=${m.retries} ` +
+    `hits=${m.cacheHits} misses=${m.cacheMisses}`
+  );
+  seqMgr.resetMetrics(); // reset window
+}, 60_000);
+```
+
+---
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `maxRetries` | `5` | Maximum retry attempts after a `tx_bad_seq` error |
+| `retryDelayMs` | `100` | Base delay between retries (ms). Actual delay uses exponential back-off + ±10 % jitter |
+| `cacheTtlMs` | `30000` | How long (ms) a cached sequence number is considered fresh |
+| `backoffMultiplier` | `2` | Multiplier applied to `retryDelayMs` on each retry |
+
+**Tuning advice:**
+
+- **High-throughput senders**: lower `retryDelayMs` to `20–50 ms`; the lock
+  already serialises requests so conflicts should be rare.
+- **Flaky networks**: raise `maxRetries` to `8–10` and increase `retryDelayMs`.
+- **Short-lived processes** (e.g. Lambda): lower `cacheTtlMs` to `5000` so
+  stale cache entries don't cause spurious `tx_bad_seq` errors after a cold start.
+
+---
+
+## Metrics
+
+The module exposes lightweight counters (no external dependencies):
+
+| Metric | Interpretation |
+|--------|---------------|
+| `conflicts` | Rising fast → network congestion or a bug producing duplicate submits |
+| `retries` | Should be ≤ `conflicts` × `maxRetries` |
+| `cacheHits / cacheMisses` | Hit rate = `hits / (hits + misses)`; a healthy deployment should be > 80 % |
+| `lockWaits` | High value → many tasks queued per account; consider rate-limiting at the API layer |
+
+Metrics can be scraped and pushed to Prometheus/Datadog using a periodic
+`setInterval` wrapper (see example above).
+
+---
+
+## Security Assumptions
+
+| Assumption | Rationale |
+|------------|-----------|
+| The sequence cache is **process-local and in-memory** | Acceptable for a single-process Node.js server. A multi-process deployment (cluster, multiple pods) must use a distributed lock (e.g. Redis `SET NX`) instead of this module. |
+| `accountId` (public key) is **trusted input** | All callers are internal services. No external user can inject an arbitrary account ID to monopolise a lock. |
+| Cached sequence numbers are **short-lived** (default 30 s) | Prevents stale data from accumulating if the Stellar ledger advances without going through this process. |
+| Private keys **never pass through** this module | The module only handles sequence numbers. Key management is the caller's responsibility. |
+| The retry loop has a **bounded maximum** | Prevents infinite loops if Horizon returns persistent errors. |
+
+---
+
+## Testing
+
+The test suite lives at:
+
+```
+tests/add-stellar-transaction-sequence-number-management.test.js
+```
+
+Run it with:
+
+```bash
+npm test tests/add-stellar-transaction-sequence-number-management.test.js
+```
+
+With coverage:
+
+```bash
+npm test -- --coverage --collectCoverageFrom='src/utils/sequenceManager.js' \
+  tests/add-stellar-transaction-sequence-number-management.test.js
+```
+
+### What is tested
+
+| Suite | Scenarios |
+|-------|-----------|
+| Factory | Default config, custom config merge, instance isolation |
+| `withAccountLock` | Single task, serialisation of 10+ concurrent tasks, parallel tasks for different accounts, error propagation, lock release after error |
+| `getSequenceNumber` | Cache miss (Horizon fetch), cache hit, TTL expiry, `invalidateCache`, `clearCache` (single + all), optimistic increment |
+| `executeWithRetry` | Success path, retry on `tx_bad_seq`, exhaust retries, non-sequence error passthrough, cache invalidation on retry, attempt index passed to fn, `maxRetries=0`, serialisation during retry, message-string detection |
+| Metrics | Snapshot isolation, `resetMetrics`, `cacheHits`, `cacheMisses`, conflict + retry counters |
+| `activeLockCount` | Zero when idle, positive while locked |
+| Edge cases | Horizon rejection, null error, independent caches per account, singleton exports, alternate error shape, config immutability |
+
+---
+
+## Edge Cases and Limitations
+
+- **Cluster / multi-pod deployments**: The per-account lock is process-local. Use
+  a distributed lock (Redis, DynamoDB conditional writes) for multi-process setups.
+- **Very long-running transactions**: If `cacheTtlMs` expires while a transaction is
+  being built, the next call inside the same lock window will fetch a fresh sequence —
+  which is safe because the lock serialises access.
+- **Ledger rollback / network upgrade**: A network-level sequence reset would cause
+  persistent `tx_bad_seq` errors that exhaust `maxRetries`. Monitor `conflicts`
+  metrics and alert when the conflict rate exceeds a threshold (e.g. > 10 in 60 s).
+- **Memory leak prevention**: `lockMap` entries are deleted once their promise chain
+  settles (`finally` clause), so the Map does not grow unboundedly even under
+  sustained load.

--- a/src/utils/sequenceManager.js
+++ b/src/utils/sequenceManager.js
@@ -1,0 +1,371 @@
+'use strict';
+
+/**
+ * @fileoverview Stellar Transaction Sequence Number Manager
+ *
+ * Manages per-account sequence numbers for Stellar blockchain transactions.
+ * Solves the concurrency problem where multiple simultaneous transactions from
+ * the same account fail because each requires a strictly incrementing sequence number.
+ *
+ * Key features:
+ * - Per-account async mutex (lock) to serialize concurrent transactions
+ * - In-memory sequence number cache to reduce Horizon API calls
+ * - Optimistic retry on `tx_bad_seq` errors with automatic cache invalidation
+ * - Prometheus-style metrics (conflict count, retry count, cache hits/misses)
+ *
+ * @module sequenceManager
+ */
+
+/**
+ * Default configuration values for the sequence manager.
+ * @type {Object}
+ */
+const DEFAULT_CONFIG = {
+  /** Maximum number of times to retry a transaction after a sequence conflict */
+  maxRetries: 5,
+  /** Base delay (ms) between retries — actual delay uses exponential back-off */
+  retryDelayMs: 100,
+  /** How long (ms) a cached sequence number is considered fresh */
+  cacheTtlMs: 30_000,
+  /** Multiplier applied to retryDelayMs on each successive attempt */
+  backoffMultiplier: 2,
+};
+
+/**
+ * @typedef {Object} SequenceCache
+ * @property {string} sequenceNumber - The cached sequence number (BigInt-safe string)
+ * @property {number} cachedAt       - Unix timestamp (ms) when the value was stored
+ */
+
+/**
+ * @typedef {Object} SequenceMetrics
+ * @property {number} conflicts   - Total sequence-number conflicts encountered
+ * @property {number} retries     - Total retry attempts made
+ * @property {number} cacheHits   - Times a valid cached value was used
+ * @property {number} cacheMisses - Times the cache was cold or stale
+ * @property {number} lockWaits   - Times a transaction had to wait for an account lock
+ */
+
+/**
+ * Creates and returns a new SequenceManager instance.
+ *
+ * @param {Object} [config={}] - Optional configuration overrides
+ * @param {number} [config.maxRetries]        - Max retries on sequence conflict
+ * @param {number} [config.retryDelayMs]      - Base retry delay in ms
+ * @param {number} [config.cacheTtlMs]        - Cache TTL in ms
+ * @param {number} [config.backoffMultiplier] - Exponential back-off multiplier
+ * @returns {SequenceManager} A new sequence manager instance
+ *
+ * @example
+ * const manager = createSequenceManager({ maxRetries: 3, retryDelayMs: 50 });
+ */
+function createSequenceManager(config = {}) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+
+  /**
+   * Per-account mutex queue.
+   * Key  : Stellar public key (string)
+   * Value: Promise chain acting as a serialization lock
+   * @type {Map<string, Promise<void>>}
+   */
+  const lockMap = new Map();
+
+  /**
+   * In-memory sequence number cache.
+   * Key  : Stellar public key (string)
+   * Value: SequenceCache object
+   * @type {Map<string, SequenceCache>}
+   */
+  const sequenceCache = new Map();
+
+  /**
+   * Live metrics counters.
+   * @type {SequenceMetrics}
+   */
+  const metrics = {
+    conflicts: 0,
+    retries: 0,
+    cacheHits: 0,
+    cacheMisses: 0,
+    lockWaits: 0,
+  };
+
+  // ─── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Returns a promise that resolves after `ms` milliseconds.
+   * @param {number} ms
+   * @returns {Promise<void>}
+   */
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Computes the retry delay for a given attempt using exponential back-off
+   * with ±10 % jitter to avoid thundering-herd problems.
+   *
+   * @param {number} attempt - Zero-based attempt index
+   * @returns {number} Delay in milliseconds
+   */
+  function computeDelay(attempt) {
+    const base = cfg.retryDelayMs * Math.pow(cfg.backoffMultiplier, attempt);
+    const jitter = base * 0.1 * (Math.random() * 2 - 1); // ±10 %
+    return Math.round(base + jitter);
+  }
+
+  /**
+   * Determines whether a Stellar error represents a sequence number conflict.
+   * Stellar SDK wraps these as `tx_bad_seq` result codes.
+   *
+   * @param {Error|Object} error - The error thrown by the Stellar SDK
+   * @returns {boolean}
+   */
+  function isSequenceConflict(error) {
+    if (!error) return false;
+    // Stellar SDK error shape: error.response.data.extras.result_codes.transaction
+    const txCode =
+      error?.response?.data?.extras?.result_codes?.transaction ||
+      error?.extras?.result_codes?.transaction ||
+      error?.result_codes?.transaction ||
+      '';
+    if (txCode === 'tx_bad_seq') return true;
+    // Some mock/test environments surface this via message
+    const msg = (error.message || '').toLowerCase();
+    return msg.includes('tx_bad_seq') || msg.includes('sequence');
+  }
+
+  /**
+   * Returns true when a cached entry is still within its TTL window.
+   *
+   * @param {SequenceCache} entry
+   * @returns {boolean}
+   */
+  function isCacheValid(entry) {
+    return Date.now() - entry.cachedAt < cfg.cacheTtlMs;
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Acquires an exclusive lock for the given account and runs `fn` within it.
+   * All callers for the same `accountId` are queued and executed serially.
+   *
+   * @template T
+   * @param {string}            accountId - Stellar public key of the sender
+   * @param {function(): Promise<T>} fn   - Async work to execute under the lock
+   * @returns {Promise<T>} Resolves with the return value of `fn`
+   *
+   * @example
+   * const result = await manager.withAccountLock(senderKey, async () => {
+   *   const seq = await manager.getSequenceNumber(senderKey, horizonClient);
+   *   return stellarService.submitTransaction(senderKey, seq);
+   * });
+   */
+  function withAccountLock(accountId, fn) {
+    const current = lockMap.get(accountId) || Promise.resolve();
+
+    // `gate` is what the next waiter queues behind — it never rejects so the
+    // chain is never broken by one task's error.
+    // `result` is what the caller awaits — it resolves/rejects with fn's value.
+    let resolveGate;
+    const gate = new Promise((res) => { resolveGate = res; });
+
+    const result = current.then(() => {
+      if (lockMap.get(accountId) !== gate) metrics.lockWaits++;
+      return fn();
+    });
+
+    // Release the gate (and clean up the map) once fn settles
+    result.then(resolveGate, resolveGate);
+    gate.finally(() => {
+      if (lockMap.get(accountId) === gate) {
+        lockMap.delete(accountId);
+      }
+    });
+
+    lockMap.set(accountId, gate);
+    return result; // callers see fn's actual resolution / rejection
+  }
+
+  /**
+   * Returns the current sequence number for `accountId`.
+   * Serves from cache when the entry is fresh; otherwise fetches from Horizon.
+   *
+   * After a successful fetch the value is stored in the cache and incremented
+   * by 1 so the *next* call within the same lock window gets an already-
+   * incremented value (optimistic increment pattern).
+   *
+   * @param {string} accountId      - Stellar public key
+   * @param {Object} horizonClient  - Object with `loadAccount(publicKey)` method
+   * @returns {Promise<string>} The sequence number to use for the next transaction
+   */
+  async function getSequenceNumber(accountId, horizonClient) {
+    const cached = sequenceCache.get(accountId);
+
+    if (cached && isCacheValid(cached)) {
+      metrics.cacheHits++;
+      // Return cached value; pre-advance cache so the next call in the same
+      // lock window receives an already-incremented, unique sequence number.
+      const toReturn = cached.sequenceNumber;
+      const next = (BigInt(toReturn) + 1n).toString();
+      sequenceCache.set(accountId, { sequenceNumber: next, cachedAt: Date.now() });
+      return toReturn;
+    }
+
+    // Cache cold or expired — fetch from Horizon
+    metrics.cacheMisses++;
+    const account = await horizonClient.loadAccount(accountId);
+    const sequenceNumber = account.sequenceNumber || account.sequence_number || '0';
+    // Pre-load cache with the next value so the very first cache hit returns
+    // an incremented sequence without another Horizon round-trip.
+    const nextAfterFetch = (BigInt(sequenceNumber) + 1n).toString();
+    sequenceCache.set(accountId, { sequenceNumber: nextAfterFetch, cachedAt: Date.now() });
+    return sequenceNumber;
+  }
+
+  /**
+   * Invalidates the cached sequence number for `accountId`.
+   * Called automatically when a `tx_bad_seq` error is detected so the next
+   * attempt fetches a fresh value from Horizon.
+   *
+   * @param {string} accountId - Stellar public key
+   * @returns {void}
+   */
+  function invalidateCache(accountId) {
+    sequenceCache.delete(accountId);
+  }
+
+  /**
+   * Executes `transactionFn` inside an account lock, retrying automatically on
+   * sequence-number conflicts up to `cfg.maxRetries` times.
+   *
+   * On each `tx_bad_seq` error the cache is invalidated so the next attempt
+   * fetches a fresh sequence number from Horizon.
+   *
+   * @template T
+   * @param {string}   accountId       - Stellar public key of the sending account
+   * @param {function(attempt: number): Promise<T>} transactionFn
+   *   Function that builds and submits the transaction.
+   *   Receives the current attempt number (0-based) as its argument.
+   * @returns {Promise<T>} Resolves with the result of a successful `transactionFn` call
+   * @throws {Error} Re-throws the last error after all retries are exhausted
+   *
+   * @example
+   * const result = await manager.executeWithRetry(senderPublicKey, async (attempt) => {
+   *   const seq = await manager.getSequenceNumber(senderPublicKey, server);
+   *   return stellarService.buildAndSubmit(senderPublicKey, recipientPublicKey, amount, seq);
+   * });
+   */
+  async function executeWithRetry(accountId, transactionFn) {
+    return withAccountLock(accountId, async () => {
+      let lastError;
+
+      for (let attempt = 0; attempt <= cfg.maxRetries; attempt++) {
+        try {
+          const result = await transactionFn(attempt);
+          return result;
+        } catch (err) {
+          lastError = err;
+
+          if (!isSequenceConflict(err)) {
+            // Non-sequence error — propagate immediately
+            throw err;
+          }
+
+          metrics.conflicts++;
+
+          if (attempt < cfg.maxRetries) {
+            metrics.retries++;
+            invalidateCache(accountId);
+            const delay = computeDelay(attempt);
+            await sleep(delay);
+          }
+        }
+      }
+
+      throw lastError;
+    });
+  }
+
+  /**
+   * Returns a snapshot of the current metrics.
+   * Values are monotonically increasing counters; reset with `resetMetrics()`.
+   *
+   * @returns {SequenceMetrics}
+   */
+  function getMetrics() {
+    return { ...metrics };
+  }
+
+  /**
+   * Resets all metrics counters to zero.
+   * Useful between test runs or monitoring intervals.
+   *
+   * @returns {void}
+   */
+  function resetMetrics() {
+    metrics.conflicts = 0;
+    metrics.retries = 0;
+    metrics.cacheHits = 0;
+    metrics.cacheMisses = 0;
+    metrics.lockWaits = 0;
+  }
+
+  /**
+   * Clears the sequence number cache for all accounts (or a single account).
+   *
+   * @param {string} [accountId] - If provided, only clear cache for this account
+   * @returns {void}
+   */
+  function clearCache(accountId) {
+    if (accountId) {
+      sequenceCache.delete(accountId);
+    } else {
+      sequenceCache.clear();
+    }
+  }
+
+  /**
+   * Returns the number of accounts currently holding an active lock.
+   * Useful for diagnostics and tests.
+   *
+   * @returns {number}
+   */
+  function activeLockCount() {
+    return lockMap.size;
+  }
+
+  return {
+    withAccountLock,
+    getSequenceNumber,
+    invalidateCache,
+    executeWithRetry,
+    getMetrics,
+    resetMetrics,
+    clearCache,
+    activeLockCount,
+    // Expose config for introspection/testing
+    _config: cfg,
+  };
+}
+
+/**
+ * Singleton instance with default configuration.
+ * Import this directly in production code; use `createSequenceManager` in tests.
+ */
+const defaultManager = createSequenceManager();
+
+module.exports = {
+  createSequenceManager,
+  defaultManager,
+  // Re-export for convenience
+  withAccountLock: defaultManager.withAccountLock,
+  getSequenceNumber: defaultManager.getSequenceNumber,
+  invalidateCache: defaultManager.invalidateCache,
+  executeWithRetry: defaultManager.executeWithRetry,
+  getMetrics: defaultManager.getMetrics,
+  resetMetrics: defaultManager.resetMetrics,
+  clearCache: defaultManager.clearCache,
+  activeLockCount: defaultManager.activeLockCount,
+};

--- a/tests/add-stellar-transaction-sequence-number-management.test.js
+++ b/tests/add-stellar-transaction-sequence-number-management.test.js
@@ -1,0 +1,584 @@
+'use strict';
+
+/**
+ * @file add-stellar-transaction-sequence-number-management.test.js
+ *
+ * Comprehensive tests for src/utils/sequenceManager.js
+ *
+ * Coverage targets (≥95 %):
+ *  - Per-account serialisation (lock mechanics)
+ *  - Sequence number caching (hits, misses, TTL expiry)
+ *  - Optimistic retry on tx_bad_seq
+ *  - Metrics tracking
+ *  - Edge cases: empty accountId, maxRetries=0, non-sequence errors, etc.
+ *
+ * No live Stellar network is used — all Horizon interactions are mocked.
+ */
+
+const { createSequenceManager } = require('../src/utils/sequenceManager');
+
+// ─── Shared helpers ────────────────────────────────────────────────────────
+
+/**
+ * Builds a minimal mock Horizon client.
+ * @param {string} [sequence='100'] Initial sequence number to return
+ * @returns {{ loadAccount: jest.Mock }}
+ */
+function buildHorizonClient(sequence = '100') {
+  return {
+    loadAccount: jest.fn().mockResolvedValue({ sequenceNumber: sequence }),
+  };
+}
+
+/**
+ * Builds a Stellar-SDK-style `tx_bad_seq` error.
+ * @returns {Error}
+ */
+function buildBadSeqError() {
+  const err = new Error('Transaction failed');
+  err.response = {
+    data: {
+      extras: {
+        result_codes: { transaction: 'tx_bad_seq' },
+      },
+    },
+  };
+  return err;
+}
+
+/**
+ * Returns a promise that resolves after `ms` ms (test utility).
+ * @param {number} ms
+ */
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Test suites ──────────────────────────────────────────────────────────
+
+describe('createSequenceManager — factory', () => {
+  it('returns a manager object with all expected methods', () => {
+    const mgr = createSequenceManager();
+    expect(typeof mgr.withAccountLock).toBe('function');
+    expect(typeof mgr.getSequenceNumber).toBe('function');
+    expect(typeof mgr.invalidateCache).toBe('function');
+    expect(typeof mgr.executeWithRetry).toBe('function');
+    expect(typeof mgr.getMetrics).toBe('function');
+    expect(typeof mgr.resetMetrics).toBe('function');
+    expect(typeof mgr.clearCache).toBe('function');
+    expect(typeof mgr.activeLockCount).toBe('function');
+  });
+
+  it('merges custom config with defaults', () => {
+    const mgr = createSequenceManager({ maxRetries: 2, retryDelayMs: 10 });
+    expect(mgr._config.maxRetries).toBe(2);
+    expect(mgr._config.retryDelayMs).toBe(10);
+    // Default unchanged values are preserved
+    expect(mgr._config.cacheTtlMs).toBe(30_000);
+  });
+
+  it('two factory calls produce independent instances', () => {
+    const a = createSequenceManager();
+    const b = createSequenceManager();
+    a.getMetrics(); // just to reference
+    b.resetMetrics();
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('withAccountLock — serialisation', () => {
+  let mgr;
+  beforeEach(() => { mgr = createSequenceManager(); });
+
+  it('executes a single task and returns its value', async () => {
+    const result = await mgr.withAccountLock('ACC1', async () => 'done');
+    expect(result).toBe('done');
+  });
+
+  it('serialises concurrent tasks for the same account', async () => {
+    const order = [];
+    const ACCOUNT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+    const t1 = mgr.withAccountLock(ACCOUNT, async () => {
+      order.push('t1-start');
+      await delay(20);
+      order.push('t1-end');
+    });
+
+    const t2 = mgr.withAccountLock(ACCOUNT, async () => {
+      order.push('t2-start');
+      await delay(5);
+      order.push('t2-end');
+    });
+
+    await Promise.all([t1, t2]);
+
+    // t1 must complete entirely before t2 starts
+    expect(order).toEqual(['t1-start', 't1-end', 't2-start', 't2-end']);
+  });
+
+  it('allows parallel execution for DIFFERENT accounts', async () => {
+    const started = [];
+
+    const t1 = mgr.withAccountLock('ACC_A', async () => {
+      started.push('A');
+      await delay(30);
+    });
+
+    const t2 = mgr.withAccountLock('ACC_B', async () => {
+      started.push('B');
+      await delay(5);
+    });
+
+    // Give both a chance to start before awaiting
+    await delay(5);
+    // Both should have started (parallel execution)
+    expect(started).toContain('A');
+    expect(started).toContain('B');
+
+    await Promise.all([t1, t2]);
+  });
+
+  it('propagates errors thrown inside the lock', async () => {
+    await expect(
+      mgr.withAccountLock('ERR_ACC', async () => { throw new Error('boom'); })
+    ).rejects.toThrow('boom');
+  });
+
+  it('releases the lock after an error so subsequent tasks can run', async () => {
+    const ACCOUNT = 'ERR_RELEASE_ACC';
+    let secondRan = false;
+
+    // First task errors
+    await mgr.withAccountLock(ACCOUNT, async () => { throw new Error('oops'); }).catch(() => {});
+
+    // Second task should still execute
+    await mgr.withAccountLock(ACCOUNT, async () => { secondRan = true; });
+    expect(secondRan).toBe(true);
+  });
+
+  it('handles 10+ concurrent transactions from the same account in order', async () => {
+    const ACCOUNT = 'CONCURRENT_ACCOUNT';
+    const order = [];
+    const N = 12;
+
+    const tasks = Array.from({ length: N }, (_, i) =>
+      mgr.withAccountLock(ACCOUNT, async () => {
+        order.push(i);
+        await delay(2);
+      })
+    );
+
+    await Promise.all(tasks);
+
+    // Every index should appear exactly once
+    expect(order).toHaveLength(N);
+    expect(new Set(order).size).toBe(N);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getSequenceNumber — caching', () => {
+  let mgr;
+  beforeEach(() => {
+    mgr = createSequenceManager({ cacheTtlMs: 200 });
+  });
+
+  it('fetches from Horizon on cache miss', async () => {
+    const client = buildHorizonClient('500');
+    const seq = await mgr.getSequenceNumber('ACC', client);
+    expect(seq).toBe('500');
+    expect(client.loadAccount).toHaveBeenCalledTimes(1);
+    expect(mgr.getMetrics().cacheMisses).toBe(1);
+  });
+
+  it('serves cached value on subsequent call within TTL', async () => {
+    const client = buildHorizonClient('500');
+    await mgr.getSequenceNumber('ACC_CACHE', client);
+    const seq2 = await mgr.getSequenceNumber('ACC_CACHE', client);
+    // loadAccount called only once
+    expect(client.loadAccount).toHaveBeenCalledTimes(1);
+    expect(mgr.getMetrics().cacheHits).toBeGreaterThanOrEqual(1);
+    // second call returns incremented sequence
+    expect(seq2).toBe('501');
+  });
+
+  it('re-fetches from Horizon after TTL expires', async () => {
+    const shortTtlMgr = createSequenceManager({ cacheTtlMs: 50 });
+    const client = buildHorizonClient('200');
+
+    await shortTtlMgr.getSequenceNumber('TTL_ACC', client);
+    await delay(60); // wait for TTL to expire
+    await shortTtlMgr.getSequenceNumber('TTL_ACC', client);
+
+    expect(client.loadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidateCache clears entry for specific account', async () => {
+    const client = buildHorizonClient('300');
+    await mgr.getSequenceNumber('INV_ACC', client);
+    mgr.invalidateCache('INV_ACC');
+    await mgr.getSequenceNumber('INV_ACC', client);
+    // loadAccount called twice because cache was cleared
+    expect(client.loadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearCache() with no argument clears all entries', async () => {
+    const clientA = buildHorizonClient('10');
+    const clientB = buildHorizonClient('20');
+    await mgr.getSequenceNumber('A', clientA);
+    await mgr.getSequenceNumber('B', clientB);
+    mgr.clearCache();
+    await mgr.getSequenceNumber('A', clientA);
+    await mgr.getSequenceNumber('B', clientB);
+    expect(clientA.loadAccount).toHaveBeenCalledTimes(2);
+    expect(clientB.loadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearCache(accountId) only clears the specified account', async () => {
+    const clientA = buildHorizonClient('10');
+    const clientB = buildHorizonClient('20');
+    await mgr.getSequenceNumber('ONLY_A', clientA);
+    await mgr.getSequenceNumber('ONLY_B', clientB);
+    mgr.clearCache('ONLY_A');
+    await mgr.getSequenceNumber('ONLY_A', clientA);
+    await mgr.getSequenceNumber('ONLY_B', clientB); // still cached
+    expect(clientA.loadAccount).toHaveBeenCalledTimes(2);
+    expect(clientB.loadAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('increments sequence optimistically for concurrent calls within same lock', async () => {
+    const client = buildHorizonClient('1000');
+    const seq1 = await mgr.getSequenceNumber('OPT_ACC', client);
+    const seq2 = await mgr.getSequenceNumber('OPT_ACC', client);
+    // seq1 = '1000', seq2 = '1001'
+    expect(BigInt(seq2)).toBe(BigInt(seq1) + 1n);
+    // Horizon called only once
+    expect(client.loadAccount).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('executeWithRetry — sequence conflict handling', () => {
+  let mgr;
+  beforeEach(() => {
+    mgr = createSequenceManager({ maxRetries: 4, retryDelayMs: 5 });
+  });
+
+  it('succeeds immediately when no error occurs', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await mgr.executeWithRetry('ACC', fn);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on tx_bad_seq and succeeds on second attempt', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(buildBadSeqError())
+      .mockResolvedValue('success');
+
+    const result = await mgr.executeWithRetry('ACC', fn);
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(mgr.getMetrics().conflicts).toBe(1);
+    expect(mgr.getMetrics().retries).toBe(1);
+  });
+
+  it('retries up to maxRetries times then throws', async () => {
+    const fn = jest.fn().mockRejectedValue(buildBadSeqError());
+
+    await expect(mgr.executeWithRetry('ACC', fn)).rejects.toMatchObject({
+      response: { data: { extras: { result_codes: { transaction: 'tx_bad_seq' } } } },
+    });
+
+    // attempt 0 … maxRetries  → 5 total calls
+    expect(fn).toHaveBeenCalledTimes(5);
+    expect(mgr.getMetrics().conflicts).toBe(5);
+    expect(mgr.getMetrics().retries).toBe(4); // retries = attempts - 1 (last one just throws)
+  });
+
+  it('does NOT retry on non-sequence errors', async () => {
+    const nonSeqErr = new Error('insufficient_balance');
+    const fn = jest.fn().mockRejectedValue(nonSeqErr);
+
+    await expect(mgr.executeWithRetry('ACC', fn)).rejects.toThrow('insufficient_balance');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(mgr.getMetrics().conflicts).toBe(0);
+  });
+
+  it('invalidates cache on each tx_bad_seq before retry', async () => {
+    // Verify the side-effect: after a tx_bad_seq the cache is cleared so
+    // Horizon is re-queried on the retry attempt.
+    const client = buildHorizonClient('100');
+
+    // Prime the cache for INVAL_ACC
+    await mgr.getSequenceNumber('INVAL_ACC', client);
+    // loadAccount called once so far
+    expect(client.loadAccount).toHaveBeenCalledTimes(1);
+
+    // Now run executeWithRetry with two bad-seq failures; each retry should
+    // clear the cache and trigger a fresh Horizon fetch.
+    const fn = jest.fn()
+      .mockImplementationOnce(async () => {
+        // On attempt 0: cache is warm (from the prime above), so Horizon
+        // is NOT called yet.  Throw bad_seq → cache cleared.
+        throw buildBadSeqError();
+      })
+      .mockImplementationOnce(async () => {
+        // On attempt 1: cache was cleared, so getSequenceNumber will call
+        // Horizon again.  Throw bad_seq → cache cleared again.
+        await mgr.getSequenceNumber('INVAL_ACC', client);
+        throw buildBadSeqError();
+      })
+      .mockResolvedValue('done');
+
+    await mgr.executeWithRetry('INVAL_ACC', fn);
+
+    // Horizon was called at least once during the retries (cache was invalidated)
+    expect(client.loadAccount).toHaveBeenCalledTimes(2);
+    expect(mgr.getMetrics().conflicts).toBe(2);
+  });
+
+  it('passes attempt index to transactionFn', async () => {
+    const attempts = [];
+    const fn = jest.fn().mockImplementation(async (attempt) => {
+      attempts.push(attempt);
+      if (attempt < 2) throw buildBadSeqError();
+      return 'done';
+    });
+
+    await mgr.executeWithRetry('ATTEMPT_ACC', fn);
+    expect(attempts).toEqual([0, 1, 2]);
+  });
+
+  it('with maxRetries=0 makes exactly one attempt and throws on conflict', async () => {
+    const zeroMgr = createSequenceManager({ maxRetries: 0, retryDelayMs: 5 });
+    const fn = jest.fn().mockRejectedValue(buildBadSeqError());
+
+    await expect(zeroMgr.executeWithRetry('Z_ACC', fn)).rejects.toBeDefined();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('serialises concurrent calls from the same account during retry', async () => {
+    const order = [];
+    const ACCOUNT = 'SERIAL_RETRY_ACC';
+
+    // Two tasks for the same account; first one errors once
+    const t1 = mgr.executeWithRetry(ACCOUNT, jest.fn()
+      .mockImplementationOnce(async () => {
+        order.push('t1-first-attempt');
+        throw buildBadSeqError();
+      })
+      .mockImplementation(async () => {
+        order.push('t1-retry');
+        return 'ok1';
+      })
+    );
+
+    const t2 = mgr.executeWithRetry(ACCOUNT, async () => {
+      order.push('t2');
+      return 'ok2';
+    });
+
+    const [r1, r2] = await Promise.all([t1, t2]);
+    expect(r1).toBe('ok1');
+    expect(r2).toBe('ok2');
+
+    // t2 must start only after t1's entire retry cycle completes
+    expect(order.indexOf('t2')).toBeGreaterThan(order.indexOf('t1-retry'));
+  });
+
+  it('detects tx_bad_seq via message string fallback', async () => {
+    const msgErr = new Error('tx_bad_seq occurred');
+    const fn = jest.fn()
+      .mockRejectedValueOnce(msgErr)
+      .mockResolvedValue('ok');
+
+    const result = await mgr.executeWithRetry('MSG_ACC', fn);
+    expect(result).toBe('ok');
+    expect(mgr.getMetrics().conflicts).toBe(1);
+  });
+
+  it('detects sequence error via "sequence" keyword in message', async () => {
+    const seqErr = new Error('bad sequence number');
+    const fn = jest.fn()
+      .mockRejectedValueOnce(seqErr)
+      .mockResolvedValue('ok');
+
+    const result = await mgr.executeWithRetry('SEQ_MSG_ACC', fn);
+    expect(result).toBe('ok');
+    expect(mgr.getMetrics().conflicts).toBe(1);
+  });
+
+  it('handles 10+ concurrent transactions from the same account', async () => {
+    const N = 15;
+    const ACCOUNT = 'HIGH_CONCURRENCY';
+    const results = [];
+
+    const tasks = Array.from({ length: N }, (_, i) =>
+      mgr.executeWithRetry(ACCOUNT, async () => {
+        results.push(i);
+        return i;
+      })
+    );
+
+    const values = await Promise.all(tasks);
+    expect(values).toHaveLength(N);
+    // Each task executed exactly once
+    expect(results).toHaveLength(N);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('metrics', () => {
+  let mgr;
+  beforeEach(() => {
+    mgr = createSequenceManager({ retryDelayMs: 5, maxRetries: 3 });
+  });
+
+  it('getMetrics returns a snapshot (not a live reference)', () => {
+    const snap1 = mgr.getMetrics();
+    // Mutating the snapshot should not affect internal state
+    snap1.conflicts = 999;
+    const snap2 = mgr.getMetrics();
+    expect(snap2.conflicts).toBe(0);
+  });
+
+  it('resetMetrics zeros all counters', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(buildBadSeqError())
+      .mockResolvedValue('ok');
+    await mgr.executeWithRetry('M_ACC', fn);
+
+    mgr.resetMetrics();
+    expect(mgr.getMetrics()).toEqual({
+      conflicts: 0,
+      retries: 0,
+      cacheHits: 0,
+      cacheMisses: 0,
+      lockWaits: 0,
+    });
+  });
+
+  it('tracks cacheHits after warmup', async () => {
+    const client = buildHorizonClient('50');
+    await mgr.getSequenceNumber('HIT_ACC', client);
+    await mgr.getSequenceNumber('HIT_ACC', client);
+    await mgr.getSequenceNumber('HIT_ACC', client);
+    expect(mgr.getMetrics().cacheHits).toBeGreaterThanOrEqual(1);
+  });
+
+  it('tracks cacheMisses on cold starts', async () => {
+    const client = buildHorizonClient('50');
+    await mgr.getSequenceNumber('MISS_ACC_1', client);
+    await mgr.getSequenceNumber('MISS_ACC_2', client);
+    expect(mgr.getMetrics().cacheMisses).toBe(2);
+  });
+
+  it('increments conflicts and retries correctly across multiple executions', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(buildBadSeqError())
+      .mockResolvedValue('ok');
+
+    await mgr.executeWithRetry('METRIC_ACC', fn);
+
+    const m = mgr.getMetrics();
+    expect(m.conflicts).toBe(1);
+    expect(m.retries).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('activeLockCount', () => {
+  it('returns 0 when no locks are held', () => {
+    const mgr = createSequenceManager();
+    expect(mgr.activeLockCount()).toBe(0);
+  });
+
+  it('returns the number of accounts with pending locks', async () => {
+    const mgr = createSequenceManager();
+    let lockCountDuring;
+
+    const p = mgr.withAccountLock('LOCK_ACC', async () => {
+      // Snapshot the lock count while the task is actively running
+      lockCountDuring = mgr.activeLockCount();
+      await delay(10);
+    });
+
+    await p;
+    // Flush any pending microtasks (gate.finally cleanup) before asserting
+    await delay(0);
+
+    expect(lockCountDuring).toBeGreaterThanOrEqual(1);
+    // After the task and cleanup settle, lock should be released
+    expect(mgr.activeLockCount()).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('edge cases and validation', () => {
+  it('handles Horizon client that rejects', async () => {
+    const mgr = createSequenceManager();
+    const badClient = {
+      loadAccount: jest.fn().mockRejectedValue(new Error('network error')),
+    };
+
+    await expect(mgr.getSequenceNumber('ACC', badClient)).rejects.toThrow('network error');
+  });
+
+  it('handles null error in executeWithRetry gracefully', async () => {
+    const mgr = createSequenceManager({ maxRetries: 1, retryDelayMs: 5 });
+    // A function that throws a non-seq, non-null error
+    const fn = jest.fn().mockRejectedValue(new Error('generic'));
+    await expect(mgr.executeWithRetry('NULL_ERR', fn)).rejects.toThrow('generic');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent calls for different accounts do not share sequence caches', async () => {
+    const mgr = createSequenceManager();
+    const clientA = buildHorizonClient('10');
+    const clientB = buildHorizonClient('20');
+
+    const [seqA, seqB] = await Promise.all([
+      mgr.getSequenceNumber('DIFF_A', clientA),
+      mgr.getSequenceNumber('DIFF_B', clientB),
+    ]);
+
+    expect(seqA).toBe('10');
+    expect(seqB).toBe('20');
+  });
+
+  it('module-level singleton exports are functional', () => {
+    // Import the module-level singleton exports
+    const mod = require('../src/utils/sequenceManager');
+    expect(typeof mod.executeWithRetry).toBe('function');
+    expect(typeof mod.getMetrics).toBe('function');
+    expect(typeof mod.defaultManager).toBe('object');
+  });
+
+  it('isSequenceConflict detects result_codes at top-level extras', async () => {
+    const mgr = createSequenceManager({ maxRetries: 1, retryDelayMs: 5 });
+    const altErr = new Error('bad seq');
+    altErr.extras = { result_codes: { transaction: 'tx_bad_seq' } };
+
+    const fn = jest.fn()
+      .mockRejectedValueOnce(altErr)
+      .mockResolvedValue('recovered');
+
+    const result = await mgr.executeWithRetry('ALT_ERR_ACC', fn);
+    expect(result).toBe('recovered');
+    expect(mgr.getMetrics().conflicts).toBe(1);
+  });
+
+  it('does not mutate the user-supplied config object', () => {
+    const userConfig = { maxRetries: 3 };
+    createSequenceManager(userConfig);
+    // Original must be untouched
+    expect(Object.keys(userConfig)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #377 

## feat: add stellar transaction sequence number management

---

### Problem

Stellar transactions require a sequence number that is exactly one greater than the account's last committed sequence number. Under concurrent load, multiple transactions from the same account share the same starting sequence number and all but one fail with `tx_bad_seq`. This produces cascading failures, wastes Horizon API round-trips, and surfaces confusing errors to end users.

---

### Solution

Adds `src/utils/sequenceManager.js` — a lightweight, zero-dependency utility that solves this with three complementary mechanisms:

| Mechanism | How it works |
|---|---|
| **Per-account async mutex** | Builds a Promise chain per public key so only one transaction is in-flight per account at a time |
| **Sequence number cache** | Stores the last known sequence in memory (TTL: 30 s by default) and pre-increments it on each hit, eliminating redundant `loadAccount` calls |
| **Optimistic retry** | On `tx_bad_seq` the cache is invalidated and the transaction is retried up to `maxRetries` times with exponential back-off + ±10 % jitter |

---

### Files changed

```
src/utils/sequenceManager.js                                  (new)
tests/add-stellar-transaction-sequence-number-management.test.js  (new)
docs/features/ADD_STELLAR_TRANSACTION_SEQUENCE_NUMBER_MANAGEMENT.md  (new)
```

---

### API surface

```js
const { createSequenceManager } = require('./src/utils/sequenceManager');

// Factory — use in tests or where isolation is needed
const mgr = createSequenceManager({ maxRetries: 5, retryDelayMs: 100 });

// High-level: lock + retry in one call
await mgr.executeWithRetry(senderPublicKey, async (attempt) => {
  const seq = await mgr.getSequenceNumber(senderPublicKey, server);
  const tx  = buildTransaction(senderPublicKey, recipientPublicKey, amount, seq);
  tx.sign(keypair);
  return server.submitTransaction(tx);
});

// Metrics snapshot
const { conflicts, retries, cacheHits, cacheMisses } = mgr.getMetrics();
```

A module-level singleton (`defaultManager`) is also exported for direct use in `StellarService.js` and `RecurringDonationScheduler.js` without instantiation.

---

### Tests — 40 tests, 0 failures

```
npm test tests/add-stellar-transaction-sequence-number-management.test.js
```

| Suite | Tests | What is verified |
|---|---|---|
| Factory | 3 | Default config, custom config merge, instance isolation |
| `withAccountLock` | 6 | Serialisation of 10+ concurrent tasks, parallel tasks for different accounts, error propagation, lock release after error |
| `getSequenceNumber` | 7 | Cache miss/hit, TTL expiry, `invalidateCache`, `clearCache` (single + all), optimistic increment |
| `executeWithRetry` | 11 | Success path, retry on `tx_bad_seq`, retry exhaustion, non-sequence error passthrough, cache invalidation on retry, attempt index, `maxRetries=0`, serialisation during retry, message-string detection |
| Metrics | 5 | Snapshot isolation, `resetMetrics`, hit/miss counters, conflict + retry counters |
| `activeLockCount` | 2 | Zero at idle, positive while locked, zero after release |
| Edge cases | 6 | Horizon rejection, independent caches per account, singleton exports, alternate error shape, config immutability |

No live Stellar network required — all Horizon interactions use mocks.

---

### Configuration

| Option | Default | Description |
|---|---|---|
| `maxRetries` | `5` | Max retries on `tx_bad_seq` |
| `retryDelayMs` | `100` | Base retry delay (ms); actual uses exponential back-off |
| `cacheTtlMs` | `30000` | How long a cached sequence number is valid |
| `backoffMultiplier` | `2` | Multiplier applied per retry attempt |

---

### Security notes

- The sequence cache is **process-local and in-memory**. Multi-process deployments (cluster, multiple pods) require a distributed lock (e.g. Redis `SET NX`) instead of this module — documented in the feature doc.
- Private keys **never pass through** this module. Key management remains the caller's responsibility.
- The retry loop has a hard upper bound (`maxRetries`) — no infinite loops.
- `accountId` (public key) is treated as trusted input from internal services only.

---

### Checklist

- [x] `src/utils/sequenceManager.js` created with per-account locking
- [x] Optimistic retry on `tx_bad_seq` with cache invalidation
- [x] Sequence number caching with configurable TTL
- [x] Concurrent transactions from the same account serialised
- [x] Metrics: `conflicts`, `retries`, `cacheHits`, `cacheMisses`, `lockWaits`
- [x] 40 tests — covers 10+ concurrent transactions from the same account
- [x] No live Stellar network required (MockStellarService pattern)
- [x] JSDoc on all public functions
- [x] Feature documentation added
- [x] Existing test suite unaffected