### PR TITLE
feat: add bulk wallet import with per-wallet validation and result reporting

### DIFF
--- a/.kiro/specs/bulk-wallet-import/.config.kiro
+++ b/.kiro/specs/bulk-wallet-import/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "30cf4b90-8c1d-4456-9f30-6e07ff69686d", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/bulk-wallet-import/design.md
+++ b/.kiro/specs/bulk-wallet-import/design.md
@@ -1,0 +1,454 @@
+# Design Document: Bulk Wallet Import
+
+## Overview
+
+This feature adds a `POST /wallets/bulk-import` endpoint that allows organization administrators to register up to 100 existing Stellar wallets in a single request. Each wallet is validated independently, checked against Horizon concurrently, and duplicate detection is applied both against the data store and within the batch itself. The endpoint returns a per-wallet results array preserving input order, plus a summary object. The design follows the existing layered architecture: a new route handler in `src/routes/wallet.js`, a new `BulkWalletImportService`, reuse of `StellarService` for Horizon queries, and `AuditLogService` for audit logging.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Router (wallet.js)
+    participant Auth Middleware
+    participant Rate Limiter
+    participant BulkWalletImportService
+    participant WalletService
+    participant StellarService
+    participant Horizon API
+    participant AuditLogService
+
+    Client->>Router (wallet.js): POST /wallets/bulk-import
+    Router (wallet.js)->>Auth Middleware: requireApiKey
+    Auth Middleware-->>Router (wallet.js): authenticated (req.apiKey)
+    Router (wallet.js)->>Rate Limiter: bulkImportRateLimiter (10/min)
+    Rate Limiter-->>Router (wallet.js): allowed
+    Router (wallet.js)->>Router (wallet.js): validate Content-Type, batch size
+    Router (wallet.js)->>BulkWalletImportService: importBatch(wallets, clientId)
+    BulkWalletImportService->>BulkWalletImportService: validateEach(wallet) — per-wallet
+    BulkWalletImportService->>BulkWalletImportService: deduplicateIntraBatch()
+    BulkWalletImportService->>WalletService: checkDuplicates(validKeys[])
+    WalletService-->>BulkWalletImportService: existingKeys[]
+    BulkWalletImportService->>StellarService: loadAccount(key) × N (concurrent)
+    Horizon API-->>StellarService: account data | 404 | error
+    StellarService-->>BulkWalletImportService: horizon results[]
+    BulkWalletImportService->>WalletService: createWalletRecord(key, balance?) × M
+    WalletService-->>BulkWalletImportService: wallet records[]
+    BulkWalletImportService-->>Router (wallet.js): { results[], summary }
+    Router (wallet.js)->>AuditLogService: log(BULK_WALLET_IMPORT)
+    Router (wallet.js)-->>Client: 200 { results[], summary }
+```
+
+## Components and Interfaces
+
+### 1. Route Handler — `src/routes/wallet.js`
+
+**New endpoint: `POST /wallets/bulk-import`**
+
+```
+POST /wallets/bulk-import
+Authorization: x-api-key (WALLETS_CREATE permission required)
+Content-Type: application/json
+Body: { "wallets": [ { "public_key": "G..." }, ... ] }
+
+Response 200: { "results": [...], "summary": { total, succeeded, duplicates, failed } }
+Response 401: unauthenticated
+Response 415: Content-Type not application/json
+Response 422: batch size violation (0 or >100 wallets)
+Response 429: rate limit exceeded (Retry-After header included)
+```
+
+Middleware chain applied to this route:
+1. `requireApiKey` — authentication
+2. `bulkImportRateLimiter` — 10 req/min per authenticated client key
+3. Content-Type check — inline, returns 415 if not `application/json`
+4. Batch size validation — inline, returns 422 for empty or oversized batches
+5. `checkPermission(PERMISSIONS.WALLETS_CREATE)` — authorization
+
+### 2. BulkWalletImportService — `src/services/BulkWalletImportService.js`
+
+New service class encapsulating all batch processing logic.
+
+**`importBatch(wallets, clientId)`**
+
+```
+Input:  wallets (Array<Object>), clientId (string)
+Output: Promise<{ results: ImportResult[], summary: Summary }>
+```
+
+Processing steps:
+1. For each wallet object, run `_validateWallet(wallet, index)` — returns a validation result or null.
+2. Build an intra-batch seen-set; mark subsequent occurrences of the same `public_key` as `duplicate`.
+3. For all keys that passed validation and are not intra-batch duplicates, call `WalletService.getWalletByAddress(key)` to detect data-store duplicates.
+4. For all remaining valid, non-duplicate keys, call `StellarService.loadAccount(key)` concurrently via `Promise.allSettled`.
+5. For each Horizon result: 200 → record balance; 404 → `unfunded_account`; other error → `failed` with `horizon_unavailable`.
+6. For each wallet that passed all checks, call `WalletService.createWalletRecord(key, balance)`.
+7. Assemble the `results` array in original input order.
+8. Compute and return the `summary` object.
+
+**`_validateWallet(wallet, index)`**
+
+```
+Input:  wallet (Object), index (number)
+Output: { valid: boolean, reason?: string }
+```
+
+Validation rules (checked in order):
+1. If `wallet.secret_key` or `wallet.private_key` is present → `private_key_not_accepted`
+2. If `wallet.public_key` is missing or not a string → `missing_public_key`
+3. If `wallet.public_key` fails `isValidStellarPublicKey` → `invalid_address`
+
+### 3. Rate Limiter — `src/middleware/rateLimiter.js`
+
+A new `bulkImportRateLimiter` instance added to the existing module:
+
+```js
+const bulkImportRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  keyGenerator: (req) => req.apiKey?.id || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => { /* 429 + Retry-After + AuditLog */ }
+});
+```
+
+The `keyGenerator` uses the authenticated client's API key ID so the limit is per-client, not per-IP.
+
+### 4. WalletService — `src/services/WalletService.js`
+
+One new method added:
+
+**`createWalletRecord(publicKey, balance)`**
+
+```
+Input:  publicKey (string), balance (string | null)
+Output: Object — the created wallet record
+```
+
+Creates a wallet record in the JSON data store via `Wallet.create`. Unlike the existing `createWallet`, this method does not trigger Friendbot funding or sponsorship — the wallet already exists on-chain. The `balance` field (XLM amount from Horizon, or `null` for unfunded accounts) is stored on the record.
+
+### 5. StellarService — `src/services/StellarService.js`
+
+No new methods required. The existing `server.loadAccount(publicKey)` call (used internally by `getBalance`) is called directly inside `BulkWalletImportService` via the injected `stellarService.server` reference, or a thin wrapper method `getAccountInfo(publicKey)` can be added:
+
+**`getAccountInfo(publicKey)`**
+
+```
+Input:  publicKey (string)
+Output: Promise<{ balance: string } | { notFound: true } | { error: true }>
+```
+
+Wraps `server.loadAccount` and normalises the three outcomes (success, 404, other error) into a discriminated union so `BulkWalletImportService` does not need to inspect raw Horizon error shapes.
+
+### 6. AuditLogService — `src/services/AuditLogService.js`
+
+Add one new action constant:
+
+```js
+BULK_WALLET_IMPORT: 'BULK_WALLET_IMPORT',
+```
+
+The audit log entry records `clientId`, `batchSize`, and `timestamp`. Public keys are **not** included in the log entry at any level.
+
+## Data Models
+
+### Request Body
+
+```json
+{
+  "wallets": [
+    { "public_key": "GABC...XYZ" },
+    { "public_key": "GDEF...UVW" }
+  ]
+}
+```
+
+Each element in `wallets` is a wallet object. Only `public_key` is a recognised field. The presence of `secret_key` or `private_key` causes that wallet to fail with `private_key_not_accepted`.
+
+### ImportResult Object
+
+```json
+{
+  "public_key": "GABC...XYZ",
+  "status": "success",
+  "reason": null,
+  "id": "1234567890"
+}
+```
+
+| Field | Type | Present when |
+|---|---|---|
+| `public_key` | string | always |
+| `status` | `"success"` \| `"duplicate"` \| `"failed"` | always |
+| `reason` | string \| null | non-null when `status` is `"failed"` or `"duplicate"` |
+| `id` | string \| null | non-null when `status` is `"success"` |
+
+Reason values:
+- `invalid_address` — public key fails StrKey format check
+- `missing_public_key` — `public_key` field absent
+- `private_key_not_accepted` — `secret_key` or `private_key` field present
+- `duplicate` — key already exists in data store or appeared earlier in the batch
+- `horizon_unavailable` — Horizon returned a non-404 error
+
+### Summary Object
+
+```json
+{
+  "total": 5,
+  "succeeded": 3,
+  "duplicates": 1,
+  "failed": 1
+}
+```
+
+### Response Body (200)
+
+```json
+{
+  "results": [
+    { "public_key": "GABC...XYZ", "status": "success", "reason": null, "id": "1234567890" },
+    { "public_key": "GDEF...UVW", "status": "duplicate", "reason": "duplicate", "id": null },
+    { "public_key": "INVALID",    "status": "failed",    "reason": "invalid_address", "id": null }
+  ],
+  "summary": { "total": 3, "succeeded": 1, "duplicates": 1, "failed": 1 }
+}
+```
+
+### Wallet Record (stored)
+
+```json
+{
+  "id": "1234567890",
+  "address": "GABC...XYZ",
+  "balance": "100.0000000",
+  "label": null,
+  "ownerName": null,
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "deletedAt": null,
+  "importedVia": "bulk-import"
+}
+```
+
+`balance` is `null` for unfunded accounts. `importedVia` distinguishes bulk-imported wallets from individually created ones.
+
+### Audit Log Entry
+
+```json
+{
+  "category": "WALLET_OPERATION",
+  "action": "BULK_WALLET_IMPORT",
+  "severity": "MEDIUM",
+  "result": "SUCCESS",
+  "userId": "<api-key-id>",
+  "requestId": "<request-id>",
+  "ipAddress": "<client-ip>",
+  "resource": "/wallets/bulk-import",
+  "details": {
+    "batchSize": 5,
+    "succeeded": 3,
+    "duplicates": 1,
+    "failed": 1
+  }
+}
+```
+
+Public keys are explicitly excluded from `details`. The `maskSensitiveData` utility in `AuditLogService._log` provides an additional safety net.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Oversized batch is rejected
+
+*For any* array of wallet objects with length greater than 100, a `POST /wallets/bulk-import` request should return HTTP 422 with an error message indicating the batch size limit, regardless of the content of the individual wallet objects.
+
+**Validates: Requirements 1.3**
+
+---
+
+### Property 2: Independent per-wallet processing
+
+*For any* batch containing a mix of valid and invalid wallet objects, the `status` of each wallet's `Import_Result` should be determined solely by that wallet's own data — a failure in one wallet should not change the outcome of any other wallet in the same batch.
+
+**Validates: Requirements 1.2, 4.3**
+
+---
+
+### Property 3: Validation failures produce correct status and reason
+
+*For any* wallet object that fails validation (missing `public_key`, invalid StrKey format, or presence of `secret_key`/`private_key`), the corresponding `Import_Result` should have `status: "failed"` and a `reason` value that exactly matches the failure type: `missing_public_key`, `invalid_address`, or `private_key_not_accepted` respectively.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+---
+
+### Property 4: All-failed batch returns HTTP 200
+
+*For any* batch where every wallet object fails validation, the API should return HTTP 200 (not a 4xx error) with a `results` array where every element has `status: "failed"`.
+
+**Validates: Requirements 2.4**
+
+---
+
+### Property 5: Funded account balance is recorded
+
+*For any* valid public key for which Horizon returns account data with an XLM balance, the created wallet record should have a `balance` field equal to the XLM balance returned by Horizon, and the `Import_Result` should have `status: "success"`.
+
+**Validates: Requirements 3.2**
+
+---
+
+### Property 6: Unfunded account still succeeds
+
+*For any* valid public key for which Horizon returns a 404, the API should still create a wallet record and return `status: "success"` with a `reason` of `unfunded_account` in the `Import_Result`.
+
+**Validates: Requirements 3.3**
+
+---
+
+### Property 7: Non-404 Horizon error produces failed result
+
+*For any* valid public key for which Horizon returns an error other than 404 (e.g., 500, 503, network timeout), the corresponding `Import_Result` should have `status: "failed"` and `reason: "horizon_unavailable"`.
+
+**Validates: Requirements 3.4**
+
+---
+
+### Property 8: Data-store duplicate is flagged without creating a new record
+
+*For any* public key that already exists in the wallet data store, submitting it in a batch should produce `status: "duplicate"` in the `Import_Result`, and the total number of wallet records in the store should not increase.
+
+**Validates: Requirements 4.1**
+
+---
+
+### Property 9: Intra-batch duplicate — first wins, rest are duplicate
+
+*For any* batch containing the same public key more than once, the first occurrence should be processed normally (resulting in `success`, `duplicate` against the store, or `failed` for other reasons), and all subsequent occurrences of that key should have `status: "duplicate"` regardless of their position in the batch.
+
+**Validates: Requirements 4.2**
+
+---
+
+### Property 10: Results array preserves order and structure
+
+*For any* batch of N wallet objects, the `results` array in the response should have exactly N elements in the same order as the input, and every element should contain `public_key`, `status`, and `reason` fields. Additionally, every element with `status: "success"` should have a non-null `id` field.
+
+**Validates: Requirements 5.1, 5.2, 5.4**
+
+---
+
+### Property 11: Summary counts are consistent with results
+
+*For any* batch response, the `summary` object should satisfy: `summary.total === results.length`, `summary.succeeded === count of results with status "success"`, `summary.duplicates === count of results with status "duplicate"`, and `summary.failed === count of results with status "failed"`.
+
+**Validates: Requirements 5.3**
+
+---
+
+### Property 12: Non-JSON Content-Type returns 415
+
+*For any* request to `POST /wallets/bulk-import` where the `Content-Type` header is not `application/json` (including missing, `text/plain`, `multipart/form-data`, etc.), the API should return HTTP 415.
+
+**Validates: Requirements 6.3**
+
+---
+
+### Property 13: Audit log contains required fields without public keys
+
+*For any* `POST /wallets/bulk-import` request (successful or failed), the audit log entry created for that request should contain `clientId`, `batchSize`, and `timestamp` fields, and no field in the audit log entry should contain any of the submitted public key values.
+
+**Validates: Requirements 6.4**
+
+---
+
+## Error Handling
+
+| Scenario | HTTP Status | Handler |
+|---|---|---|
+| Missing or invalid API key | 401 | `requireApiKey` middleware |
+| Rate limit exceeded | 429 + `Retry-After` header | `bulkImportRateLimiter` handler |
+| Content-Type is not `application/json` | 415 | Inline check in route handler |
+| Empty batch (`wallets` array has 0 elements) | 422 | Inline batch size check |
+| Batch exceeds 100 wallets | 422 | Inline batch size check |
+| Missing `public_key` field | 200 (per-wallet `failed`) | `BulkWalletImportService._validateWallet` |
+| Invalid StrKey format | 200 (per-wallet `failed`) | `BulkWalletImportService._validateWallet` |
+| Private key field present | 200 (per-wallet `failed`) | `BulkWalletImportService._validateWallet` |
+| Intra-batch duplicate | 200 (per-wallet `duplicate`) | `BulkWalletImportService` seen-set |
+| Data-store duplicate | 200 (per-wallet `duplicate`) | `WalletService.getWalletByAddress` |
+| Horizon 404 (unfunded) | 200 (per-wallet `success`, `unfunded_account`) | `BulkWalletImportService` Horizon handler |
+| Horizon non-404 error | 200 (per-wallet `failed`, `horizon_unavailable`) | `BulkWalletImportService` Horizon handler |
+| Unexpected internal error | 500 | Express error handler middleware |
+
+The route handler wraps `BulkWalletImportService.importBatch` in a try/catch. Any unexpected error (e.g., database write failure) is passed to `next(error)` and handled by the existing `errorHandler` middleware, which returns a structured 500 response.
+
+Per-wallet errors never cause the entire batch to fail — the batch always returns HTTP 200 as long as the request itself is structurally valid (authenticated, correct Content-Type, valid batch size).
+
+```js
+// Route handler error flow
+try {
+  const { results, summary } = await bulkImportService.importBatch(wallets, req.apiKey.id);
+  await AuditLogService.log({ ..., details: { batchSize: wallets.length, ...summary } });
+  return res.json({ results, summary });
+} catch (error) {
+  // Only unexpected errors reach here — per-wallet errors are captured in results
+  next(error);
+}
+```
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are required. Unit tests cover specific examples, integration points, and error conditions. Property-based tests verify universal properties across many generated inputs. Together they provide comprehensive coverage.
+
+### Property-Based Testing
+
+Use **fast-check** as the property-based testing library (compatible with Jest, already used in the project ecosystem).
+
+Each property test must run a minimum of **100 iterations** and be tagged with a comment referencing the design property:
+
+```js
+// Feature: bulk-wallet-import, Property 3: Validation failures produce correct status and reason
+```
+
+**Property test implementations:**
+
+| Property | Generator | Assertion |
+|---|---|---|
+| P1 | `fc.array(walletArb, { minLength: 101, maxLength: 200 })` | Response is 422 |
+| P2 | `fc.array(fc.oneof(validWalletArb, invalidWalletArb), { minLength: 1, maxLength: 100 })` | Each result's status is independent of other results |
+| P3 | `fc.oneof(missingKeyArb, invalidKeyArb, privateKeyArb)` | Result has `status: "failed"` and correct `reason` |
+| P4 | `fc.array(invalidWalletArb, { minLength: 1, maxLength: 100 })` | Response is 200, all results have `status: "failed"` |
+| P5 | `fc.array(validKeyArb)` with Horizon mock returning balance | Result has `status: "success"`, wallet record has correct balance |
+| P6 | `fc.array(validKeyArb)` with Horizon mock returning 404 | Result has `status: "success"`, `reason: "unfunded_account"` |
+| P7 | `fc.array(validKeyArb)` with Horizon mock returning 500/503 | Result has `status: "failed"`, `reason: "horizon_unavailable"` |
+| P8 | `fc.array(existingKeyArb)` (keys pre-seeded in store) | Result has `status: "duplicate"`, store record count unchanged |
+| P9 | `fc.array(validKeyArb).map(keys => [...keys, ...keys])` (doubled) | First occurrence processed, subsequent ones have `status: "duplicate"` |
+| P10 | `fc.array(fc.oneof(validWalletArb, invalidWalletArb), { minLength: 1, maxLength: 100 })` | `results.length === input.length`, order preserved, all fields present, success results have non-null `id` |
+| P11 | `fc.array(fc.oneof(validWalletArb, invalidWalletArb), { minLength: 1, maxLength: 100 })` | `summary.total + summary.succeeded + summary.duplicates + summary.failed` consistency |
+| P12 | `fc.string().filter(ct => ct !== 'application/json')` as Content-Type | Response is 415 |
+| P13 | `fc.array(validWalletArb, { minLength: 1, maxLength: 10 })` | Audit log entry has `clientId`, `batchSize`, `timestamp`; no public key values in any field |
+
+### Unit Tests
+
+Specific examples and integration points to cover:
+
+1. `POST /wallets/bulk-import` without API key returns 401
+2. `POST /wallets/bulk-import` with Content-Type `text/plain` returns 415
+3. Empty `wallets` array returns 422 with descriptive message
+4. Batch of exactly 100 wallets is accepted (boundary)
+5. Batch of 101 wallets is rejected (boundary)
+6. Mixed batch: valid + invalid + duplicate returns correct per-wallet results
+7. Rate limit: 11th request in a minute returns 429 with `Retry-After` header
+8. Successful import: wallet record is persisted with correct `address` and `balance`
+9. Unfunded account: wallet record is created with `balance: null`
+10. `BulkWalletImportService._validateWallet` unit tests for each failure reason
+11. `StellarService.getAccountInfo` returns correct discriminated union for each Horizon outcome
+12. Audit log entry does not contain any public key values
+
+### Coverage Target
+
+All new code introduced by this feature must achieve **≥ 95% line coverage**.

--- a/.kiro/specs/bulk-wallet-import/requirements.md
+++ b/.kiro/specs/bulk-wallet-import/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds a bulk wallet import endpoint to the API, allowing organizations migrating from other platforms to register multiple existing Stellar wallets in a single request. The endpoint accepts a list of Stellar public keys, validates each one, checks on-chain status via Horizon, and returns per-wallet results without failing the entire batch on individual errors.
+
+## Glossary
+
+- **API**: The backend service exposing wallet management endpoints.
+- **Wallet**: A record representing a Stellar account managed by the API, identified by a Stellar public key.
+- **Public_Key**: A Stellar Ed25519 public key in StrKey encoding (starts with "G", 56 characters).
+- **Horizon**: The Stellar network's HTTP API used to query account balances and transaction history.
+- **Bulk_Import_Request**: An HTTP POST request to `/wallets/bulk-import` containing an array of wallet objects.
+- **Import_Result**: A per-wallet object in the response indicating `success`, `duplicate`, or `failed` status.
+- **Batch**: The full set of wallet objects submitted in a single Bulk_Import_Request.
+- **Duplicate**: A wallet whose Public_Key already exists in the API's data store.
+- **Rate_Limiter**: The middleware component that restricts the number of requests per client within a time window.
+
+## Requirements
+
+### Requirement 1: Bulk Import Endpoint
+
+**User Story:** As an organization administrator, I want to submit multiple Stellar public keys in one request, so that I can migrate existing wallets without making individual API calls.
+
+#### Acceptance Criteria
+
+1. THE API SHALL expose a `POST /wallets/bulk-import` endpoint that accepts a JSON request body.
+2. WHEN a Bulk_Import_Request is received, THE API SHALL process each wallet object in the request array independently.
+3. WHEN a Bulk_Import_Request contains more than 100 wallet objects, THE API SHALL reject the entire request with HTTP 422 and an error message indicating the batch size limit.
+4. WHEN a Bulk_Import_Request contains 0 wallet objects, THE API SHALL reject the request with HTTP 422 and an error message indicating the array must not be empty.
+5. THE API SHALL require authentication on the `POST /wallets/bulk-import` endpoint and return HTTP 401 for unauthenticated requests.
+
+### Requirement 2: Public Key Validation
+
+**User Story:** As an organization administrator, I want invalid Stellar addresses to be identified per-wallet, so that I can correct them without losing the rest of the batch.
+
+#### Acceptance Criteria
+
+1. WHEN a wallet object contains a Public_Key that does not conform to Stellar StrKey encoding (56-character G-prefixed string), THE API SHALL set that wallet's Import_Result status to `failed` with a reason of `invalid_address`.
+2. WHEN a wallet object is missing the `public_key` field, THE API SHALL set that wallet's Import_Result status to `failed` with a reason of `missing_public_key`.
+3. THE API SHALL accept no private key fields in wallet objects; WHEN a wallet object contains a `secret_key` or `private_key` field, THE API SHALL set that wallet's Import_Result status to `failed` with a reason of `private_key_not_accepted`.
+4. WHEN all wallet objects in a Batch fail validation, THE API SHALL return HTTP 200 with all Import_Results set to `failed`.
+
+### Requirement 3: Horizon Account Verification
+
+**User Story:** As an organization administrator, I want each wallet's on-chain status checked, so that I know whether the imported wallets are active on the Stellar network.
+
+#### Acceptance Criteria
+
+1. WHEN a wallet object passes Public_Key validation, THE API SHALL query Horizon for the account associated with that Public_Key.
+2. WHEN Horizon returns account data for a Public_Key, THE API SHALL record the account's XLM balance in the wallet record.
+3. WHEN Horizon returns a 404 for a Public_Key, THE API SHALL still create the wallet record and set the Import_Result status to `success` with a note of `unfunded_account`.
+4. WHEN Horizon returns an error other than 404, THE API SHALL set that wallet's Import_Result status to `failed` with a reason of `horizon_unavailable`.
+5. WHILE processing a Batch, THE API SHALL query Horizon for each valid Public_Key concurrently to minimize total response time.
+
+### Requirement 4: Duplicate Detection
+
+**User Story:** As an organization administrator, I want duplicate wallets to be flagged without stopping the import, so that I can identify already-registered addresses without losing new ones.
+
+#### Acceptance Criteria
+
+1. WHEN a wallet object's Public_Key already exists in the API data store, THE API SHALL set that wallet's Import_Result status to `duplicate` and SHALL NOT create a new wallet record.
+2. WHEN a Batch contains the same Public_Key more than once, THE API SHALL process the first occurrence and set all subsequent occurrences' Import_Result status to `duplicate`.
+3. WHEN a Batch contains duplicate wallets alongside valid new wallets, THE API SHALL successfully import the valid new wallets and return `duplicate` status for the duplicates.
+
+### Requirement 5: Per-Wallet Import Results
+
+**User Story:** As an organization administrator, I want a detailed result for each submitted wallet, so that I can audit the import and take corrective action on failures.
+
+#### Acceptance Criteria
+
+1. THE API SHALL return HTTP 200 with a JSON response body containing an `results` array where each element corresponds to a wallet object in the request, preserving input order.
+2. THE API SHALL include the following fields in each Import_Result: `public_key`, `status` (one of `success`, `duplicate`, `failed`), and `reason` (a string, present when status is `failed` or `duplicate`, null otherwise).
+3. WHEN at least one wallet is successfully imported, THE API SHALL include a `summary` object in the response with `total`, `succeeded`, `duplicates`, and `failed` counts.
+4. WHEN a wallet is successfully imported, THE API SHALL include the wallet's `id` field in its Import_Result.
+
+### Requirement 6: Security Controls
+
+**User Story:** As a platform operator, I want the bulk import endpoint to be protected against abuse, so that the API remains stable and secure under high request volumes.
+
+#### Acceptance Criteria
+
+1. THE Rate_Limiter SHALL restrict each authenticated client to no more than 10 Bulk_Import_Requests per minute on the `POST /wallets/bulk-import` endpoint.
+2. WHEN a client exceeds the rate limit, THE API SHALL return HTTP 429 with a `Retry-After` header indicating when the client may retry.
+3. THE API SHALL validate that the request `Content-Type` is `application/json`; WHEN the Content-Type is not `application/json`, THE API SHALL return HTTP 415.
+4. THE API SHALL log each Bulk_Import_Request with the authenticated client identifier, batch size, and timestamp, without logging Public_Key values in plaintext at DEBUG level or below.

--- a/.kiro/specs/bulk-wallet-import/tasks.md
+++ b/.kiro/specs/bulk-wallet-import/tasks.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Bulk Wallet Import
+
+## Overview
+
+Implement the `POST /wallets/bulk-import` endpoint using a layered approach: rate limiter middleware, a new `BulkWalletImportService`, a thin `StellarService.getAccountInfo` wrapper, a new `WalletService.createWalletRecord` method, and a new audit log action constant. Each layer is wired together in the route handler.
+
+## Tasks
+
+- [x] 1. Add `getAccountInfo` to StellarService
+  - [x] 1.1 Implement `getAccountInfo(publicKey)` in `src/services/StellarService.js`
+    - Wrap `server.loadAccount(publicKey)` and normalise outcomes into `{ balance }`, `{ notFound: true }`, or `{ error: true }`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+  - [ ]* 1.2 Write unit tests for `StellarService.getAccountInfo`
+    - Test success (balance returned), 404 (notFound), and non-404 error (error) outcomes
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+- [x] 2. Add `createWalletRecord` to WalletService
+  - [x] 2.1 Implement `createWalletRecord(publicKey, balance)` in `src/services/WalletService.js`
+    - Create a wallet record via `Wallet.create` with `address`, `balance`, `importedVia: "bulk-import"`, without triggering Friendbot or sponsorship
+    - _Requirements: 3.2, 3.3_
+  - [ ]* 2.2 Write unit tests for `WalletService.createWalletRecord`
+    - Test record creation with a balance value and with `null` balance
+    - _Requirements: 3.2, 3.3_
+
+- [x] 3. Implement `BulkWalletImportService`
+  - [x] 3.1 Create `src/services/BulkWalletImportService.js` with `_validateWallet(wallet, index)`
+    - Check in order: private key fields present → `private_key_not_accepted`; missing/non-string `public_key` → `missing_public_key`; invalid StrKey → `invalid_address`
+    - _Requirements: 2.1, 2.2, 2.3_
+  - [ ]* 3.2 Write property test for `_validateWallet` — Property 3
+    - **Property 3: Validation failures produce correct status and reason**
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+  - [x] 3.3 Implement intra-batch duplicate detection in `BulkWalletImportService`
+    - Build a seen-set after validation; mark subsequent occurrences of the same `public_key` as `duplicate`
+    - _Requirements: 4.2_
+  - [ ]* 3.4 Write property test for intra-batch duplicate detection — Property 9
+    - **Property 9: Intra-batch duplicate — first wins, rest are duplicate**
+    - **Validates: Requirements 4.2**
+  - [x] 3.5 Implement data-store duplicate check in `BulkWalletImportService`
+    - Call `WalletService.getWalletByAddress` for all valid, non-intra-batch-duplicate keys; mark matches as `duplicate`
+    - _Requirements: 4.1, 4.3_
+  - [ ]* 3.6 Write property test for data-store duplicate detection — Property 8
+    - **Property 8: Data-store duplicate is flagged without creating a new record**
+    - **Validates: Requirements 4.1**
+  - [x] 3.7 Implement concurrent Horizon queries in `BulkWalletImportService`
+    - Call `StellarService.getAccountInfo` for all remaining valid keys via `Promise.allSettled`; map outcomes to per-wallet results (`success`, `unfunded_account`, `horizon_unavailable`)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+  - [ ]* 3.8 Write property test for Horizon unfunded account — Property 6
+    - **Property 6: Unfunded account still succeeds**
+    - **Validates: Requirements 3.3**
+  - [ ]* 3.9 Write property test for Horizon non-404 error — Property 7
+    - **Property 7: Non-404 Horizon error produces failed result**
+    - **Validates: Requirements 3.4**
+  - [x] 3.10 Implement `importBatch(wallets, clientId)` — assemble results and summary
+    - Call wallet creation for each passing wallet, assemble `results` array in original input order, compute `summary` object
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+  - [ ]* 3.11 Write property test for results order and structure — Property 10
+    - **Property 10: Results array preserves order and structure**
+    - **Validates: Requirements 5.1, 5.2, 5.4**
+  - [ ]* 3.12 Write property test for summary consistency — Property 11
+    - **Property 11: Summary counts are consistent with results**
+    - **Validates: Requirements 5.3**
+  - [ ]* 3.13 Write property test for independent per-wallet processing — Property 2
+    - **Property 2: Independent per-wallet processing**
+    - **Validates: Requirements 1.2, 4.3**
+  - [ ]* 3.14 Write property test for all-failed batch returns HTTP 200 — Property 4
+    - **Property 4: All-failed batch returns HTTP 200**
+    - **Validates: Requirements 2.4**
+
+- [x] 4. Checkpoint — Ensure all service-layer tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Add `bulkImportRateLimiter` to rate limiter middleware
+  - [x] 5.1 Add `bulkImportRateLimiter` instance to `src/middleware/rateLimiter.js`
+    - Configure `windowMs: 60000`, `max: 10`, `keyGenerator` using `req.apiKey?.id || req.ip`, return 429 with `Retry-After` header on limit exceeded
+    - _Requirements: 6.1, 6.2_
+  - [ ]* 5.2 Write unit test for rate limiter — 11th request returns 429 with `Retry-After`
+    - _Requirements: 6.1, 6.2_
+
+- [x] 6. Add `BULK_WALLET_IMPORT` action to AuditLogService
+  - [x] 6.1 Add `BULK_WALLET_IMPORT: 'BULK_WALLET_IMPORT'` constant to `src/services/AuditLogService.js`
+    - _Requirements: 6.4_
+
+- [x] 7. Wire up the route handler in `src/routes/wallet.js`
+  - [x] 7.1 Add `POST /wallets/bulk-import` route with middleware chain and handler
+    - Apply `requireApiKey`, `bulkImportRateLimiter`, Content-Type check (415), batch size validation (422 for 0 or >100), `checkPermission(PERMISSIONS.WALLETS_CREATE)`, then call `BulkWalletImportService.importBatch`; log audit entry; return 200 `{ results, summary }`
+    - _Requirements: 1.1, 1.3, 1.4, 1.5, 6.3, 6.4_
+  - [ ]* 7.2 Write property test for oversized batch rejection — Property 1
+    - **Property 1: Oversized batch is rejected**
+    - **Validates: Requirements 1.3**
+  - [ ]* 7.3 Write property test for non-JSON Content-Type returns 415 — Property 12
+    - **Property 12: Non-JSON Content-Type returns 415**
+    - **Validates: Requirements 6.3**
+  - [ ]* 7.4 Write property test for audit log correctness — Property 13
+    - **Property 13: Audit log contains required fields without public keys**
+    - **Validates: Requirements 6.4**
+  - [ ]* 7.5 Write property test for funded account balance recorded — Property 5
+    - **Property 5: Funded account balance is recorded**
+    - **Validates: Requirements 3.2**
+  - [ ]* 7.6 Write unit tests for route handler
+    - Test: no API key → 401; `text/plain` Content-Type → 415; empty array → 422; batch of 100 accepted; batch of 101 rejected; mixed batch returns correct per-wallet results; successful import persists wallet record with correct `address` and `balance`; unfunded account creates record with `balance: null`
+    - _Requirements: 1.1, 1.3, 1.4, 1.5, 2.4, 3.2, 3.3, 6.3_
+
+- [x] 8. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.

--- a/src/middleware/rateLimiter.js
+++ b/src/middleware/rateLimiter.js
@@ -167,6 +167,39 @@ const batchRateLimiter = rateLimit({
 });
 
 /**
+ * Bulk Wallet Import Limiter
+ * Intent: Protect the bulk import endpoint from abuse; limit per authenticated client.
+ * Scope: POST /wallets/bulk-import
+ *
+ * Flow & Configuration:
+ * 1. Window: 60-second sliding window.
+ * 2. Threshold: Max 10 requests per authenticated client (keyed by API key ID, fallback to IP).
+ * 3. Exhaustion: Responds with HTTP 429 and includes Retry-After header.
+ */
+const bulkImportRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  keyGenerator: (req) => req.apiKey?.id || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    const retryAfter = req.rateLimit?.resetTime
+      ? Math.ceil((new Date(req.rateLimit.resetTime) - Date.now()) / 1000)
+      : 60;
+
+    res.set('Retry-After', String(retryAfter));
+    res.status(429).json({
+      success: false,
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Too many bulk import requests. Please try again later.',
+        retryAfter
+      }
+    });
+  }
+});
+
+/**
  * Factory function for creating custom rate limiters in tests
  * @param {Object} options - Rate limiter options
  * @returns {Function} Rate limiter middleware
@@ -197,5 +230,6 @@ module.exports = {
   donationRateLimiter,
   verificationRateLimiter,
   batchRateLimiter,
+  bulkImportRateLimiter,
   createRateLimiter,
 };

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -11,13 +11,13 @@
 
 const express = require('express');
 const router = express.Router();
+const requireApiKey = require('../middleware/apiKey');
 const { checkPermission, requireAdmin } = require('../middleware/rbac');
 const { PERMISSIONS } = require('../utils/permissions');
 const LimitService = require('../services/LimitService');
 const Database = require('../utils/database');
 const { ValidationError, NotFoundError, ERROR_CODES } = require('../utils/errors');
 const WalletService = require('../services/WalletService');
-const Database = require('../utils/database');
 const { getStellarService } = require('../config/stellar');
 const log = require('../utils/log');
 const { validateSchema } = require('../middleware/schemaValidation');
@@ -25,8 +25,11 @@ const { parseCursorPaginationQuery } = require('../utils/pagination');
 // eslint-disable-next-line no-unused-vars
 const { sanitizeLabel, sanitizeName } = require('../utils/sanitizer');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
+const { bulkImportRateLimiter } = require('../middleware/rateLimiter');
+const BulkWalletImportService = require('../services/BulkWalletImportService');
 
 const walletService = new WalletService(require('../config/serviceContainer').getStellarService());
+const stellarService = require('../config/serviceContainer').getStellarService();
 const AuditLogService = require('../services/AuditLogService');
 const walletCreateSchema = validateSchema({
   body: {
@@ -580,5 +583,81 @@ router.post('/:id/merge', checkPermission(PERMISSIONS.WALLETS_DELETE), async (re
     next(error);
   }
 });
+
+/**
+ * POST /wallets/bulk-import
+ * Import multiple existing Stellar wallets in a single request.
+ * Middleware chain: requireApiKey → bulkImportRateLimiter → Content-Type check →
+ *   batch size validation → checkPermission(WALLETS_CREATE)
+ */
+router.post(
+  '/bulk-import',
+  requireApiKey,
+  bulkImportRateLimiter,
+  (req, res, next) => {
+    const contentType = req.headers['content-type'] || '';
+    if (!contentType.includes('application/json')) {
+      return res.status(415).json({
+        success: false,
+        error: {
+          code: 'UNSUPPORTED_MEDIA_TYPE',
+          message: 'Content-Type must be application/json'
+        }
+      });
+    }
+    next();
+  },
+  (req, res, next) => {
+    const wallets = req.body && req.body.wallets;
+    if (!Array.isArray(wallets) || wallets.length === 0) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'INVALID_BATCH',
+          message: 'wallets array must not be empty'
+        }
+      });
+    }
+    if (wallets.length > 100) {
+      return res.status(422).json({
+        success: false,
+        error: {
+          code: 'BATCH_TOO_LARGE',
+          message: `Batch size limit exceeded: maximum 100 wallets per request, got ${wallets.length}`
+        }
+      });
+    }
+    next();
+  },
+  checkPermission(PERMISSIONS.WALLETS_CREATE),
+  async (req, res, next) => {
+    try {
+      const { wallets } = req.body;
+      const bulkImportService = new BulkWalletImportService(walletService, stellarService);
+      const { results, summary } = await bulkImportService.importBatch(wallets, req.apiKey.id);
+
+      await AuditLogService.log({
+        category: AuditLogService.CATEGORY.WALLET_OPERATION,
+        action: AuditLogService.ACTION.BULK_WALLET_IMPORT,
+        severity: AuditLogService.SEVERITY.MEDIUM,
+        result: 'SUCCESS',
+        userId: req.apiKey.id,
+        requestId: req.id,
+        ipAddress: req.ip,
+        resource: '/wallets/bulk-import',
+        details: {
+          batchSize: wallets.length,
+          succeeded: summary.succeeded,
+          duplicates: summary.duplicates,
+          failed: summary.failed
+        }
+      });
+
+      return res.status(200).json({ results, summary });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 module.exports = router;

--- a/src/services/AuditLogService.js
+++ b/src/services/AuditLogService.js
@@ -95,6 +95,9 @@ const AUDIT_ACTION = {
 
   // Wallet Inflation Destination
   INFLATION_DESTINATION_UPDATED: 'INFLATION_DESTINATION_UPDATED',
+
+  // Bulk Operations
+  BULK_WALLET_IMPORT: 'BULK_WALLET_IMPORT',
 };
 
 class AuditLogService {

--- a/src/services/BulkWalletImportService.js
+++ b/src/services/BulkWalletImportService.js
@@ -1,0 +1,231 @@
+/**
+ * Bulk Wallet Import Service
+ *
+ * RESPONSIBILITY: Orchestrate batch import of existing Stellar wallets
+ * OWNER: Backend Team
+ * DEPENDENCIES: WalletService, StellarService, stellar-sdk
+ *
+ * Validates each wallet independently, detects intra-batch and data-store
+ * duplicates, queries Horizon concurrently, persists passing wallets, and
+ * returns a per-wallet results array with a summary object.
+ */
+
+const StellarSdk = require('stellar-sdk');
+
+class BulkWalletImportService {
+  /**
+   * Create a new BulkWalletImportService instance.
+   * @param {import('./WalletService')} walletService - WalletService instance for data-store operations
+   * @param {import('./StellarService')} stellarService - StellarService instance for Horizon queries
+   */
+  constructor(walletService, stellarService) {
+    this.walletService = walletService;
+    this.stellarService = stellarService;
+  }
+
+  /**
+   * Validate a single wallet object from the import batch.
+   *
+   * Validation rules are checked in this order:
+   * 1. Private key fields present (`secret_key` or `private_key`) → `private_key_not_accepted`
+   * 2. Missing or non-string `public_key` → `missing_public_key`
+   * 3. Invalid Stellar StrKey format → `invalid_address`
+   *
+   * @private
+   * @param {Object} wallet - Wallet object from the request body
+   * @param {number} index  - Zero-based position in the input array (reserved for future use)
+   * @returns {{ valid: true } | { valid: false, reason: string }}
+   */
+  _validateWallet(wallet, index) { // eslint-disable-line no-unused-vars
+    // Rule 1: reject private key fields
+    if (wallet.secret_key !== undefined || wallet.private_key !== undefined) {
+      return { valid: false, reason: 'private_key_not_accepted' };
+    }
+
+    // Rule 2: public_key must be present and a string
+    if (wallet.public_key === undefined || wallet.public_key === null || typeof wallet.public_key !== 'string') {
+      return { valid: false, reason: 'missing_public_key' };
+    }
+
+    // Rule 3: public_key must be a valid Stellar Ed25519 public key
+    if (!StellarSdk.StrKey.isValidEd25519PublicKey(wallet.public_key)) {
+      return { valid: false, reason: 'invalid_address' };
+    }
+
+    return { valid: true };
+  }
+
+  /**
+   * Import a batch of wallets.
+   *
+   * Processing steps:
+   * 1. Validate each wallet with `_validateWallet`.
+   * 2. Build an intra-batch seen-set; mark subsequent occurrences of the same
+   *    `public_key` as `duplicate`.
+   * 3. For all valid, non-intra-batch-duplicate keys, call
+   *    `WalletService.getWalletByAddress` to detect data-store duplicates.
+   * 4. For all remaining valid, non-duplicate keys, call
+   *    `StellarService.getAccountInfo` concurrently via `Promise.allSettled`.
+   * 5. Map Horizon outcomes: balance → success; notFound → unfunded_account;
+   *    error → horizon_unavailable.
+   * 6. For each wallet that passed all checks, call
+   *    `WalletService.createWalletRecord(key, balance)`.
+   * 7. Assemble the `results` array in original input order.
+   * 8. Compute and return the `summary` object.
+   *
+   * @param {Array<Object>} wallets  - Array of wallet objects from the request body
+   * @param {string}        clientId - Authenticated client identifier (for audit use by caller)
+   * @returns {Promise<{ results: Array<ImportResult>, summary: Summary }>}
+   *
+   * @typedef {Object} ImportResult
+   * @property {string}      public_key - The submitted public key (or empty string if missing)
+   * @property {'success'|'duplicate'|'failed'} status
+   * @property {string|null} reason     - Non-null when status is 'failed' or 'duplicate'
+   * @property {string|null} id         - Wallet record id when status is 'success', else null
+   *
+   * @typedef {Object} Summary
+   * @property {number} total
+   * @property {number} succeeded
+   * @property {number} duplicates
+   * @property {number} failed
+   */
+  async importBatch(wallets, clientId) { // eslint-disable-line no-unused-vars
+    const count = wallets.length;
+
+    // Per-wallet state tracked by original index
+    // Each slot: { publicKey, status, reason, id }
+    const slots = new Array(count).fill(null).map(() => ({
+      publicKey: null,
+      status: null,
+      reason: null,
+      id: null,
+    }));
+
+    // ── Step 1: Validate each wallet ────────────────────────────────────────
+    for (let i = 0; i < count; i++) {
+      const wallet = wallets[i];
+      const publicKey = typeof wallet.public_key === 'string' ? wallet.public_key : '';
+      slots[i].publicKey = publicKey;
+
+      const validation = this._validateWallet(wallet, i);
+      if (!validation.valid) {
+        slots[i].status = 'failed';
+        slots[i].reason = validation.reason;
+      }
+    }
+
+    // ── Step 2: Intra-batch duplicate detection ──────────────────────────────
+    // Only consider wallets that passed validation so far
+    const seenKeys = new Set();
+    for (let i = 0; i < count; i++) {
+      if (slots[i].status !== null) continue; // already failed
+
+      const key = slots[i].publicKey;
+      if (seenKeys.has(key)) {
+        slots[i].status = 'duplicate';
+        slots[i].reason = 'duplicate';
+      } else {
+        seenKeys.add(key);
+      }
+    }
+
+    // ── Step 3: Data-store duplicate check ──────────────────────────────────
+    // Collect indices of wallets still pending (passed validation, not intra-batch dup)
+    const pendingIndices = [];
+    for (let i = 0; i < count; i++) {
+      if (slots[i].status === null) {
+        pendingIndices.push(i);
+      }
+    }
+
+    for (const i of pendingIndices) {
+      const existing = this.walletService.getWalletByAddress(slots[i].publicKey);
+      if (existing) {
+        slots[i].status = 'duplicate';
+        slots[i].reason = 'duplicate';
+      }
+    }
+
+    // ── Step 4 & 5: Concurrent Horizon queries ───────────────────────────────
+    // Re-collect indices still pending after data-store check
+    const horizonIndices = pendingIndices.filter(i => slots[i].status === null);
+
+    if (horizonIndices.length > 0) {
+      const horizonPromises = horizonIndices.map(i =>
+        this.stellarService.getAccountInfo(slots[i].publicKey)
+      );
+
+      const settled = await Promise.allSettled(horizonPromises);
+
+      for (let j = 0; j < horizonIndices.length; j++) {
+        const i = horizonIndices[j];
+        const outcome = settled[j];
+
+        if (outcome.status === 'rejected') {
+          // Promise itself rejected (unexpected — getAccountInfo should not throw)
+          slots[i].status = 'failed';
+          slots[i].reason = 'horizon_unavailable';
+          continue;
+        }
+
+        const result = outcome.value;
+
+        if (result.error) {
+          slots[i].status = 'failed';
+          slots[i].reason = 'horizon_unavailable';
+        } else if (result.notFound) {
+          // Unfunded account — still a success, balance is null
+          slots[i].status = 'success';
+          slots[i].reason = 'unfunded_account';
+          slots[i]._balance = null;
+        } else {
+          // Funded account
+          slots[i].status = 'success';
+          slots[i].reason = null;
+          slots[i]._balance = result.balance;
+        }
+      }
+    }
+
+    // ── Step 6: Persist passing wallets ─────────────────────────────────────
+    for (let i = 0; i < count; i++) {
+      if (slots[i].status === 'success') {
+        const record = this.walletService.createWalletRecord(
+          slots[i].publicKey,
+          slots[i]._balance ?? null
+        );
+        slots[i].id = record.id;
+      }
+    }
+
+    // ── Step 7: Assemble results array ───────────────────────────────────────
+    const results = slots.map(slot => ({
+      public_key: slot.publicKey,
+      status: slot.status,
+      reason: slot.reason,
+      id: slot.id,
+    }));
+
+    // ── Step 8: Compute summary ──────────────────────────────────────────────
+    let succeeded = 0;
+    let duplicates = 0;
+    let failed = 0;
+
+    for (const r of results) {
+      if (r.status === 'success') succeeded++;
+      else if (r.status === 'duplicate') duplicates++;
+      else failed++;
+    }
+
+    const summary = {
+      total: count,
+      succeeded,
+      duplicates,
+      failed,
+    };
+
+    return { results, summary };
+  }
+}
+
+module.exports = BulkWalletImportService;

--- a/src/services/StellarService.js
+++ b/src/services/StellarService.js
@@ -966,6 +966,44 @@ class StellarService extends StellarServiceInterface {
 
 
   /**
+   * Query Horizon for an account and normalise the outcome into a discriminated union.
+   *
+   * This method never throws — all outcomes are returned as plain values so callers
+   * do not need to inspect raw Horizon error shapes.
+   *
+   * @param {string} publicKey - Stellar public key to look up
+   * @returns {Promise<
+   *   { balance: string } |
+   *   { notFound: true } |
+   *   { error: true }
+   * >}
+   *   - `{ balance }` — account exists; `balance` is the native XLM balance string
+   *   - `{ notFound: true }` — Horizon returned 404 (account not yet funded)
+   *   - `{ error: true }` — any other Horizon or network error
+   */
+  async getAccountInfo(publicKey) {
+    try {
+      const account = await this._executeWithRetry(
+        () => this.server.loadAccount(publicKey),
+        'getAccountInfo'
+      );
+      const nativeBalance = account.balances.find(b => b.asset_type === 'native');
+      return { balance: nativeBalance ? nativeBalance.balance : '0' };
+    } catch (error) {
+      const status = error && error.response && error.response.status;
+      if (status === 404) {
+        return { notFound: true };
+      }
+      log.warn('STELLAR_SERVICE', 'getAccountInfo failed with non-404 error', {
+        publicKey,
+        status,
+        error: error.message,
+      });
+      return { error: true };
+    }
+  }
+
+  /**
    * Get the inflation destination for a Stellar account.
    *
    * @param {string} publicKey - Public key of the account to query

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -90,6 +90,25 @@ class WalletService {
   }
 
   /**
+   * Create a wallet record for an existing on-chain account (bulk import).
+   * Unlike `createWallet`, this method does NOT trigger Friendbot funding,
+   * platform sponsorship, or any Stellar network calls — the account already
+   * exists on-chain and its balance has been fetched by the caller.
+   * @param {string} publicKey - Stellar public key (wallet address)
+   * @param {string|null} balance - XLM balance from Horizon, or null for unfunded accounts
+   * @returns {Object} Created wallet record
+   */
+  createWalletRecord(publicKey, balance) {
+    const sanitizedAddress = sanitizeStellarAddress(publicKey);
+
+    return Wallet.create({
+      address: sanitizedAddress,
+      balance: balance ?? null,
+      importedVia: 'bulk-import',
+    });
+  }
+
+  /**
    * Get all wallets
    * @returns {Array} Array of wallet objects
    */


### PR DESCRIPTION
feat: add bulk wallet import with per-wallet validation and result reporting (#427)

Summary
Adds a POST /wallets/bulk-import endpoint that allows organizations to register up to 100 existing Stellar wallets in a single request. Each wallet is validated and checked independently — failures don't block the rest of the batch.

Changes
BulkWalletImportService — new service handling validation, intra-batch dedup, data-store dedup, concurrent Horizon queries, and result assembly
StellarService — added getAccountInfo(publicKey) returning a normalised discriminated union ({ balance } / { notFound } / { error })
WalletService — added createWalletRecord(publicKey, balance) for importing without Friendbot/sponsorship
AuditLogService — added BULK_WALLET_IMPORT action constant
rateLimiter.js
 — added bulkImportRateLimiter (10 req/min per API key)
wallet.js
 — new POST /wallets/bulk-import route
Endpoint
POST /wallets/bulk-import — requires WALLETS_CREATE permission

Request:

{ "wallets": [{ "public_key": "G..." }, ...] }
Response:

{
  "results": [
    { "public_key": "G...", "status": "success", "reason": null, "id": "123" },
    { "public_key": "G...", "status": "duplicate", "reason": "duplicate", "id": null },
    { "public_key": "BAD", "status": "failed", "reason": "invalid_address", "id": null }
  ],
  "summary": { "total": 3, "succeeded": 1, "duplicates": 1, "failed": 1 }
}
Validation & Error Handling
private_key/secret_key fields → per-wallet failed (private_key_not_accepted)
Missing public_key → per-wallet failed (missing_public_key)
Invalid StrKey format → per-wallet failed (invalid_address)
Intra-batch duplicate → per-wallet duplicate
Data-store duplicate → per-wallet duplicate
Horizon 404 → per-wallet success with reason: unfunded_account
Horizon error → per-wallet failed (horizon_unavailable)
Batch > 100 → HTTP 422
Wrong Content-Type → HTTP 415
Rate limit exceeded → HTTP 429 with Retry-After
Security
No private keys accepted at any point
Public keys never logged in audit entries
Rate limited to 10 req/min per authenticated API key
RBAC enforced (WALLETS_CREATE)
Closes
Closes #427