### PR TITLE
feat: add distributed tracing with OpenTelemetry

### DIFF
--- a/docs/features/IMPLEMENT_DISTRIBUTED_TRACING_WITH_OPENTELEMETRY.md
+++ b/docs/features/IMPLEMENT_DISTRIBUTED_TRACING_WITH_OPENTELEMETRY.md
@@ -1,0 +1,199 @@
+# Distributed Tracing with OpenTelemetry
+
+End-to-end distributed tracing for the Stellar Micro-Donation API using the
+[OpenTelemetry](https://opentelemetry.io/) standard. Traces flow from inbound
+HTTP requests through database queries and Stellar network calls, and are
+exported to any OTLP-compatible backend (Jaeger, Zipkin, Grafana Tempo, AWS
+X-Ray OTLP, etc.).
+
+---
+
+## Architecture
+
+```
+HTTP Request
+    │
+    ▼
+httpTracingMiddleware()          ← root SERVER span, traceparent injected into response
+    │
+    ├── traceDbQuery()           ← child CLIENT span (db.system=sqlite)
+    │
+    └── traceStellarCall()       ← child CLIENT span (peer.service=stellar-horizon)
+```
+
+All spans within a single request share the same `traceId`. The W3C
+`traceparent` header is read from inbound requests (enabling cross-service
+parent linking) and written to outbound responses.
+
+---
+
+## Module: `src/utils/tracing.js`
+
+### Lifecycle
+
+```js
+const { initTracing, shutdownTracing } = require('./utils/tracing');
+
+// Call once at application startup (before any requests are served)
+initTracing({
+  serviceName: 'stellar-donation-api',   // default: OTEL_SERVICE_NAME env var
+  endpoint: 'http://collector:4318',     // default: OTEL_EXPORTER_OTLP_ENDPOINT
+  exporterHeaders: 'Authorization=Bearer token', // or object
+  enabled: true,                         // default: OTEL_ENABLED !== 'false'
+});
+
+// Call during graceful shutdown
+process.on('SIGTERM', async () => {
+  await shutdownTracing();
+  process.exit(0);
+});
+```
+
+`initTracing` is idempotent — safe to call multiple times.
+
+### HTTP Middleware
+
+```js
+const { httpTracingMiddleware } = require('./utils/tracing');
+
+app.use(httpTracingMiddleware());
+```
+
+Creates a root `SERVER` span for every request with attributes:
+
+| Attribute | Value |
+|---|---|
+| `http.method` | `GET`, `POST`, … |
+| `http.url` | Full URL including query string |
+| `http.route` | Path without query string |
+| `http.host` | Hostname |
+| `http.scheme` | `http` / `https` |
+| `net.peer.ip` | Client IP |
+| `http.request_id` | Value of `X-Request-ID` / `req.id` |
+| `http.status_code` | Set on response finish |
+
+The `traceparent` header is injected into the response. If the inbound request
+carries a `traceparent` header, the new span is created as a child of that
+remote span (enabling cross-service trace stitching).
+
+### Generic Span Helper
+
+```js
+const { withSpan } = require('./utils/tracing');
+
+const result = await withSpan(
+  'my.operation',
+  { 'custom.attribute': 'value' },
+  async (span) => {
+    span.setAttribute('result.count', 42);
+    return doWork();
+  }
+);
+```
+
+- Sets `OK` status on success, `ERROR` + records exception on throw.
+- Span is always ended, even if the callback throws.
+- Nested calls automatically create parent-child relationships.
+
+### Database Tracing
+
+```js
+const { traceDbQuery } = require('./utils/tracing');
+
+const rows = await traceDbQuery('SELECT', 'donations', () =>
+  db.all('SELECT * FROM donations WHERE user_id = ?', [userId])
+);
+```
+
+Span attributes: `db.system=sqlite`, `db.operation`, `db.sql.table`,
+`db.rows_affected`.
+
+### Stellar Network Tracing
+
+```js
+const { traceStellarCall } = require('./utils/tracing');
+
+const result = await traceStellarCall(
+  'sendDonation',
+  { 'stellar.network': 'testnet', 'stellar.horizon_url': horizonUrl },
+  () => stellarService.sendDonation(params)
+);
+```
+
+Span attributes: `stellar.operation`, `peer.service=stellar-horizon`, plus any
+extra attributes passed.
+
+### Context Propagation
+
+```js
+const { injectTraceHeaders, extractTraceContext, getCurrentTraceparent } =
+  require('./utils/tracing');
+
+// Inject W3C traceparent into outbound HTTP headers
+const headers = injectTraceHeaders({ 'Content-Type': 'application/json' });
+
+// Extract trace context from inbound headers
+const ctx = extractTraceContext(req.headers);
+
+// Get the current traceparent string (useful for logging)
+const tp = getCurrentTraceparent(); // "00-<traceId>-<spanId>-01" or null
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_ENABLED` | `true` | Set to `false` to disable all tracing |
+| `OTEL_SERVICE_NAME` | `stellar-donation-api` | Service name in traces |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP collector base URL |
+| `OTEL_EXPORTER_OTLP_HEADERS` | _(none)_ | Auth headers: `key=value,key2=value2` |
+
+---
+
+## Graceful Degradation
+
+The module requires only `@opentelemetry/api` at runtime. The full SDK
+packages (`@opentelemetry/sdk-node`, `@opentelemetry/exporter-trace-otlp-http`,
+etc.) are loaded lazily. If they are not installed, tracing initialises in
+no-op mode — all `withSpan` / `traceStellarCall` / `traceDbQuery` calls still
+execute their callbacks normally, they just don't emit spans.
+
+---
+
+## Security Considerations
+
+- No PII is added to span attributes by default.
+- The `traceparent` header is a standard W3C header; it contains only opaque
+  hex IDs (no user data).
+- OTLP exporter headers (e.g. `Authorization`) are read from environment
+  variables, never hardcoded.
+- Tracing can be disabled entirely via `OTEL_ENABLED=false` for environments
+  where telemetry export is not permitted.
+
+---
+
+## Testing
+
+Tests live in
+`tests/implement-distributed-tracing-with-opentelemetry.test.js`.
+
+The test suite uses a hand-rolled in-memory `RecordingTracer` and a minimal
+`AsyncLocalStorage`-based context manager — no live collector or full SDK
+packages required.
+
+```bash
+npx jest tests/implement-distributed-tracing-with-opentelemetry.test.js
+```
+
+Coverage areas:
+- `initTracing` / `shutdownTracing` lifecycle and idempotency
+- `withSpan`: success, error, nested parent-child relationships
+- `startSpan`: manual span management
+- `httpTracingMiddleware`: attributes, status codes, traceparent propagation
+- `traceDbQuery`: db attributes, rows_affected, error handling
+- `traceStellarCall`: stellar attributes, MockStellarService integration
+- `injectTraceHeaders` / `extractTraceContext`: round-trip propagation
+- `getCurrentTraceparent` / `getActiveSpanContext`
+- Edge cases: concurrent spans, deeply nested spans, missing SDK

--- a/src/utils/tracing.js
+++ b/src/utils/tracing.js
@@ -1,0 +1,454 @@
+/**
+ * Distributed Tracing Utility - OpenTelemetry Integration
+ *
+ * RESPONSIBILITY: End-to-end distributed tracing for HTTP requests, database queries,
+ *                 and Stellar network calls via OpenTelemetry SDK.
+ * OWNER: Platform Team
+ * DEPENDENCIES: @opentelemetry/api, optional SDK packages
+ *
+ * Provides automatic and manual instrumentation with graceful degradation when
+ * the full SDK is not installed. Traces are exported to a configurable OTLP endpoint.
+ *
+ * Environment variables:
+ *   OTEL_EXPORTER_OTLP_ENDPOINT  - OTLP collector endpoint (default: http://localhost:4318)
+ *   OTEL_SERVICE_NAME            - Service name reported in traces (default: stellar-donation-api)
+ *   OTEL_ENABLED                 - Set to "false" to disable tracing entirely (default: true)
+ *   OTEL_EXPORTER_OTLP_HEADERS  - Comma-separated key=value auth headers for the exporter
+ */
+
+'use strict';
+
+const api = require('@opentelemetry/api');
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TRACER_NAME = 'stellar-donation-api';
+const TRACER_VERSION = '1.0.0';
+
+/** W3C traceparent header name */
+const TRACEPARENT_HEADER = 'traceparent';
+/** W3C tracestate header name */
+const TRACESTATE_HEADER = 'tracestate';
+
+// ─── SDK Loader (graceful degradation) ────────────────────────────────────────
+
+/**
+ * Attempt to load and initialise the OpenTelemetry Node SDK.
+ * Returns null when SDK packages are not installed so the application
+ * continues to run without tracing rather than crashing.
+ *
+ * @param {Object} [options] - Initialisation options (see initTracing)
+ * @returns {Object|null} SDK instance or null
+ */
+function _loadSdk(options = {}) {
+  try {
+    const { NodeSDK } = require('@opentelemetry/sdk-node');
+    const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+    const { Resource } = require('@opentelemetry/resources');
+    const { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_VERSION } =
+      require('@opentelemetry/semantic-conventions');
+    const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+
+    const endpoint =
+      options.endpoint ||
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+      'http://localhost:4318';
+
+    const serviceName =
+      options.serviceName ||
+      process.env.OTEL_SERVICE_NAME ||
+      'stellar-donation-api';
+
+    const exporterHeaders = _parseExporterHeaders(
+      options.exporterHeaders || process.env.OTEL_EXPORTER_OTLP_HEADERS
+    );
+
+    const exporter = new OTLPTraceExporter({
+      url: `${endpoint}/v1/traces`,
+      headers: exporterHeaders,
+    });
+
+    const sdk = new NodeSDK({
+      resource: new Resource({
+        [SEMRESATTRS_SERVICE_NAME]: serviceName,
+        [SEMRESATTRS_SERVICE_VERSION]: TRACER_VERSION,
+      }),
+      traceExporter: exporter,
+      instrumentations: [
+        getNodeAutoInstrumentations({
+          '@opentelemetry/instrumentation-fs': { enabled: false },
+        }),
+      ],
+    });
+
+    return sdk;
+  } catch (_err) {
+    // SDK packages not installed — tracing disabled
+    return null;
+  }
+}
+
+/**
+ * Parse OTLP exporter headers from a "key=value,key2=value2" string or object.
+ *
+ * @param {string|Object|undefined} raw - Raw header input
+ * @returns {Object} Parsed headers object
+ */
+function _parseExporterHeaders(raw) {
+  if (!raw) return {};
+  if (typeof raw === 'object') return raw;
+  return raw.split(',').reduce((acc, pair) => {
+    const idx = pair.indexOf('=');
+    if (idx > 0) {
+      acc[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
+    }
+    return acc;
+  }, {});
+}
+
+// ─── Module State ─────────────────────────────────────────────────────────────
+
+let _sdk = null;
+let _initialised = false;
+let _enabled = true;
+
+// ─── Initialisation ───────────────────────────────────────────────────────────
+
+/**
+ * Initialise the OpenTelemetry SDK and register a global tracer provider.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ *
+ * @param {Object} [options] - Configuration options
+ * @param {string} [options.endpoint]       - OTLP collector base URL
+ * @param {string} [options.serviceName]    - Service name for resource attributes
+ * @param {string|Object} [options.exporterHeaders] - Auth headers for the exporter
+ * @param {boolean} [options.enabled]       - Explicitly enable/disable tracing
+ * @returns {boolean} True when tracing was successfully initialised
+ */
+function initTracing(options = {}) {
+  if (_initialised) return _enabled;
+
+  _enabled =
+    options.enabled !== undefined
+      ? Boolean(options.enabled)
+      : process.env.OTEL_ENABLED !== 'false';
+
+  _initialised = true;
+
+  if (!_enabled) return false;
+
+  _sdk = _loadSdk(options);
+
+  if (_sdk) {
+    try {
+      _sdk.start();
+    } catch (_err) {
+      // Non-fatal — continue without exporting
+    }
+  }
+
+  return _enabled;
+}
+
+/**
+ * Shut down the SDK and flush pending spans.
+ * Should be called during graceful shutdown.
+ *
+ * @returns {Promise<void>}
+ */
+async function shutdownTracing() {
+  if (_sdk) {
+    try {
+      await _sdk.shutdown();
+    } catch (_err) {
+      // Ignore shutdown errors
+    }
+  }
+  _initialised = false;
+  _sdk = null;
+}
+
+// ─── Tracer Access ────────────────────────────────────────────────────────────
+
+let _tracerOverride = null;
+
+/**
+ * Get the application tracer instance.
+ * Returns the global no-op tracer when the SDK is not initialised.
+ *
+ * @returns {import('@opentelemetry/api').Tracer}
+ */
+function getTracer() {
+  if (_tracerOverride) return _tracerOverride;
+  return api.trace.getTracer(TRACER_NAME, TRACER_VERSION);
+}
+
+/**
+ * Override the tracer used by this module (for testing only).
+ * Pass null to restore the default global tracer.
+ *
+ * @param {import('@opentelemetry/api').Tracer|null} tracer
+ */
+function _setTracerForTesting(tracer) {
+  _tracerOverride = tracer;
+}
+
+// ─── Span Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Execute a function inside a new span, automatically ending it on completion.
+ * The span is set as the active span for the duration of the callback.
+ *
+ * @param {string} spanName - Human-readable span name
+ * @param {Object} [attributes] - Initial span attributes
+ * @param {Function} fn - Async or sync callback receiving the active span
+ * @param {import('@opentelemetry/api').SpanOptions} [spanOptions] - Additional span options
+ * @returns {Promise<*>} Result of fn
+ */
+async function withSpan(spanName, attributes, fn, spanOptions = {}) {
+  if (typeof attributes === 'function') {
+    fn = attributes;
+    attributes = {};
+  }
+
+  const tracer = getTracer();
+  const opts = { ...spanOptions, attributes: { ...attributes, ...(spanOptions.attributes || {}) } };
+
+  return tracer.startActiveSpan(spanName, opts, async (span) => {
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: api.SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err);
+      span.setStatus({ code: api.SpanStatusCode.ERROR, message: err.message });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Create a child span under the currently active span without replacing the
+ * active context. Useful for fire-and-forget sub-operations.
+ *
+ * @param {string} spanName - Span name
+ * @param {Object} [attributes] - Span attributes
+ * @returns {import('@opentelemetry/api').Span} Started span (caller must call .end())
+ */
+function startSpan(spanName, attributes = {}) {
+  const tracer = getTracer();
+  return tracer.startSpan(spanName, { attributes });
+}
+
+// ─── HTTP Instrumentation ─────────────────────────────────────────────────────
+
+/**
+ * Express middleware that creates a root span for every inbound HTTP request
+ * and injects the W3C traceparent header into the response.
+ *
+ * Attributes set on the span:
+ *   http.method, http.route, http.url, http.host, http.scheme,
+ *   net.peer.ip, http.request_id
+ *
+ * @returns {Function} Express middleware (req, res, next)
+ */
+function httpTracingMiddleware() {
+  return function tracingMiddleware(req, res, next) {
+    const tracer = getTracer();
+
+    // Extract W3C trace context from inbound headers
+    const parentContext = api.propagation.extract(api.context.active(), req.headers);
+
+    const spanName = `${req.method} ${req.path}`;
+    const span = tracer.startSpan(
+      spanName,
+      {
+        kind: api.SpanKind.SERVER,
+        attributes: {
+          'http.method': req.method,
+          'http.url': req.originalUrl || req.url,
+          'http.route': req.path,
+          'http.host': req.hostname,
+          'http.scheme': req.protocol || 'http',
+          'net.peer.ip': req.ip,
+          'http.request_id': req.id || req.headers['x-request-id'] || '',
+        },
+      },
+      parentContext
+    );
+
+    // Make span active for the duration of the request
+    const ctx = api.trace.setSpan(parentContext, span);
+
+    // Inject traceparent into response headers
+    const carrier = {};
+    api.propagation.inject(ctx, carrier);
+    if (carrier[TRACEPARENT_HEADER]) {
+      res.setHeader(TRACEPARENT_HEADER, carrier[TRACEPARENT_HEADER]);
+    }
+    if (carrier[TRACESTATE_HEADER]) {
+      res.setHeader(TRACESTATE_HEADER, carrier[TRACESTATE_HEADER]);
+    }
+
+    // Attach span to request for downstream use
+    req.span = span;
+    req.traceContext = ctx;
+
+    res.on('finish', () => {
+      span.setAttribute('http.status_code', res.statusCode);
+      if (res.statusCode >= 500) {
+        span.setStatus({ code: api.SpanStatusCode.ERROR });
+      } else {
+        span.setStatus({ code: api.SpanStatusCode.OK });
+      }
+      span.end();
+    });
+
+    api.context.with(ctx, next);
+  };
+}
+
+// ─── Database Instrumentation ─────────────────────────────────────────────────
+
+/**
+ * Wrap a database query function to emit a child span with query details.
+ *
+ * @param {string} operation - SQL operation type (SELECT, INSERT, etc.)
+ * @param {string} table - Target table name
+ * @param {Function} queryFn - Async function that executes the query
+ * @returns {Promise<*>} Query result
+ */
+async function traceDbQuery(operation, table, queryFn) {
+  return withSpan(
+    `db.${operation.toLowerCase()} ${table}`,
+    {
+      'db.system': 'sqlite',
+      'db.operation': operation.toUpperCase(),
+      'db.sql.table': table,
+      'span.kind': 'client',
+    },
+    async (span) => {
+      const result = await queryFn();
+      span.setAttribute('db.rows_affected', result?.changes ?? result?.length ?? 0);
+      return result;
+    },
+    { kind: api.SpanKind.CLIENT }
+  );
+}
+
+// ─── Stellar Instrumentation ──────────────────────────────────────────────────
+
+/**
+ * Wrap a Stellar network operation to emit a child span with operation details.
+ *
+ * @param {string} operation - Stellar operation name (e.g. "sendDonation", "loadAccount")
+ * @param {Object} [attributes] - Additional span attributes (network, horizon URL, etc.)
+ * @param {Function} fn - Async function performing the Stellar call
+ * @returns {Promise<*>} Operation result
+ */
+async function traceStellarCall(operation, attributes, fn) {
+  if (typeof attributes === 'function') {
+    fn = attributes;
+    attributes = {};
+  }
+
+  return withSpan(
+    `stellar.${operation}`,
+    {
+      'stellar.operation': operation,
+      'peer.service': 'stellar-horizon',
+      ...attributes,
+    },
+    fn,
+    { kind: api.SpanKind.CLIENT }
+  );
+}
+
+// ─── Context Propagation ──────────────────────────────────────────────────────
+
+/**
+ * Inject W3C traceparent/tracestate headers into an outbound headers object.
+ * Mutates the provided headers object in place.
+ *
+ * @param {Object} headers - Mutable headers object for the outbound request
+ * @returns {Object} The same headers object with trace context injected
+ */
+function injectTraceHeaders(headers) {
+  api.propagation.inject(api.context.active(), headers);
+  return headers;
+}
+
+/**
+ * Extract trace context from inbound headers and return an active context.
+ *
+ * @param {Object} headers - Inbound request headers
+ * @returns {import('@opentelemetry/api').Context} Active context with parent span
+ */
+function extractTraceContext(headers) {
+  return api.propagation.extract(api.context.active(), headers);
+}
+
+/**
+ * Build a W3C traceparent header value from the currently active span.
+ * Returns null when there is no active span.
+ *
+ * @returns {string|null} traceparent header value or null
+ */
+function getCurrentTraceparent() {
+  const span = api.trace.getActiveSpan();
+  if (!span) return null;
+
+  const ctx = span.spanContext();
+  if (!api.isSpanContextValid(ctx)) return null;
+
+  const flags = ctx.traceFlags.toString(16).padStart(2, '0');
+  return `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
+}
+
+/**
+ * Return the active span context, or null if none is active.
+ *
+ * @returns {import('@opentelemetry/api').SpanContext|null}
+ */
+function getActiveSpanContext() {
+  const span = api.trace.getActiveSpan();
+  if (!span) return null;
+  const ctx = span.spanContext();
+  return api.isSpanContextValid(ctx) ? ctx : null;
+}
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // Lifecycle
+  initTracing,
+  shutdownTracing,
+
+  // Tracer
+  getTracer,
+  _setTracerForTesting,
+
+  // Span helpers
+  withSpan,
+  startSpan,
+
+  // Middleware
+  httpTracingMiddleware,
+
+  // Domain-specific wrappers
+  traceDbQuery,
+  traceStellarCall,
+
+  // Propagation
+  injectTraceHeaders,
+  extractTraceContext,
+  getCurrentTraceparent,
+  getActiveSpanContext,
+
+  // Constants (exported for tests)
+  TRACEPARENT_HEADER,
+  TRACESTATE_HEADER,
+  TRACER_NAME,
+};

--- a/tests/implement-distributed-tracing-with-opentelemetry.test.js
+++ b/tests/implement-distributed-tracing-with-opentelemetry.test.js
@@ -1,0 +1,813 @@
+/**
+ * Tests: Distributed Tracing with OpenTelemetry
+ *
+ * Covers:
+ *  - initTracing / shutdownTracing lifecycle
+ *  - withSpan: success, error, nested spans
+ *  - startSpan: manual span management
+ *  - httpTracingMiddleware: root span attributes, traceparent header, status codes
+ *  - traceDbQuery: child span attributes
+ *  - traceStellarCall: child span attributes
+ *  - injectTraceHeaders / extractTraceContext propagation
+ *  - getCurrentTraceparent / getActiveSpanContext
+ *  - Edge cases: disabled tracing, missing SDK, invalid contexts
+ *
+ * Uses a hand-rolled in-memory TracerProvider so no SDK packages beyond
+ * @opentelemetry/api are required.
+ */
+
+'use strict';
+
+const api = require('@opentelemetry/api');
+
+// ─── In-memory span recorder ──────────────────────────────────────────────────
+// We build a minimal TracerProvider that records finished spans in an array.
+// This avoids any dependency on @opentelemetry/sdk-trace-base.
+
+const finishedSpans = [];
+
+function resetSpans() {
+  finishedSpans.length = 0;
+}
+
+function getFinishedSpans() {
+  return [...finishedSpans];
+}
+
+function _randomHex(len) {
+  let s = '';
+  while (s.length < len) s += Math.floor(Math.random() * 16).toString(16);
+  return s.slice(0, len);
+}
+
+/** Minimal span implementation — compatible with @opentelemetry/api context propagation */
+class RecordingSpan {
+  constructor(name, options, parentSpanId, traceId) {
+    this.name = name;
+    this.kind = options.kind !== undefined ? options.kind : api.SpanKind.INTERNAL;
+    this.attributes = { ...(options.attributes || {}) };
+    this.events = [];
+    this.status = { code: api.SpanStatusCode.UNSET };
+    this.endTime = null;
+    this._traceId = traceId || _randomHex(32);
+    this._spanId = _randomHex(16);
+    this.parentSpanId = parentSpanId || undefined;
+    // Pre-build the SpanContext so the same object is returned every time
+    // (required for api.trace.setSpan / getActiveSpan to work correctly)
+    this._spanContext = {
+      traceId: this._traceId,
+      spanId: this._spanId,
+      traceFlags: api.TraceFlags.SAMPLED,
+      isRemote: false,
+    };
+  }
+
+  setAttribute(key, value) { this.attributes[key] = value; return this; }
+  setAttributes(attrs) { Object.assign(this.attributes, attrs); return this; }
+  addEvent(name, attrs) { this.events.push({ name, attributes: attrs || {} }); return this; }
+  setStatus(status) { this.status = status; return this; }
+  recordException(err) {
+    this.addEvent('exception', {
+      'exception.message': err && err.message ? err.message : String(err),
+      'exception.type': err && err.name ? err.name : 'Error',
+    });
+  }
+  end() {
+    this.endTime = Date.now();
+    finishedSpans.push(this);
+  }
+  spanContext() { return this._spanContext; }
+  isRecording() { return this.endTime === null; }
+}
+
+/** Minimal tracer */
+class RecordingTracer {
+  startSpan(name, options = {}, context) {
+    // Prefer the explicitly passed context, then fall back to the active context
+    const resolvedCtx = context !== undefined ? context : api.context.active();
+    const parentSpan = api.trace.getSpan(resolvedCtx);
+    const parentCtx = parentSpan ? parentSpan.spanContext() : null;
+    // Only inherit traceId from a valid (non-remote-invalid) parent
+    const traceId = (parentCtx && parentCtx.traceId && parentCtx.traceId !== '0'.repeat(32))
+      ? parentCtx.traceId
+      : _randomHex(32);
+    const parentSpanId = parentCtx ? parentCtx.spanId : undefined;
+    return new RecordingSpan(name, options, parentSpanId, traceId);
+  }
+
+  startActiveSpan(name, options, context, fn) {
+    // Normalise overloaded signatures: (name, fn) | (name, opts, fn) | (name, opts, ctx, fn)
+    if (typeof options === 'function') { fn = options; options = {}; context = undefined; }
+    else if (typeof context === 'function') { fn = context; context = undefined; }
+
+    const parentContext = context !== undefined ? context : api.context.active();
+    const span = this.startSpan(name, options, parentContext);
+    const ctx = api.trace.setSpan(parentContext, span);
+    return api.context.with(ctx, fn, undefined, span);
+  }
+}
+
+/** Minimal provider */
+class RecordingTracerProvider {
+  getTracer() { return new RecordingTracer(); }
+}
+
+// ─── Minimal AsyncLocalStorage context manager ───────────────────────────────
+// The OTel API falls back to NoopContextManager when no SDK is installed,
+// which means api.context.with() doesn't propagate context. We register a
+// real AsyncLocalStorage-based manager so spans are properly nested.
+
+const { AsyncLocalStorage } = require('async_hooks');
+const { ROOT_CONTEXT } = api;
+
+class AsyncContextManager {
+  constructor() {
+    this._storage = new AsyncLocalStorage();
+  }
+  active() {
+    return this._storage.getStore() || ROOT_CONTEXT;
+  }
+  with(context, fn, thisArg, ...args) {
+    return this._storage.run(context, fn.bind(thisArg), ...args);
+  }
+  bind(context, fn) {
+    const self = this;
+    return function (...args) {
+      return self._storage.run(context, fn, this, ...args);
+    };
+  }
+  enable() { return this; }
+  disable() { this._storage.disable(); return this; }
+}
+
+// Register once — subsequent calls are silently ignored by registerGlobal
+api.context.setGlobalContextManager(new AsyncContextManager());
+
+// Also register the W3C propagator so traceparent injection/extraction works.
+class MinimalW3CPropagator {
+  inject(context, carrier) {
+    const span = api.trace.getSpan(context);
+    if (!span) return;
+    const sc = span.spanContext();
+    if (!api.isSpanContextValid(sc)) return;
+    const flags = (sc.traceFlags || 0).toString(16).padStart(2, '0');
+    carrier['traceparent'] = `00-${sc.traceId}-${sc.spanId}-${flags}`;
+  }
+  extract(context, carrier) {
+    const header = carrier['traceparent'] || carrier['Traceparent'];
+    if (!header) return context;
+    const parts = header.split('-');
+    if (parts.length < 4 || parts[0] !== '00') return context;
+    const [, traceId, spanId, flagsHex] = parts;
+    if (!traceId || !spanId) return context;
+    const traceFlags = parseInt(flagsHex, 16) || 0;
+    const spanContext = { traceId, spanId, traceFlags, isRemote: true };
+    const remoteSpan = api.trace.wrapSpanContext(spanContext);
+    return api.trace.setSpan(context, remoteSpan);
+  }
+  fields() { return ['traceparent', 'tracestate']; }
+}
+api.propagation.setGlobalPropagator(new MinimalW3CPropagator());
+
+// ─── Module under test ────────────────────────────────────────────────────────
+jest.resetModules();
+const tracing = require('../src/utils/tracing');
+
+// Inject our recording tracer so withSpan / startSpan use it directly
+// This avoids relying on the global provider registration which is one-time-only.
+const recordingTracer = new RecordingTracer();
+tracing._setTracerForTesting(recordingTracer);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeReqRes(overrides = {}) {
+  const req = {
+    method: 'GET',
+    path: '/donations',
+    originalUrl: '/donations?page=1',
+    hostname: 'localhost',
+    protocol: 'http',
+    ip: '127.0.0.1',
+    id: 'req-abc',
+    headers: {},
+    ...overrides,
+  };
+  const resHeaders = {};
+  const res = {
+    statusCode: 200,
+    setHeader: (k, v) => { resHeaders[k] = v; },
+    headers: resHeaders,
+    on: (event, cb) => { res[`_${event}`] = cb; },
+    finish: () => res._finish && res._finish(),
+  };
+  return { req, res, resHeaders };
+}
+
+beforeEach(() => resetSpans());
+
+// ─── 1. initTracing / shutdownTracing ─────────────────────────────────────────
+
+describe('initTracing', () => {
+  test('returns true when enabled', () => {
+    jest.resetModules();
+    const t = require('../src/utils/tracing');
+    t._setTracerForTesting(new RecordingTracer());
+    expect(t.initTracing({ enabled: true })).toBe(true);
+  });
+
+  test('returns false when explicitly disabled', () => {
+    jest.resetModules();
+    const t = require('../src/utils/tracing');
+    t._setTracerForTesting(new RecordingTracer());
+    expect(t.initTracing({ enabled: false })).toBe(false);
+  });
+
+  test('respects OTEL_ENABLED=false env var', () => {
+    process.env.OTEL_ENABLED = 'false';
+    jest.resetModules();
+    const t = require('../src/utils/tracing');
+    t._setTracerForTesting(new RecordingTracer());
+    expect(t.initTracing()).toBe(false);
+    delete process.env.OTEL_ENABLED;
+  });
+
+  test('is idempotent — second call is a no-op', () => {
+    jest.resetModules();
+    const t = require('../src/utils/tracing');
+    t._setTracerForTesting(new RecordingTracer());
+    const first = t.initTracing({ enabled: true });
+    const second = t.initTracing({ enabled: false }); // ignored
+    expect(first).toBe(second);
+  });
+
+  test('shutdownTracing resolves without error', async () => {
+    jest.resetModules();
+    const t = require('../src/utils/tracing');
+    t._setTracerForTesting(new RecordingTracer());
+    await expect(t.shutdownTracing()).resolves.toBeUndefined();
+  });
+
+  test('shutdownTracing can be called multiple times safely', async () => {
+    jest.resetModules();
+    const t = require('../src/utils/tracing');
+    t._setTracerForTesting(new RecordingTracer());
+    await t.shutdownTracing();
+    await expect(t.shutdownTracing()).resolves.toBeUndefined();
+  });
+});
+
+// ─── 2. getTracer ─────────────────────────────────────────────────────────────
+
+describe('getTracer', () => {
+  test('returns an object with startSpan and startActiveSpan', () => {
+    const t = tracing.getTracer();
+    expect(typeof t.startSpan).toBe('function');
+    expect(typeof t.startActiveSpan).toBe('function');
+  });
+});
+
+// ─── 3. withSpan ─────────────────────────────────────────────────────────────
+
+describe('withSpan', () => {
+  test('returns the callback result', async () => {
+    const result = await tracing.withSpan('test.op', { 'custom.attr': 'hello' }, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  test('creates a finished span with correct name and attributes', async () => {
+    await tracing.withSpan('my.span', { 'foo': 'bar' }, async () => {});
+    const span = getFinishedSpans().find(s => s.name === 'my.span');
+    expect(span).toBeDefined();
+    expect(span.attributes['foo']).toBe('bar');
+  });
+
+  test('sets OK status on success', async () => {
+    await tracing.withSpan('ok.span', async () => {});
+    const span = getFinishedSpans().find(s => s.name === 'ok.span');
+    expect(span.status.code).toBe(api.SpanStatusCode.OK);
+  });
+
+  test('records exception and sets ERROR status on throw', async () => {
+    await expect(
+      tracing.withSpan('err.span', async () => { throw new Error('boom'); })
+    ).rejects.toThrow('boom');
+
+    const span = getFinishedSpans().find(s => s.name === 'err.span');
+    expect(span.status.code).toBe(api.SpanStatusCode.ERROR);
+    expect(span.status.message).toBe('boom');
+    expect(span.events.some(e => e.name === 'exception')).toBe(true);
+  });
+
+  test('span is ended even when callback throws', async () => {
+    await expect(
+      tracing.withSpan('ended.throw', async () => { throw new Error('x'); })
+    ).rejects.toThrow();
+    const span = getFinishedSpans().find(s => s.name === 'ended.throw');
+    expect(span.endTime).not.toBeNull();
+  });
+
+  test('works without explicit attributes argument', async () => {
+    const result = await tracing.withSpan('no.attrs', async () => 'ok');
+    expect(result).toBe('ok');
+    expect(getFinishedSpans().find(s => s.name === 'no.attrs')).toBeDefined();
+  });
+
+  test('nested spans share the same traceId', async () => {
+    await tracing.withSpan('parent.span', async () => {
+      await tracing.withSpan('child.span', async () => {});
+    });
+
+    const spans = getFinishedSpans();
+    const parent = spans.find(s => s.name === 'parent.span');
+    const child = spans.find(s => s.name === 'child.span');
+    expect(parent).toBeDefined();
+    expect(child).toBeDefined();
+    expect(child.spanContext().traceId).toBe(parent.spanContext().traceId);
+    expect(child.parentSpanId).toBe(parent.spanContext().spanId);
+  });
+
+  test('propagates non-Error throws', async () => {
+    await expect(
+      tracing.withSpan('str.throw', async () => { throw 'string error'; }) // eslint-disable-line no-throw-literal
+    ).rejects.toBe('string error');
+  });
+});
+
+// ─── 4. startSpan ─────────────────────────────────────────────────────────────
+
+describe('startSpan', () => {
+  test('creates a span that must be ended manually', () => {
+    const span = tracing.startSpan('manual.span', { 'db.system': 'sqlite' });
+    expect(typeof span.end).toBe('function');
+    span.end();
+    const finished = getFinishedSpans().find(s => s.name === 'manual.span');
+    expect(finished).toBeDefined();
+    expect(finished.attributes['db.system']).toBe('sqlite');
+  });
+
+  test('works without attributes', () => {
+    const span = tracing.startSpan('bare.span');
+    span.end();
+    expect(getFinishedSpans().find(s => s.name === 'bare.span')).toBeDefined();
+  });
+});
+
+// ─── 5. httpTracingMiddleware ─────────────────────────────────────────────────
+
+describe('httpTracingMiddleware', () => {
+  test('calls next()', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes();
+    const next = jest.fn();
+    mw(req, res, next);
+    res.finish();
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('creates a SERVER span with correct HTTP attributes', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes({ method: 'POST', path: '/donations' });
+    mw(req, res, jest.fn());
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'POST /donations');
+    expect(span).toBeDefined();
+    expect(span.attributes['http.method']).toBe('POST');
+    expect(span.attributes['http.route']).toBe('/donations');
+    expect(span.attributes['net.peer.ip']).toBe('127.0.0.1');
+    expect(span.kind).toBe(api.SpanKind.SERVER);
+  });
+
+  test('sets http.status_code on finish', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes();
+    mw(req, res, jest.fn());
+    res.statusCode = 201;
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /donations');
+    expect(span.attributes['http.status_code']).toBe(201);
+  });
+
+  test('sets ERROR status for 5xx', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes();
+    mw(req, res, jest.fn());
+    res.statusCode = 503;
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /donations');
+    expect(span.status.code).toBe(api.SpanStatusCode.ERROR);
+  });
+
+  test('sets OK status for 2xx', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes();
+    mw(req, res, jest.fn());
+    res.statusCode = 200;
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /donations');
+    expect(span.status.code).toBe(api.SpanStatusCode.OK);
+  });
+
+  test('sets OK status for 4xx (client error, not server error)', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes();
+    mw(req, res, jest.fn());
+    res.statusCode = 404;
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /donations');
+    expect(span.status.code).toBe(api.SpanStatusCode.OK);
+  });
+
+  test('attaches span and traceContext to req', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes();
+    mw(req, res, jest.fn());
+    expect(req.span).toBeDefined();
+    expect(req.traceContext).toBeDefined();
+    res.finish();
+  });
+
+  test('injects traceparent into response headers', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res, resHeaders } = makeReqRes();
+    mw(req, res, jest.fn());
+    res.finish();
+    // Our propagator injects traceparent
+    expect(resHeaders['traceparent']).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+  });
+
+  test('extracts traceparent from inbound headers and continues the trace', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes({
+      headers: { traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' },
+    });
+    mw(req, res, jest.fn());
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /donations');
+    expect(span.spanContext().traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736');
+  });
+
+  test('handles missing request id gracefully', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes({ id: undefined, headers: {} });
+    expect(() => mw(req, res, jest.fn())).not.toThrow();
+    res.finish();
+  });
+
+  test('handles missing originalUrl gracefully', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes({ originalUrl: undefined });
+    expect(() => mw(req, res, jest.fn())).not.toThrow();
+    res.finish();
+  });
+
+  test('records http.request_id attribute', () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes({ id: 'my-request-id' });
+    mw(req, res, jest.fn());
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /donations');
+    expect(span.attributes['http.request_id']).toBe('my-request-id');
+  });
+});
+
+// ─── 6. traceDbQuery ─────────────────────────────────────────────────────────
+
+describe('traceDbQuery', () => {
+  test('creates a CLIENT span with db attributes', async () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    const result = await tracing.traceDbQuery('SELECT', 'donations', async () => rows);
+
+    expect(result).toEqual(rows);
+    const span = getFinishedSpans().find(s => s.name === 'db.select donations');
+    expect(span).toBeDefined();
+    expect(span.attributes['db.system']).toBe('sqlite');
+    expect(span.attributes['db.operation']).toBe('SELECT');
+    expect(span.attributes['db.sql.table']).toBe('donations');
+    expect(span.kind).toBe(api.SpanKind.CLIENT);
+  });
+
+  test('records rows_affected for INSERT (changes property)', async () => {
+    await tracing.traceDbQuery('INSERT', 'users', async () => ({ changes: 3 }));
+    const span = getFinishedSpans().find(s => s.name === 'db.insert users');
+    expect(span.attributes['db.rows_affected']).toBe(3);
+  });
+
+  test('records rows_affected for SELECT (array length)', async () => {
+    await tracing.traceDbQuery('SELECT', 'wallets', async () => [1, 2, 3]);
+    const span = getFinishedSpans().find(s => s.name === 'db.select wallets');
+    expect(span.attributes['db.rows_affected']).toBe(3);
+  });
+
+  test('records 0 rows_affected for undefined result', async () => {
+    await tracing.traceDbQuery('UPDATE', 'config', async () => undefined);
+    const span = getFinishedSpans().find(s => s.name === 'db.update config');
+    expect(span.attributes['db.rows_affected']).toBe(0);
+  });
+
+  test('sets ERROR status when query throws', async () => {
+    await expect(
+      tracing.traceDbQuery('SELECT', 'bad_table', async () => { throw new Error('no such table'); })
+    ).rejects.toThrow('no such table');
+
+    const span = getFinishedSpans().find(s => s.name === 'db.select bad_table');
+    expect(span.status.code).toBe(api.SpanStatusCode.ERROR);
+  });
+
+  test('operation name is lowercased in span name', async () => {
+    await tracing.traceDbQuery('DELETE', 'sessions', async () => ({ changes: 0 }));
+    expect(getFinishedSpans().find(s => s.name === 'db.delete sessions')).toBeDefined();
+  });
+
+  test('db.operation attribute is uppercased', async () => {
+    await tracing.traceDbQuery('select', 'logs', async () => []);
+    const span = getFinishedSpans().find(s => s.name === 'db.select logs');
+    expect(span.attributes['db.operation']).toBe('SELECT');
+  });
+});
+
+// ─── 7. traceStellarCall ──────────────────────────────────────────────────────
+
+describe('traceStellarCall', () => {
+  test('creates a CLIENT span with stellar attributes', async () => {
+    const mockResult = { hash: 'abc123', ledger: 42 };
+    const result = await tracing.traceStellarCall(
+      'sendDonation',
+      { 'stellar.network': 'testnet', 'stellar.horizon_url': 'https://horizon-testnet.stellar.org' },
+      async () => mockResult
+    );
+
+    expect(result).toEqual(mockResult);
+    const span = getFinishedSpans().find(s => s.name === 'stellar.sendDonation');
+    expect(span).toBeDefined();
+    expect(span.attributes['stellar.operation']).toBe('sendDonation');
+    expect(span.attributes['peer.service']).toBe('stellar-horizon');
+    expect(span.attributes['stellar.network']).toBe('testnet');
+    expect(span.kind).toBe(api.SpanKind.CLIENT);
+  });
+
+  test('works without extra attributes (fn as second arg)', async () => {
+    await tracing.traceStellarCall('loadAccount', async () => ({ id: 'G123' }));
+    const span = getFinishedSpans().find(s => s.name === 'stellar.loadAccount');
+    expect(span).toBeDefined();
+    expect(span.attributes['stellar.operation']).toBe('loadAccount');
+  });
+
+  test('sets ERROR status when Stellar call throws', async () => {
+    await expect(
+      tracing.traceStellarCall('submitTransaction', async () => {
+        throw new Error('horizon unavailable');
+      })
+    ).rejects.toThrow('horizon unavailable');
+
+    const span = getFinishedSpans().find(s => s.name === 'stellar.submitTransaction');
+    expect(span.status.code).toBe(api.SpanStatusCode.ERROR);
+    expect(span.events.some(e => e.name === 'exception')).toBe(true);
+  });
+
+  test('MockStellarService operations can be wrapped', async () => {
+    const MockStellarService = require('../src/services/MockStellarService');
+    const svc = new MockStellarService();
+    const wallet = await svc.createWallet();
+
+    const result = await tracing.traceStellarCall(
+      'getBalance',
+      { 'stellar.network': 'testnet' },
+      () => svc.getBalance(wallet.publicKey)
+    );
+
+    expect(result).toBeDefined();
+    const span = getFinishedSpans().find(s => s.name === 'stellar.getBalance');
+    expect(span).toBeDefined();
+    expect(span.status.code).toBe(api.SpanStatusCode.OK);
+  });
+
+  test('peer.service is always stellar-horizon', async () => {
+    await tracing.traceStellarCall('getTransaction', async () => ({}));
+    const span = getFinishedSpans().find(s => s.name === 'stellar.getTransaction');
+    expect(span.attributes['peer.service']).toBe('stellar-horizon');
+  });
+});
+
+// ─── 8. injectTraceHeaders / extractTraceContext ──────────────────────────────
+
+describe('injectTraceHeaders', () => {
+  test('returns the same headers object', async () => {
+    let h;
+    await tracing.withSpan('inject.test', async () => {
+      const input = { 'x-custom': 'val' };
+      h = tracing.injectTraceHeaders(input);
+      expect(h).toBe(input);
+    });
+  });
+
+  test('adds traceparent when inside an active span', async () => {
+    let headers;
+    await tracing.withSpan('inject.active', async () => {
+      headers = tracing.injectTraceHeaders({});
+    });
+    expect(headers['traceparent']).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+  });
+
+  test('does not crash outside any span', () => {
+    const headers = tracing.injectTraceHeaders({ 'x-custom': 'value' });
+    expect(headers['x-custom']).toBe('value');
+  });
+
+  test('traceparent contains the active span traceId', async () => {
+    let headers;
+    let spanTraceId;
+    await tracing.withSpan('trace.id.check', async (span) => {
+      spanTraceId = span.spanContext().traceId;
+      headers = tracing.injectTraceHeaders({});
+    });
+    expect(headers['traceparent']).toContain(spanTraceId);
+  });
+});
+
+describe('extractTraceContext', () => {
+  test('returns a context object', () => {
+    const ctx = tracing.extractTraceContext({
+      traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+    });
+    expect(ctx).toBeDefined();
+  });
+
+  test('round-trip: inject then extract preserves traceId', async () => {
+    let injected;
+    let originalTraceId;
+    await tracing.withSpan('round.trip', async (span) => {
+      originalTraceId = span.spanContext().traceId;
+      injected = tracing.injectTraceHeaders({});
+    });
+
+    const ctx = tracing.extractTraceContext(injected);
+    const extractedSpan = api.trace.getSpan(ctx);
+    expect(extractedSpan).toBeDefined();
+    expect(extractedSpan.spanContext().traceId).toBe(originalTraceId);
+  });
+
+  test('returns active context unchanged when no traceparent header', () => {
+    const ctx = tracing.extractTraceContext({});
+    expect(ctx).toBeDefined();
+  });
+});
+
+// ─── 9. getCurrentTraceparent / getActiveSpanContext ─────────────────────────
+
+describe('getCurrentTraceparent', () => {
+  test('returns null when no active span', () => {
+    expect(tracing.getCurrentTraceparent()).toBeNull();
+  });
+
+  test('returns a valid W3C traceparent string inside a span', async () => {
+    let tp;
+    await tracing.withSpan('tp.test', async () => {
+      tp = tracing.getCurrentTraceparent();
+    });
+    expect(tp).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+  });
+
+  test('version byte is always 00', async () => {
+    let tp;
+    await tracing.withSpan('version.check', async () => {
+      tp = tracing.getCurrentTraceparent();
+    });
+    expect(tp.startsWith('00-')).toBe(true);
+  });
+
+  test('traceparent traceId matches active span traceId', async () => {
+    let tp;
+    let spanTraceId;
+    await tracing.withSpan('match.check', async (span) => {
+      spanTraceId = span.spanContext().traceId;
+      tp = tracing.getCurrentTraceparent();
+    });
+    expect(tp.split('-')[1]).toBe(spanTraceId);
+  });
+});
+
+describe('getActiveSpanContext', () => {
+  test('returns null when no active span', () => {
+    expect(tracing.getActiveSpanContext()).toBeNull();
+  });
+
+  test('returns span context with valid traceId and spanId', async () => {
+    let ctx;
+    await tracing.withSpan('ctx.test', async () => {
+      ctx = tracing.getActiveSpanContext();
+    });
+    expect(ctx).not.toBeNull();
+    expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+// ─── 10. Constants ────────────────────────────────────────────────────────────
+
+describe('Exported constants', () => {
+  test('TRACER_NAME is stellar-donation-api', () => {
+    expect(tracing.TRACER_NAME).toBe('stellar-donation-api');
+  });
+
+  test('TRACEPARENT_HEADER is traceparent', () => {
+    expect(tracing.TRACEPARENT_HEADER).toBe('traceparent');
+  });
+
+  test('TRACESTATE_HEADER is tracestate', () => {
+    expect(tracing.TRACESTATE_HEADER).toBe('tracestate');
+  });
+});
+
+// ─── 11. Edge cases ───────────────────────────────────────────────────────────
+
+describe('Edge cases', () => {
+  test('multiple concurrent spans do not interfere', async () => {
+    await Promise.all([
+      tracing.withSpan('concurrent.a', async () => 'a'),
+      tracing.withSpan('concurrent.b', async () => 'b'),
+      tracing.withSpan('concurrent.c', async () => 'c'),
+    ]);
+
+    const spans = getFinishedSpans();
+    expect(spans.find(s => s.name === 'concurrent.a')).toBeDefined();
+    expect(spans.find(s => s.name === 'concurrent.b')).toBeDefined();
+    expect(spans.find(s => s.name === 'concurrent.c')).toBeDefined();
+  });
+
+  test('deeply nested spans all share the root traceId', async () => {
+    await tracing.withSpan('root', async () => {
+      await tracing.withSpan('level1', async () => {
+        await tracing.withSpan('level2', async () => {});
+      });
+    });
+
+    const spans = getFinishedSpans();
+    const root = spans.find(s => s.name === 'root');
+    const l1 = spans.find(s => s.name === 'level1');
+    const l2 = spans.find(s => s.name === 'level2');
+    const traceId = root.spanContext().traceId;
+    expect(l1.spanContext().traceId).toBe(traceId);
+    expect(l2.spanContext().traceId).toBe(traceId);
+  });
+
+  test('traceDbQuery with empty array result records 0 rows', async () => {
+    await tracing.traceDbQuery('SELECT', 'empty_table', async () => []);
+    const span = getFinishedSpans().find(s => s.name === 'db.select empty_table');
+    expect(span.attributes['db.rows_affected']).toBe(0);
+  });
+});
+
+// ─── 12. Integration: HTTP → DB → Stellar trace chain ────────────────────────
+
+describe('Integration: full trace chain', () => {
+  test('DB and Stellar spans share traceId with HTTP root span', async () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res } = makeReqRes({ method: 'POST', path: '/donations' });
+
+    await new Promise((resolve) => {
+      mw(req, res, async () => {
+        await api.context.with(req.traceContext, async () => {
+          await tracing.traceDbQuery('INSERT', 'donations', async () => ({ changes: 1 }));
+          await tracing.traceStellarCall('sendDonation', { 'stellar.network': 'testnet' }, async () => ({
+            hash: 'txhash123',
+          }));
+        });
+        res.statusCode = 201;
+        res.finish();
+        resolve();
+      });
+    });
+
+    const spans = getFinishedSpans();
+    const httpSpan = spans.find(s => s.name === 'POST /donations');
+    const dbSpan = spans.find(s => s.name === 'db.insert donations');
+    const stellarSpan = spans.find(s => s.name === 'stellar.sendDonation');
+
+    expect(httpSpan).toBeDefined();
+    expect(dbSpan).toBeDefined();
+    expect(stellarSpan).toBeDefined();
+
+    const traceId = httpSpan.spanContext().traceId;
+    expect(dbSpan.spanContext().traceId).toBe(traceId);
+    expect(stellarSpan.spanContext().traceId).toBe(traceId);
+  });
+
+  test('traceparent in response matches the root span traceId', async () => {
+    const mw = tracing.httpTracingMiddleware();
+    const { req, res, resHeaders } = makeReqRes({ method: 'GET', path: '/wallets' });
+    mw(req, res, jest.fn());
+    res.finish();
+
+    const span = getFinishedSpans().find(s => s.name === 'GET /wallets');
+    const tp = resHeaders['traceparent'];
+    expect(tp).toBeDefined();
+    expect(tp.split('-')[1]).toBe(span.spanContext().traceId);
+  });
+});


### PR DESCRIPTION
- Added src/utils/tracing.js with full OTel instrumentation
- HTTP middleware creates root SERVER span with W3C traceparent propagation
- traceDbQuery() and traceStellarCall() wrap domain operations as child spans
- Graceful degradation when SDK packages are not installed
- 62 tests covering spans, propagation, middleware, and error handling
- Added docs/features/IMPLEMENT_DISTRIBUTED_TRACING_WITH_OPENTELEMETRY.md

closes #330 
