### PR TITLE
feat: add daily schedule for npm audit security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main", "master" ]
   pull_request:
     branches: [ "main", "master" ]
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
this pr closes #389 

Description
The project's npm dependencies may contain known vulnerabilities that are discovered after the initial installation. This PR adds a daily schedule (cron: '0 0 * * *') to the existing 

security-scan.yml
 GitHub Actions workflow to run our automated vulnerability scanning on a regular basis.

Why is this needed?
Catches newly discovered vulnerabilities promptly, ensuring our application remains secure after the initial installation phase.
Runs npm audit --audit-level=high, which appropriately blocks deployments on critical/high vulnerabilities (by failing the job), while effectively allowing moderate vulnerabilities to pass through but generate visible warnings in the CI logs without blocking the pipeline.
Changes Included
Added schedule trigger (daily at midnight UTC) to 

.github/workflows/security-scan.yml
.