### PR TITLE
test: increase coverage thresholds to 80% and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Tests with Coverage
+        run: npm run test:coverage:ci

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,10 +32,10 @@ module.exports = {
   coverageReporters: ['text', 'text-summary', 'lcov', 'html', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 30,
-      functions: 30,
-      lines: 30,
-      statements: 30,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
   coverageDirectory: 'coverage',


### PR DESCRIPTION


thi spr closes #385 

Description
The current test coverage thresholds were set at 30%, which is too low for a financial application. This PR increases the coverage requirements to at least 80% and integrates a continuous testing workflow to ensure coverage regressions block merges.

Changes Included
Jest Configuration (

jest.config.js
): Increased the global coverageThreshold for branches, functions, lines, and statements from 30% up to 80%.
CI Pipeline (

.github/workflows/ci.yml
): Added a new GitHub Actions workflow that executes npm run test:coverage:ci on every push and pull request. If the coverage thresholds aren't met, Jest will fail and the pipeline will block the merge automatically.