### PR TITLE
feat: implement donation subscription tiers with recurring scheduler …

### DIFF
--- a/docs/features/SUBSCRIPTION_TIERS.md
+++ b/docs/features/SUBSCRIPTION_TIERS.md
@@ -1,0 +1,109 @@
+# Donation Subscription Tiers
+
+## Overview
+
+Subscription tiers let organizations offer structured recurring donation levels (e.g. Bronze $5/month, Silver $25/month, Gold $100/month). Each tier has a fixed amount, interval, and optional benefits description. When a donor subscribes to a tier, a `recurring_donation` schedule is automatically created and picked up by the existing `RecurringDonationScheduler`.
+
+## Database Schema
+
+### `subscription_tiers`
+
+| Column      | Type     | Description                              |
+|-------------|----------|------------------------------------------|
+| `id`        | INTEGER  | Primary key                              |
+| `name`      | TEXT     | Unique tier name (e.g. "Gold")           |
+| `amount`    | REAL     | XLM amount per interval                  |
+| `interval`  | TEXT     | `daily` \| `weekly` \| `monthly`         |
+| `benefits`  | TEXT     | Free-form benefits description (optional)|
+| `createdAt` | DATETIME | Creation timestamp                       |
+
+### `donor_subscriptions`
+
+| Column               | Type     | Description                                    |
+|----------------------|----------|------------------------------------------------|
+| `id`                 | INTEGER  | Primary key                                    |
+| `donorId`            | INTEGER  | FK → `users.id`                                |
+| `tierId`             | INTEGER  | FK → `subscription_tiers.id`                   |
+| `recurringDonationId`| INTEGER  | FK → `recurring_donations.id`                  |
+| `status`             | TEXT     | `active` \| `cancelled`                        |
+| `createdAt`          | DATETIME | Subscription creation timestamp                |
+| `cancelledAt`        | DATETIME | Cancellation timestamp (null if active)        |
+
+## API
+
+### `POST /tiers` — Create a tier
+
+Requires `ADMIN_ALL` permission.
+
+```json
+{ "name": "Gold", "amount": 100, "interval": "monthly", "benefits": "Priority support" }
+```
+
+Response `201`:
+```json
+{ "success": true, "data": { "id": 3, "name": "Gold", "amount": 100, "interval": "monthly", "benefits": "Priority support", "createdAt": "..." } }
+```
+
+### `GET /tiers` — List all tiers
+
+Requires `donations:read`. Returns tiers ordered by amount ascending.
+
+### `POST /tiers/:id/subscribe` — Subscribe a donor
+
+Requires `stream:create`. Creates a `recurring_donation` schedule using the tier's amount and interval.
+
+```json
+{ "donorPublicKey": "G...", "recipientPublicKey": "G...", "startDate": "2026-04-01" }
+```
+
+Response `201`:
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "tierId": 3,
+    "tierName": "Gold",
+    "tierAmount": 100,
+    "tierInterval": "monthly",
+    "recurringDonationId": 42,
+    "status": "active",
+    "createdAt": "..."
+  }
+}
+```
+
+### `DELETE /tiers/subscriptions/:subId` — Cancel a subscription
+
+Requires `stream:delete`. Sets subscription status to `cancelled` and cancels the linked recurring donation schedule.
+
+### `GET /tiers/analytics` — Tier analytics
+
+Requires `stats:admin`. Returns subscriber counts and active revenue per tier.
+
+```json
+{
+  "success": true,
+  "data": [
+    { "tierId": 1, "name": "Bronze", "amount": 5, "interval": "monthly", "activeSubscribers": 42, "cancelledSubscribers": 3, "totalSubscribers": 45, "activeRevenue": 210 },
+    { "tierId": 2, "name": "Gold",   "amount": 100, "interval": "monthly", "activeSubscribers": 8, "cancelledSubscribers": 1, "totalSubscribers": 9, "activeRevenue": 800 }
+  ]
+}
+```
+
+## Scheduler Integration
+
+Subscribing a donor calls `RecurringDonationScheduler.calculateNextExecutionDate()` to determine the first execution date, then inserts a row into `recurring_donations` with the tier's `amount` and `interval`. The scheduler picks it up on its next poll cycle (every 60 seconds) and executes it like any other recurring donation.
+
+## Security Assumptions
+
+- **Tier amount immutability**: Once a subscription is created, the recurring donation schedule stores the amount at subscription time. Changing a tier's amount does not retroactively affect existing subscriptions.
+- **Subscription cancellation**: Cancelling a subscription also cancels the linked `recurring_donation` schedule, preventing future executions.
+- **Duplicate prevention**: A donor cannot have two active subscriptions to the same tier simultaneously.
+- **Admin-only tier creation**: Only admin API keys can define tiers. Subscription enrollment uses the standard `stream:create` permission.
+
+## Running the Migration
+
+```bash
+node src/scripts/migrations/addSubscriptionTiers.js
+```

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -29,6 +29,7 @@ const matchingProgramsAdminRoutes = require('./admin/matchingPrograms');
 const networkRoutes = require('./network');
 const webhooksRoutes = require('./webhooks');
 const campaignsRoutes = require('./campaigns');
+const tiersRoutes = require('./tiers');
 const offersRoutes = require('./offers');
 const tagsRoutes = require('./tags');
 const leaderboardRoutes = require('./leaderboard');
@@ -183,6 +184,7 @@ app.use('/admin/transactions', (req, res, next) => {
 app.use('/network', networkRoutes);
 app.use('/webhooks', webhooksRoutes);
 app.use('/campaigns', campaignsRoutes);
+app.use('/tiers', tiersRoutes);
 app.use('/offers', offersRoutes);
 app.use('/tags', tagsRoutes);
 app.use('/leaderboard', leaderboardRoutes);

--- a/src/routes/tiers.js
+++ b/src/routes/tiers.js
@@ -1,0 +1,212 @@
+/**
+ * Subscription Tier Routes - API Endpoint Layer
+ *
+ * RESPONSIBILITY: HTTP request handling for tier management and donor enrollment
+ * OWNER: Backend Team
+ * DEPENDENCIES: SubscriptionTierService, middleware (auth, RBAC)
+ *
+ * Endpoints:
+ *   POST  /tiers                    – create a tier (admin)
+ *   GET   /tiers                    – list all tiers (authenticated)
+ *   POST  /tiers/:id/subscribe      – subscribe a donor to a tier
+ *   DELETE /tiers/subscriptions/:subId – cancel a subscription
+ *   GET   /tiers/analytics          – tier analytics (admin)
+ */
+
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const { checkPermission } = require('../middleware/rbac');
+const { PERMISSIONS } = require('../utils/permissions');
+const SubscriptionTierService = require('../services/SubscriptionTierService');
+const serviceContainer = require('../config/serviceContainer');
+const AuditLogService = require('../services/AuditLogService');
+
+/** Lazy singleton — avoids circular-require issues at module load time */
+function getTierService() {
+  return new SubscriptionTierService(serviceContainer.getRecurringDonationScheduler());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /tiers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @route   POST /tiers
+ * @desc    Create a new subscription tier
+ * @access  admin (ADMIN_ALL)
+ *
+ * @body {string} name              - Unique tier name (e.g. "Gold")
+ * @body {number} amount            - XLM amount per interval
+ * @body {string} [interval]        - daily | weekly | monthly (default: monthly)
+ * @body {string|Object} [benefits] - Free-form benefits description
+ */
+router.post('/', checkPermission(PERMISSIONS.ADMIN_ALL), async (req, res, next) => {
+  try {
+    const { name, amount, interval, benefits } = req.body;
+    const tier = await getTierService().createTier({ name, amount, interval, benefits });
+
+    await AuditLogService.log({
+      category: AuditLogService.CATEGORY.CONFIGURATION,
+      action: 'SUBSCRIPTION_TIER_CREATED',
+      severity: AuditLogService.SEVERITY.MEDIUM,
+      result: 'SUCCESS',
+      userId: req.user && req.user.id,
+      requestId: req.id,
+      ipAddress: req.ip,
+      resource: `/tiers/${tier.id}`,
+      details: { tierId: tier.id, name: tier.name, amount: tier.amount },
+    }).catch(() => {});
+
+    res.status(201).json({ success: true, data: tier });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /tiers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @route   GET /tiers
+ * @desc    List all subscription tiers
+ * @access  donations:read
+ */
+router.get('/', checkPermission(PERMISSIONS.DONATIONS_READ), async (req, res, next) => {
+  try {
+    const tiers = await getTierService().listTiers();
+    res.json({ success: true, data: tiers, count: tiers.length });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /tiers/analytics
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @route   GET /tiers/analytics
+ * @desc    Tier analytics: subscriber counts and revenue per tier
+ * @access  stats:admin
+ */
+router.get('/analytics', checkPermission(PERMISSIONS.STATS_ADMIN), async (req, res, next) => {
+  try {
+    const analytics = await getTierService().getTierAnalytics();
+
+    await AuditLogService.log({
+      category: AuditLogService.CATEGORY.DATA_ACCESS,
+      action: 'TIER_ANALYTICS_ACCESSED',
+      severity: AuditLogService.SEVERITY.LOW,
+      result: 'SUCCESS',
+      userId: req.user && req.user.id,
+      requestId: req.id,
+      ipAddress: req.ip,
+      resource: '/tiers/analytics',
+      details: {},
+    }).catch(() => {});
+
+    res.json({ success: true, data: analytics });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /tiers/:id/subscribe
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @route   POST /tiers/:id/subscribe
+ * @desc    Subscribe a donor to a tier (creates a recurring donation schedule)
+ * @access  stream:create
+ *
+ * @param {string} id                    - Tier ID
+ * @body  {string} donorPublicKey        - Donor's Stellar public key
+ * @body  {string} recipientPublicKey    - Recipient's Stellar public key
+ * @body  {string} [startDate]           - ISO date for first execution
+ */
+router.post('/:id/subscribe', checkPermission(PERMISSIONS.STREAM_CREATE), async (req, res, next) => {
+  try {
+    const tierId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(tierId) || tierId < 1) {
+      return res.status(400).json({ success: false, error: 'Invalid tier ID' });
+    }
+
+    const { donorPublicKey, recipientPublicKey, startDate } = req.body;
+
+    if (!donorPublicKey || !recipientPublicKey) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required fields: donorPublicKey, recipientPublicKey',
+      });
+    }
+
+    const subscription = await getTierService().subscribe({
+      tierId,
+      donorPublicKey,
+      recipientPublicKey,
+      startDate,
+    });
+
+    await AuditLogService.log({
+      category: AuditLogService.CATEGORY.FINANCIAL_OPERATION,
+      action: 'TIER_SUBSCRIPTION_CREATED',
+      severity: AuditLogService.SEVERITY.MEDIUM,
+      result: 'SUCCESS',
+      userId: req.user && req.user.id,
+      requestId: req.id,
+      ipAddress: req.ip,
+      resource: `/tiers/${tierId}/subscribe`,
+      details: {
+        subscriptionId: subscription.id,
+        tierId,
+        recurringDonationId: subscription.recurringDonationId,
+      },
+    }).catch(() => {});
+
+    res.status(201).json({ success: true, data: subscription });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /tiers/subscriptions/:subId
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @route   DELETE /tiers/subscriptions/:subId
+ * @desc    Cancel a donor subscription (also cancels the recurring donation)
+ * @access  stream:delete
+ */
+router.delete('/subscriptions/:subId', checkPermission(PERMISSIONS.STREAM_DELETE), async (req, res, next) => {
+  try {
+    const subId = parseInt(req.params.subId, 10);
+    if (!Number.isInteger(subId) || subId < 1) {
+      return res.status(400).json({ success: false, error: 'Invalid subscription ID' });
+    }
+
+    const subscription = await getTierService().cancelSubscription(subId);
+
+    await AuditLogService.log({
+      category: AuditLogService.CATEGORY.FINANCIAL_OPERATION,
+      action: 'TIER_SUBSCRIPTION_CANCELLED',
+      severity: AuditLogService.SEVERITY.MEDIUM,
+      result: 'SUCCESS',
+      userId: req.user && req.user.id,
+      requestId: req.id,
+      ipAddress: req.ip,
+      resource: `/tiers/subscriptions/${subId}`,
+      details: { subscriptionId: subId },
+    }).catch(() => {});
+
+    res.json({ success: true, data: subscription });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/src/scripts/migrations/addSubscriptionTiers.js
+++ b/src/scripts/migrations/addSubscriptionTiers.js
@@ -1,0 +1,64 @@
+/**
+ * Migration: Add subscription_tiers and donor_subscriptions tables
+ *
+ * Creates:
+ *   subscription_tiers   – tier definitions (name, amount, interval, benefits)
+ *   donor_subscriptions  – links donors to tiers and their recurring_donation schedule
+ */
+
+'use strict';
+
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const DB_PATH = path.join(__dirname, '../../../data/stellar_donations.db');
+
+function runMigration() {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(DB_PATH, (err) => {
+      if (err) return reject(new Error(`Failed to connect: ${err.message}`));
+
+      db.serialize(() => {
+        db.run(`
+          CREATE TABLE IF NOT EXISTS subscription_tiers (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            name        TEXT    NOT NULL UNIQUE,
+            amount      REAL    NOT NULL,
+            interval    TEXT    NOT NULL DEFAULT 'monthly',
+            benefits    TEXT,
+            createdAt   DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updatedAt   DATETIME DEFAULT CURRENT_TIMESTAMP
+          )
+        `, (err) => { if (err) console.warn('subscription_tiers:', err.message); });
+
+        db.run(`
+          CREATE TABLE IF NOT EXISTS donor_subscriptions (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            donorId             INTEGER NOT NULL,
+            tierId              INTEGER NOT NULL,
+            recurringDonationId INTEGER,
+            status              TEXT    NOT NULL DEFAULT 'active',
+            createdAt           DATETIME DEFAULT CURRENT_TIMESTAMP,
+            cancelledAt         DATETIME DEFAULT NULL,
+            FOREIGN KEY (donorId)             REFERENCES users(id),
+            FOREIGN KEY (tierId)              REFERENCES subscription_tiers(id),
+            FOREIGN KEY (recurringDonationId) REFERENCES recurring_donations(id)
+          )
+        `, (err) => {
+          db.close();
+          if (err) return reject(err);
+          console.log('✓ Migration addSubscriptionTiers complete');
+          resolve();
+        });
+      });
+    });
+  });
+}
+
+if (require.main === module) {
+  runMigration()
+    .then(() => process.exit(0))
+    .catch((err) => { console.error(err); process.exit(1); });
+}
+
+module.exports = { runMigration };

--- a/src/services/SubscriptionTierService.js
+++ b/src/services/SubscriptionTierService.js
@@ -1,0 +1,335 @@
+/**
+ * Subscription Tier Service
+ *
+ * RESPONSIBILITY: Tier definition management, donor enrollment, and tier analytics
+ * OWNER: Backend Team
+ * DEPENDENCIES: Database, RecurringDonationScheduler
+ *
+ * Handles all business logic for subscription tiers:
+ *  - Creating and listing tiers
+ *  - Enrolling donors (creates a recurring_donation schedule under the hood)
+ *  - Cancelling subscriptions
+ *  - Tier-based analytics (subscriber counts, revenue per tier)
+ */
+
+'use strict';
+
+const Database = require('../utils/database');
+const { ValidationError, NotFoundError, DuplicateError, ERROR_CODES } = require('../utils/errors');
+const { SCHEDULE_STATUS, DONATION_FREQUENCIES } = require('../constants');
+const log = require('../utils/log');
+
+/** Allowed interval values for a tier */
+const VALID_INTERVALS = Object.freeze([
+  DONATION_FREQUENCIES.DAILY,
+  DONATION_FREQUENCIES.WEEKLY,
+  DONATION_FREQUENCIES.MONTHLY,
+]);
+
+class SubscriptionTierService {
+  /**
+   * @param {Object} recurringDonationScheduler - RecurringDonationScheduler instance
+   */
+  constructor(recurringDonationScheduler) {
+    this.scheduler = recurringDonationScheduler;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tier management
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Create a new subscription tier.
+   *
+   * @param {Object} params
+   * @param {string} params.name     - Unique tier name (e.g. "Gold")
+   * @param {number} params.amount   - Donation amount per interval (XLM)
+   * @param {string} [params.interval='monthly'] - Frequency: daily | weekly | monthly
+   * @param {string|Object} [params.benefits]    - Free-form benefits description or JSON
+   * @returns {Promise<Object>} Created tier row
+   * @throws {ValidationError} on invalid input
+   * @throws {DuplicateError}  if name already exists
+   */
+  async createTier({ name, amount, interval = 'monthly', benefits }) {
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      throw new ValidationError('name is required', null, ERROR_CODES.MISSING_REQUIRED_FIELD);
+    }
+
+    const parsedAmount = parseFloat(amount);
+    if (!isFinite(parsedAmount) || parsedAmount <= 0) {
+      throw new ValidationError('amount must be a positive number', null, ERROR_CODES.INVALID_AMOUNT);
+    }
+
+    if (!VALID_INTERVALS.includes(interval)) {
+      throw new ValidationError(
+        `interval must be one of: ${VALID_INTERVALS.join(', ')}`,
+        null,
+        ERROR_CODES.INVALID_REQUEST
+      );
+    }
+
+    const benefitsStr = benefits
+      ? (typeof benefits === 'string' ? benefits : JSON.stringify(benefits))
+      : null;
+
+    try {
+      const result = await Database.run(
+        `INSERT INTO subscription_tiers (name, amount, interval, benefits)
+         VALUES (?, ?, ?, ?)`,
+        [name.trim(), parsedAmount, interval, benefitsStr]
+      );
+
+      log.info('SUBSCRIPTION_TIER_SERVICE', 'Tier created', { tierId: result.id, name, amount, interval });
+      return this._getTierById(result.id);
+    } catch (err) {
+      if (err.code === 'SQLITE_CONSTRAINT' || (err.message && err.message.includes('UNIQUE'))) {
+        throw new DuplicateError(`Tier with name "${name}" already exists`);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * List all subscription tiers.
+   *
+   * @returns {Promise<Object[]>} Array of tier objects
+   */
+  async listTiers() {
+    const rows = await Database.query(
+      'SELECT * FROM subscription_tiers ORDER BY amount ASC'
+    );
+    return rows.map(this._formatTier);
+  }
+
+  /**
+   * Get a single tier by ID.
+   *
+   * @param {number|string} id - Tier ID
+   * @returns {Promise<Object>} Tier object
+   * @throws {NotFoundError} if not found
+   */
+  async getTierById(id) {
+    return this._getTierById(id);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Subscriptions
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Subscribe a donor to a tier.
+   * Creates a recurring_donation schedule using the tier's amount and interval,
+   * then records the subscription linking donor → tier → schedule.
+   *
+   * @param {Object} params
+   * @param {number|string} params.tierId           - Tier ID to subscribe to
+   * @param {string}        params.donorPublicKey   - Donor's Stellar public key
+   * @param {string}        params.recipientPublicKey - Recipient's Stellar public key
+   * @param {string}        [params.startDate]      - ISO date for first execution
+   * @returns {Promise<Object>} Subscription record with tier and schedule details
+   * @throws {NotFoundError}   if tier, donor, or recipient not found
+   * @throws {DuplicateError}  if donor already has an active subscription to this tier
+   */
+  async subscribe({ tierId, donorPublicKey, recipientPublicKey, startDate }) {
+    const tier = await this._getTierById(tierId);
+
+    const donor = await Database.get(
+      'SELECT id, publicKey FROM users WHERE publicKey = ?',
+      [donorPublicKey]
+    );
+    if (!donor) {
+      throw new NotFoundError('Donor wallet not found', ERROR_CODES.WALLET_NOT_FOUND);
+    }
+
+    const recipient = await Database.get(
+      'SELECT id, publicKey FROM users WHERE publicKey = ?',
+      [recipientPublicKey]
+    );
+    if (!recipient) {
+      throw new NotFoundError('Recipient wallet not found', ERROR_CODES.WALLET_NOT_FOUND);
+    }
+
+    if (donor.id === recipient.id) {
+      throw new ValidationError('Donor and recipient cannot be the same', null, ERROR_CODES.INVALID_REQUEST);
+    }
+
+    // Prevent duplicate active subscriptions to the same tier
+    const existing = await Database.get(
+      `SELECT id FROM donor_subscriptions
+       WHERE donorId = ? AND tierId = ? AND status = 'active'`,
+      [donor.id, tier.id]
+    );
+    if (existing) {
+      throw new DuplicateError('Donor already has an active subscription to this tier');
+    }
+
+    // Calculate first execution date
+    const firstExecution = startDate
+      ? new Date(startDate).toISOString()
+      : this.scheduler.calculateNextExecutionDate(new Date(), tier.interval).toISOString();
+
+    // Create the recurring donation schedule
+    const scheduleResult = await Database.run(
+      `INSERT INTO recurring_donations
+         (donorId, recipientId, amount, frequency, nextExecutionDate, status)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [donor.id, recipient.id, tier.amount, tier.interval, firstExecution, SCHEDULE_STATUS.ACTIVE]
+    );
+
+    // Record the subscription
+    const subResult = await Database.run(
+      `INSERT INTO donor_subscriptions (donorId, tierId, recurringDonationId, status)
+       VALUES (?, ?, ?, 'active')`,
+      [donor.id, tier.id, scheduleResult.id]
+    );
+
+    log.info('SUBSCRIPTION_TIER_SERVICE', 'Donor subscribed to tier', {
+      subscriptionId: subResult.id,
+      donorId: donor.id,
+      tierId: tier.id,
+      scheduleId: scheduleResult.id,
+    });
+
+    return this._getSubscriptionById(subResult.id);
+  }
+
+  /**
+   * Cancel a donor's subscription.
+   * Sets the subscription status to 'cancelled' and cancels the linked recurring schedule.
+   *
+   * @param {number|string} subscriptionId - Subscription ID
+   * @returns {Promise<Object>} Updated subscription record
+   * @throws {NotFoundError} if subscription not found
+   */
+  async cancelSubscription(subscriptionId) {
+    const sub = await Database.get(
+      'SELECT * FROM donor_subscriptions WHERE id = ?',
+      [subscriptionId]
+    );
+    if (!sub) {
+      throw new NotFoundError('Subscription not found', ERROR_CODES.NOT_FOUND);
+    }
+
+    await Database.run(
+      `UPDATE donor_subscriptions SET status = 'cancelled', cancelledAt = CURRENT_TIMESTAMP
+       WHERE id = ?`,
+      [subscriptionId]
+    );
+
+    if (sub.recurringDonationId) {
+      await Database.run(
+        `UPDATE recurring_donations SET status = ? WHERE id = ?`,
+        [SCHEDULE_STATUS.CANCELLED, sub.recurringDonationId]
+      );
+    }
+
+    log.info('SUBSCRIPTION_TIER_SERVICE', 'Subscription cancelled', { subscriptionId });
+    return this._getSubscriptionById(subscriptionId);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Analytics
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Get tier-based analytics: subscriber counts and total projected monthly revenue.
+   *
+   * @returns {Promise<Object[]>} Array of analytics objects per tier
+   */
+  async getTierAnalytics() {
+    const rows = await Database.query(
+      `SELECT
+         st.id,
+         st.name,
+         st.amount,
+         st.interval,
+         COUNT(CASE WHEN ds.status = 'active' THEN 1 END)     AS activeSubscribers,
+         COUNT(CASE WHEN ds.status = 'cancelled' THEN 1 END)  AS cancelledSubscribers,
+         COUNT(ds.id)                                          AS totalSubscribers,
+         COALESCE(SUM(CASE WHEN ds.status = 'active' THEN st.amount END), 0) AS activeRevenue
+       FROM subscription_tiers st
+       LEFT JOIN donor_subscriptions ds ON ds.tierId = st.id
+       GROUP BY st.id
+       ORDER BY st.amount ASC`
+    );
+
+    return rows.map((row) => ({
+      tierId: row.id,
+      name: row.name,
+      amount: row.amount,
+      interval: row.interval,
+      activeSubscribers: row.activeSubscribers || 0,
+      cancelledSubscribers: row.cancelledSubscribers || 0,
+      totalSubscribers: row.totalSubscribers || 0,
+      activeRevenue: parseFloat((row.activeRevenue || 0).toFixed(7)),
+    }));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Private helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * @private
+   */
+  async _getTierById(id) {
+    const row = await Database.get('SELECT * FROM subscription_tiers WHERE id = ?', [id]);
+    if (!row) {
+      throw new NotFoundError(`Subscription tier ${id} not found`, ERROR_CODES.NOT_FOUND);
+    }
+    return this._formatTier(row);
+  }
+
+  /**
+   * @private
+   */
+  async _getSubscriptionById(id) {
+    const row = await Database.get(
+      `SELECT ds.*, st.name AS tierName, st.amount AS tierAmount, st.interval AS tierInterval
+       FROM donor_subscriptions ds
+       JOIN subscription_tiers st ON ds.tierId = st.id
+       WHERE ds.id = ?`,
+      [id]
+    );
+    if (!row) throw new NotFoundError('Subscription not found', ERROR_CODES.NOT_FOUND);
+    return this._formatSubscription(row);
+  }
+
+  /**
+   * @private
+   */
+  _formatTier(row) {
+    let benefits = row.benefits;
+    try {
+      if (benefits && benefits.startsWith('{')) benefits = JSON.parse(benefits);
+    } catch (_) { /* keep as string */ }
+    return {
+      id: row.id,
+      name: row.name,
+      amount: row.amount,
+      interval: row.interval,
+      benefits,
+      createdAt: row.createdAt,
+    };
+  }
+
+  /**
+   * @private
+   */
+  _formatSubscription(row) {
+    return {
+      id: row.id,
+      donorId: row.donorId,
+      tierId: row.tierId,
+      tierName: row.tierName,
+      tierAmount: row.tierAmount,
+      tierInterval: row.tierInterval,
+      recurringDonationId: row.recurringDonationId,
+      status: row.status,
+      createdAt: row.createdAt,
+      cancelledAt: row.cancelledAt || null,
+    };
+  }
+}
+
+module.exports = SubscriptionTierService;

--- a/tests/subscription-tiers.test.js
+++ b/tests/subscription-tiers.test.js
@@ -1,0 +1,501 @@
+'use strict';
+
+/**
+ * Subscription Tiers Tests
+ *
+ * Covers:
+ * - SubscriptionTierService: tier creation, listing, subscription, cancellation, analytics
+ * - POST /tiers, GET /tiers, POST /tiers/:id/subscribe, DELETE /tiers/subscriptions/:id
+ * - GET /tiers/analytics
+ * - Recurring donation created from tier config
+ * - Auth enforcement
+ */
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../src/utils/database', () => ({
+  run: jest.fn(),
+  get: jest.fn(),
+  query: jest.fn(),
+}));
+jest.mock('../src/middleware/rbac', () => ({
+  checkPermission: () => (req, res, next) => {
+    req.user = { id: 'admin-user', role: 'admin' };
+    next();
+  },
+  requireAdmin: () => (req, res, next) => {
+    req.user = { id: 'admin-user', role: 'admin' };
+    next();
+  },
+}));
+jest.mock('../src/services/AuditLogService', () => ({
+  log: jest.fn().mockResolvedValue(undefined),
+  CATEGORY: { CONFIGURATION: 'CONFIGURATION', DATA_ACCESS: 'DATA_ACCESS', FINANCIAL_OPERATION: 'FINANCIAL_OPERATION', AUTHORIZATION: 'AUTHORIZATION' },
+  ACTION: {},
+  SEVERITY: { HIGH: 'HIGH', MEDIUM: 'MEDIUM', LOW: 'LOW' },
+}));
+jest.mock('../src/config/serviceContainer', () => ({
+  getRecurringDonationScheduler: jest.fn(() => mockScheduler),
+  getStellarService: jest.fn(() => ({})),
+}));
+
+// ─── Shared mock scheduler ────────────────────────────────────────────────────
+
+const mockScheduler = {
+  calculateNextExecutionDate: jest.fn((now, _interval) => {
+    const d = new Date(now);
+    d.setMonth(d.getMonth() + 1);
+    return d;
+  }),
+};
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+const Database = require('../src/utils/database');
+const SubscriptionTierService = require('../src/services/SubscriptionTierService');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeService() {
+  return new SubscriptionTierService(mockScheduler);
+}
+
+const TIER_ROW = { id: 1, name: 'Silver', amount: 25, interval: 'monthly', benefits: 'Newsletter', createdAt: '2026-01-01' };
+const DONOR_ROW = { id: 10, publicKey: 'GDONOR123' };
+const RECIPIENT_ROW = { id: 20, publicKey: 'GRECIP456' };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SubscriptionTierService unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SubscriptionTierService.createTier()', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('creates a tier and returns formatted row', async () => {
+    Database.run.mockResolvedValue({ id: 1 });
+    Database.get.mockResolvedValue(TIER_ROW);
+
+    const svc = makeService();
+    const tier = await svc.createTier({ name: 'Silver', amount: 25, interval: 'monthly', benefits: 'Newsletter' });
+
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO subscription_tiers'),
+      ['Silver', 25, 'monthly', 'Newsletter']
+    );
+    expect(tier.name).toBe('Silver');
+    expect(tier.amount).toBe(25);
+  });
+
+  test('defaults interval to monthly', async () => {
+    Database.run.mockResolvedValue({ id: 2 });
+    Database.get.mockResolvedValue({ ...TIER_ROW, id: 2 });
+
+    const svc = makeService();
+    await svc.createTier({ name: 'Bronze', amount: 5 });
+
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.any(String),
+      ['Bronze', 5, 'monthly', null]
+    );
+  });
+
+  test('throws ValidationError for missing name', async () => {
+    const svc = makeService();
+    await expect(svc.createTier({ amount: 10 })).rejects.toThrow('name is required');
+  });
+
+  test('throws ValidationError for non-positive amount', async () => {
+    const svc = makeService();
+    await expect(svc.createTier({ name: 'X', amount: -5 })).rejects.toThrow('amount must be a positive number');
+    await expect(svc.createTier({ name: 'X', amount: 0 })).rejects.toThrow('amount must be a positive number');
+  });
+
+  test('throws ValidationError for invalid interval', async () => {
+    const svc = makeService();
+    await expect(svc.createTier({ name: 'X', amount: 10, interval: 'yearly' })).rejects.toThrow('interval must be one of');
+  });
+
+  test('throws DuplicateError on UNIQUE constraint violation', async () => {
+    const uniqueErr = new Error('UNIQUE constraint failed');
+    uniqueErr.code = 'SQLITE_CONSTRAINT';
+    Database.run.mockRejectedValue(uniqueErr);
+
+    const svc = makeService();
+    await expect(svc.createTier({ name: 'Silver', amount: 25 })).rejects.toThrow('already exists');
+  });
+});
+
+describe('SubscriptionTierService.listTiers()', () => {
+  test('returns all tiers ordered by amount', async () => {
+    Database.query.mockResolvedValue([
+      { id: 1, name: 'Bronze', amount: 5, interval: 'monthly', benefits: null, createdAt: '2026-01-01' },
+      { id: 2, name: 'Silver', amount: 25, interval: 'monthly', benefits: null, createdAt: '2026-01-01' },
+    ]);
+
+    const svc = makeService();
+    const tiers = await svc.listTiers();
+
+    expect(tiers).toHaveLength(2);
+    expect(tiers[0].name).toBe('Bronze');
+    expect(tiers[1].name).toBe('Silver');
+  });
+});
+
+describe('SubscriptionTierService.subscribe()', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('creates recurring donation and subscription record', async () => {
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)          // getTierById
+      .mockResolvedValueOnce(DONOR_ROW)          // donor lookup
+      .mockResolvedValueOnce(RECIPIENT_ROW)      // recipient lookup
+      .mockResolvedValueOnce(null)               // no existing active subscription
+      .mockResolvedValueOnce({                   // getSubscriptionById
+        id: 1, donorId: 10, tierId: 1, recurringDonationId: 5,
+        status: 'active', createdAt: '2026-01-01', cancelledAt: null,
+        tierName: 'Silver', tierAmount: 25, tierInterval: 'monthly',
+      });
+
+    Database.run
+      .mockResolvedValueOnce({ id: 5 })  // INSERT recurring_donations
+      .mockResolvedValueOnce({ id: 1 }); // INSERT donor_subscriptions
+
+    const svc = makeService();
+    const sub = await svc.subscribe({
+      tierId: 1,
+      donorPublicKey: 'GDONOR123',
+      recipientPublicKey: 'GRECIP456',
+    });
+
+    // Recurring donation was created with tier's amount and interval
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO recurring_donations'),
+      expect.arrayContaining([10, 20, 25, 'monthly'])
+    );
+
+    expect(sub.recurringDonationId).toBe(5);
+    expect(sub.status).toBe('active');
+    expect(sub.tierName).toBe('Silver');
+  });
+
+  test('throws NotFoundError when donor does not exist', async () => {
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)  // tier
+      .mockResolvedValueOnce(null);     // donor not found
+
+    const svc = makeService();
+    await expect(svc.subscribe({ tierId: 1, donorPublicKey: 'GNONE', recipientPublicKey: 'GRECIP456' }))
+      .rejects.toThrow('Donor wallet not found');
+  });
+
+  test('throws NotFoundError when recipient does not exist', async () => {
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)
+      .mockResolvedValueOnce(DONOR_ROW)
+      .mockResolvedValueOnce(null); // recipient not found
+
+    const svc = makeService();
+    await expect(svc.subscribe({ tierId: 1, donorPublicKey: 'GDONOR123', recipientPublicKey: 'GNONE' }))
+      .rejects.toThrow('Recipient wallet not found');
+  });
+
+  test('throws ValidationError for self-donation', async () => {
+    const sameUser = { id: 10, publicKey: 'GSAME' };
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)
+      .mockResolvedValueOnce(sameUser)
+      .mockResolvedValueOnce(sameUser);
+
+    const svc = makeService();
+    await expect(svc.subscribe({ tierId: 1, donorPublicKey: 'GSAME', recipientPublicKey: 'GSAME' }))
+      .rejects.toThrow('cannot be the same');
+  });
+
+  test('throws DuplicateError when donor already has active subscription to tier', async () => {
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)
+      .mockResolvedValueOnce(DONOR_ROW)
+      .mockResolvedValueOnce(RECIPIENT_ROW)
+      .mockResolvedValueOnce({ id: 99 }); // existing active subscription
+
+    const svc = makeService();
+    await expect(svc.subscribe({ tierId: 1, donorPublicKey: 'GDONOR123', recipientPublicKey: 'GRECIP456' }))
+      .rejects.toThrow('already has an active subscription');
+  });
+
+  test('uses scheduler.calculateNextExecutionDate when no startDate provided', async () => {
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)
+      .mockResolvedValueOnce(DONOR_ROW)
+      .mockResolvedValueOnce(RECIPIENT_ROW)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 1, donorId: 10, tierId: 1, recurringDonationId: 5,
+        status: 'active', createdAt: '2026-01-01', cancelledAt: null,
+        tierName: 'Silver', tierAmount: 25, tierInterval: 'monthly',
+      });
+    Database.run.mockResolvedValue({ id: 1 });
+
+    const svc = makeService();
+    await svc.subscribe({ tierId: 1, donorPublicKey: 'GDONOR123', recipientPublicKey: 'GRECIP456' });
+
+    expect(mockScheduler.calculateNextExecutionDate).toHaveBeenCalled();
+  });
+});
+
+describe('SubscriptionTierService.cancelSubscription()', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('cancels subscription and linked recurring donation', async () => {
+    const subRow = { id: 1, donorId: 10, tierId: 1, recurringDonationId: 5, status: 'active' };
+    const cancelledRow = {
+      id: 1, donorId: 10, tierId: 1, recurringDonationId: 5,
+      status: 'cancelled', createdAt: '2026-01-01', cancelledAt: '2026-03-27',
+      tierName: 'Silver', tierAmount: 25, tierInterval: 'monthly',
+    };
+
+    Database.get
+      .mockResolvedValueOnce(subRow)     // find subscription
+      .mockResolvedValueOnce(cancelledRow); // getSubscriptionById after update
+    Database.run.mockResolvedValue({ changes: 1 });
+
+    const svc = makeService();
+    const result = await svc.cancelSubscription(1);
+
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'cancelled'"),
+      [1]
+    );
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE recurring_donations'),
+      ['cancelled', 5]
+    );
+    expect(result.status).toBe('cancelled');
+  });
+
+  test('throws NotFoundError for unknown subscription', async () => {
+    Database.get.mockResolvedValueOnce(null);
+    const svc = makeService();
+    await expect(svc.cancelSubscription(999)).rejects.toThrow('Subscription not found');
+  });
+});
+
+describe('SubscriptionTierService.getTierAnalytics()', () => {
+  test('returns subscriber counts and revenue per tier', async () => {
+    Database.query.mockResolvedValue([
+      { id: 1, name: 'Bronze', amount: 5, interval: 'monthly', activeSubscribers: 10, cancelledSubscribers: 2, totalSubscribers: 12, activeRevenue: 50 },
+      { id: 2, name: 'Gold', amount: 100, interval: 'monthly', activeSubscribers: 3, cancelledSubscribers: 0, totalSubscribers: 3, activeRevenue: 300 },
+    ]);
+
+    const svc = makeService();
+    const analytics = await svc.getTierAnalytics();
+
+    expect(analytics).toHaveLength(2);
+    expect(analytics[0].name).toBe('Bronze');
+    expect(analytics[0].activeSubscribers).toBe(10);
+    expect(analytics[0].activeRevenue).toBe(50);
+    expect(analytics[1].name).toBe('Gold');
+    expect(analytics[1].activeRevenue).toBe(300);
+  });
+
+  test('handles tiers with no subscribers', async () => {
+    Database.query.mockResolvedValue([
+      { id: 1, name: 'Bronze', amount: 5, interval: 'monthly', activeSubscribers: 0, cancelledSubscribers: 0, totalSubscribers: 0, activeRevenue: 0 },
+    ]);
+
+    const svc = makeService();
+    const analytics = await svc.getTierAnalytics();
+
+    expect(analytics[0].activeSubscribers).toBe(0);
+    expect(analytics[0].activeRevenue).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route integration tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+const request = require('supertest');
+const express = require('express');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  const tiersRouter = require('../src/routes/tiers');
+  app.use('/tiers', tiersRouter);
+  app.use((err, req, res, _next) => {
+    res.status(err.statusCode || err.status || 500).json({ success: false, error: err.message });
+  });
+  return app;
+}
+
+describe('POST /tiers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('creates a tier and returns 201', async () => {
+    Database.run.mockResolvedValue({ id: 1 });
+    Database.get.mockResolvedValue(TIER_ROW);
+
+    const res = await buildApp()
+      ._router
+      ? request(buildApp()).post('/tiers').send({ name: 'Silver', amount: 25 })
+      : null;
+
+    const app = buildApp();
+    const response = await request(app).post('/tiers').send({ name: 'Silver', amount: 25 });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data.name).toBe('Silver');
+  });
+
+  test('returns 400 for missing name', async () => {
+    const app = buildApp();
+    const response = await request(app).post('/tiers').send({ amount: 25 });
+    expect(response.status).toBe(400);
+  });
+
+  test('returns 400 for invalid amount', async () => {
+    const app = buildApp();
+    const response = await request(app).post('/tiers').send({ name: 'X', amount: -1 });
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('GET /tiers', () => {
+  test('returns list of tiers', async () => {
+    Database.query.mockResolvedValue([TIER_ROW]);
+
+    const app = buildApp();
+    const response = await request(app).get('/tiers');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toHaveLength(1);
+    expect(response.body.count).toBe(1);
+  });
+});
+
+describe('POST /tiers/:id/subscribe', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('subscribes donor and returns 201 with subscription', async () => {
+    Database.get
+      .mockResolvedValueOnce(TIER_ROW)
+      .mockResolvedValueOnce(DONOR_ROW)
+      .mockResolvedValueOnce(RECIPIENT_ROW)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 1, donorId: 10, tierId: 1, recurringDonationId: 5,
+        status: 'active', createdAt: '2026-01-01', cancelledAt: null,
+        tierName: 'Silver', tierAmount: 25, tierInterval: 'monthly',
+      });
+    Database.run.mockResolvedValue({ id: 1 });
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/tiers/1/subscribe')
+      .send({ donorPublicKey: 'GDONOR123', recipientPublicKey: 'GRECIP456' });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data.recurringDonationId).toBe(5);
+    expect(response.body.data.tierName).toBe('Silver');
+  });
+
+  test('returns 400 when donorPublicKey is missing', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/tiers/1/subscribe')
+      .send({ recipientPublicKey: 'GRECIP456' });
+
+    expect(response.status).toBe(400);
+  });
+
+  test('returns 404 when tier does not exist', async () => {
+    const { NotFoundError } = require('../src/utils/errors');
+    Database.get.mockResolvedValueOnce(null); // tier not found
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/tiers/999/subscribe')
+      .send({ donorPublicKey: 'GDONOR123', recipientPublicKey: 'GRECIP456' });
+
+    expect(response.status).toBe(404);
+  });
+
+  test('returns 400 for invalid tier ID', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/tiers/abc/subscribe')
+      .send({ donorPublicKey: 'GDONOR123', recipientPublicKey: 'GRECIP456' });
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('DELETE /tiers/subscriptions/:subId', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('cancels subscription and returns updated record', async () => {
+    const subRow = { id: 1, donorId: 10, tierId: 1, recurringDonationId: 5, status: 'active' };
+    const cancelledRow = {
+      id: 1, donorId: 10, tierId: 1, recurringDonationId: 5,
+      status: 'cancelled', createdAt: '2026-01-01', cancelledAt: '2026-03-27',
+      tierName: 'Silver', tierAmount: 25, tierInterval: 'monthly',
+    };
+    Database.get.mockResolvedValueOnce(subRow).mockResolvedValueOnce(cancelledRow);
+    Database.run.mockResolvedValue({ changes: 1 });
+
+    const app = buildApp();
+    const response = await request(app).delete('/tiers/subscriptions/1');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.status).toBe('cancelled');
+  });
+
+  test('returns 404 for unknown subscription', async () => {
+    Database.get.mockResolvedValueOnce(null);
+
+    const app = buildApp();
+    const response = await request(app).delete('/tiers/subscriptions/999');
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('GET /tiers/analytics', () => {
+  test('returns analytics per tier', async () => {
+    Database.query.mockResolvedValue([
+      { id: 1, name: 'Bronze', amount: 5, interval: 'monthly', activeSubscribers: 10, cancelledSubscribers: 2, totalSubscribers: 12, activeRevenue: 50 },
+    ]);
+
+    const app = buildApp();
+    const response = await request(app).get('/tiers/analytics');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data[0].activeSubscribers).toBe(10);
+    expect(response.body.data[0].activeRevenue).toBe(50);
+  });
+});
+
+describe('Auth enforcement', () => {
+  test('POST /tiers uses ADMIN_ALL permission', () => {
+    const fs = require('fs');
+    const src = fs.readFileSync(require('path').join(__dirname, '../src/routes/tiers.js'), 'utf8');
+    expect(src).toMatch(/PERMISSIONS\.ADMIN_ALL/);
+  });
+
+  test('POST /tiers/:id/subscribe uses STREAM_CREATE permission', () => {
+    const fs = require('fs');
+    const src = fs.readFileSync(require('path').join(__dirname, '../src/routes/tiers.js'), 'utf8');
+    expect(src).toMatch(/PERMISSIONS\.STREAM_CREATE/);
+  });
+
+  test('GET /tiers/analytics uses STATS_ADMIN permission', () => {
+    const fs = require('fs');
+    const src = fs.readFileSync(require('path').join(__dirname, '../src/routes/tiers.js'), 'utf8');
+    expect(src).toMatch(/PERMISSIONS\.STATS_ADMIN/);
+  });
+});


### PR DESCRIPTION
…integration

- Add subscription_tiers and donor_subscriptions tables (migration)
- Implement SubscriptionTierService: createTier, listTiers, subscribe, cancelSubscription, getTierAnalytics
- Add POST /tiers, GET /tiers, POST /tiers/:id/subscribe, DELETE /tiers/subscriptions/:id, GET /tiers/analytics
- Integrate tier subscriptions with RecurringDonationScheduler (calculateNextExecutionDate)
- Register /tiers routes in app.js
- Write 31 tests covering tier creation, subscription, cancellation, analytics, and auth
- Add docs/features/SUBSCRIPTION_TIERS.md

closes #418 