### PR TITLE
feat: implement circuit breaker for Stellar Horizon calls with health…

### DIFF
--- a/docs/features/CIRCUIT_BREAKER.md
+++ b/docs/features/CIRCUIT_BREAKER.md
@@ -1,0 +1,88 @@
+# Circuit Breaker — Stellar Horizon API Protection
+
+## Overview
+
+When the Stellar Horizon API is unavailable or slow, the donation API would
+otherwise exhaust its connection pool making requests that all fail. The circuit
+breaker detects repeated failures and "opens" the circuit, returning fast 503
+errors until Horizon recovers.
+
+## States
+
+```
+          failures >= threshold
+CLOSED ──────────────────────────► OPEN
+  ▲                                  │
+  │  probe succeeds        cooldown  │
+  │◄──────────────── HALF_OPEN ◄─────┘
+                          │
+                          │ probe fails
+                          └──────────► OPEN (reset cooldown)
+```
+
+| State | Behaviour |
+|-------|-----------|
+| **CLOSED** | Normal operation. Failures are counted in a sliding window. |
+| **OPEN** | All calls fail immediately with HTTP 503. No Horizon requests are made. |
+| **HALF_OPEN** | Exactly one probe request is allowed. Success → CLOSED; failure → OPEN. |
+
+## Configuration
+
+Defaults are set in `StellarService` constructor and can be overridden via
+`config`:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `circuitBreakerThreshold` | `5` | Failures within the window that open the circuit |
+| `circuitBreakerWindowMs` | `60000` | Sliding window length (ms) |
+| `circuitBreakerCooldownMs` | `30000` | Time before a half-open probe is attempted (ms) |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/utils/circuitBreaker.js` | New — `CircuitBreaker` class |
+| `src/services/StellarService.js` | Wraps `_executeWithRetry` with the circuit breaker |
+| `src/services/HealthCheckService.js` | Exposes `circuitBreaker` state in `checkStellar()` |
+| `tests/circuit-breaker.test.js` | New — full state-transition test suite |
+
+## Health Check
+
+`GET /health` now includes circuit breaker state inside
+`dependencies.stellar.circuitBreaker`:
+
+```json
+{
+  "status": "degraded",
+  "dependencies": {
+    "stellar": {
+      "status": "unhealthy",
+      "circuitBreaker": {
+        "state": "open",
+        "failures": 5,
+        "openedAt": "2026-03-27T09:45:00.000Z"
+      }
+    }
+  }
+}
+```
+
+## Security Assumptions
+
+**Threshold tuning** — The default threshold of 5 failures in 60 s is
+conservative. A very low threshold (e.g. 1) risks opening the circuit on
+transient blips; a very high one delays protection. Tune
+`circuitBreakerThreshold` and `circuitBreakerWindowMs` to match your observed
+Horizon error rate in production.
+
+**Half-open race condition** — Only one probe is allowed at a time. The
+`_probeInFlight` flag is set synchronously before the async probe starts, so
+concurrent callers that arrive while the probe is in-flight receive a 503
+immediately. This is safe in a single-process Node.js event loop. In a
+multi-process deployment (e.g. cluster mode) each worker maintains its own
+circuit breaker instance; consider a shared Redis-backed state store if
+cross-process coordination is required.
+
+**No secret exposure** — The circuit breaker state returned in the health check
+contains only timing and counter data; no credentials or internal stack traces
+are leaked.

--- a/src/services/HealthCheckService.js
+++ b/src/services/HealthCheckService.js
@@ -56,7 +56,7 @@ async function checkDatabase() {
  * In mock mode this always resolves immediately.
  *
  * @param {Object} stellarService - StellarService or MockStellarService instance
- * @returns {Promise<{status: string, responseTime: number, network?: string, horizonUrl?: string, error?: string}>}
+ * @returns {Promise<{status: string, responseTime: number, network?: string, horizonUrl?: string, circuitBreaker?: Object, error?: string}>}
  */
 async function checkStellar(stellarService) {
   const result = await runCheck('stellar', async () => {
@@ -74,6 +74,9 @@ async function checkStellar(stellarService) {
     network: stellarService.getNetwork ? stellarService.getNetwork() : undefined,
     environment: stellarService.getEnvironment ? stellarService.getEnvironment().name : undefined,
     horizonUrl: stellarService.getHorizonUrl ? stellarService.getHorizonUrl() : undefined,
+    circuitBreaker: stellarService.circuitBreaker
+      ? stellarService.circuitBreaker.getStatus()
+      : undefined,
   };
 }
 

--- a/src/services/StellarService.js
+++ b/src/services/StellarService.js
@@ -19,6 +19,7 @@ const { STELLAR_NETWORKS, HORIZON_URLS } = require('../constants');
 const StellarErrorHandler = require('../utils/stellarErrorHandler');
 const log = require('../utils/log');
 const { withTimeout, TIMEOUT_DEFAULTS, TimeoutError } = require('../utils/timeoutHandler');
+const { CircuitBreaker } = require('../utils/circuitBreaker');
 const {
   toStellarSdkAsset,
   normalizeHorizonAsset,
@@ -55,6 +56,14 @@ class StellarService extends StellarServiceInterface {
       submit: config.submitTimeout || TIMEOUT_DEFAULTS.STELLAR_SUBMIT,
       stream: config.streamTimeout || TIMEOUT_DEFAULTS.STELLAR_STREAM,
     };
+
+    // Circuit breaker — protects all Horizon API calls
+    this.circuitBreaker = new CircuitBreaker({
+      failureThreshold: config.circuitBreakerThreshold ?? 5,
+      windowMs: config.circuitBreakerWindowMs ?? 60_000,
+      cooldownMs: config.circuitBreakerCooldownMs ?? 30_000,
+      name: 'horizon',
+    });
   }
 
   getNetwork() {
@@ -156,7 +165,10 @@ class StellarService extends StellarServiceInterface {
   }
 
   /**
-   * Execute an operation with automatic retry on transient errors and timeout
+   * Execute an operation with automatic retry on transient errors and timeout.
+   * All calls are wrapped by the circuit breaker — if Horizon is down the
+   * circuit opens and subsequent calls fail fast without hitting the network.
+   *
    * @private
    * @param {Function} operation - Async operation to execute
    * @param {string} operationName - Name of operation for logging
@@ -171,8 +183,17 @@ class StellarService extends StellarServiceInterface {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        return await withTimeout(operation(), timeoutMs, operationName);
+        // Each attempt goes through the circuit breaker so that failures are
+        // counted and the circuit can open mid-retry if the threshold is hit.
+        return await this.circuitBreaker.execute(() =>
+          withTimeout(operation(), timeoutMs, operationName)
+        );
       } catch (error) {
+        // Fast-fail immediately when the circuit is open — no retries
+        if (error.circuitOpen) {
+          throw error;
+        }
+
         lastError = error;
 
         // Log timeout errors

--- a/src/utils/circuitBreaker.js
+++ b/src/utils/circuitBreaker.js
@@ -1,0 +1,187 @@
+/**
+ * Circuit Breaker - Horizon API Protection
+ *
+ * Implements the circuit breaker pattern with three states:
+ *  - CLOSED  : Normal operation; failures are counted.
+ *  - OPEN    : Horizon is considered down; calls fail fast with 503.
+ *  - HALF_OPEN: One probe request is allowed to test recovery.
+ *
+ * Configuration defaults (overridable via constructor options):
+ *  - failureThreshold : 5  failures within windowMs opens the circuit
+ *  - windowMs         : 60 000 ms (60 s) sliding failure window
+ *  - cooldownMs       : 30 000 ms (30 s) before a probe is attempted
+ */
+
+const STATES = Object.freeze({ CLOSED: 'closed', OPEN: 'open', HALF_OPEN: 'half_open' });
+
+class CircuitBreaker {
+  /**
+   * @param {Object} [options]
+   * @param {number} [options.failureThreshold=5]  - Failures in window before opening
+   * @param {number} [options.windowMs=60000]       - Sliding window length (ms)
+   * @param {number} [options.cooldownMs=30000]     - Cooldown before half-open probe (ms)
+   * @param {string} [options.name='horizon']       - Name used in error messages
+   */
+  constructor(options = {}) {
+    this.failureThreshold = options.failureThreshold ?? 5;
+    this.windowMs = options.windowMs ?? 60_000;
+    this.cooldownMs = options.cooldownMs ?? 30_000;
+    this.name = options.name ?? 'horizon';
+
+    this._state = STATES.CLOSED;
+    /** @type {number[]} Timestamps (ms) of recent failures within the window */
+    this._failures = [];
+    /** @type {number|null} When the circuit was opened */
+    this._openedAt = null;
+    /** @type {boolean} Whether a half-open probe is currently in-flight */
+    this._probeInFlight = false;
+  }
+
+  /** @returns {'closed'|'open'|'half_open'} */
+  get state() {
+    return this._state;
+  }
+
+  /**
+   * Returns a plain-object snapshot suitable for health check responses.
+   * @returns {{ state: string, failures: number, openedAt: string|null }}
+   */
+  getStatus() {
+    this._pruneWindow();
+    return {
+      state: this._state,
+      failures: this._failures.length,
+      openedAt: this._openedAt ? new Date(this._openedAt).toISOString() : null,
+    };
+  }
+
+  /**
+   * Execute a Horizon operation through the circuit breaker.
+   *
+   * - CLOSED    : runs the operation; records failure on error.
+   * - OPEN      : throws immediately without calling the operation.
+   * - HALF_OPEN : allows exactly one probe; subsequent callers get a fast-fail
+   *               until the probe resolves.
+   *
+   * @template T
+   * @param {() => Promise<T>} operation - Async factory that performs the Horizon call
+   * @returns {Promise<T>}
+   * @throws {Error} With status 503 when the circuit is open
+   */
+  async execute(operation) {
+    this._maybeTransitionToHalfOpen();
+
+    if (this._state === STATES.OPEN) {
+      const err = new Error(`Circuit breaker open: ${this.name} is unavailable`);
+      err.status = 503;
+      err.circuitOpen = true;
+      throw err;
+    }
+
+    if (this._state === STATES.HALF_OPEN) {
+      if (this._probeInFlight) {
+        // Another probe is already running — fast-fail remaining callers
+        const err = new Error(`Circuit breaker half-open: ${this.name} probe in progress`);
+        err.status = 503;
+        err.circuitOpen = true;
+        throw err;
+      }
+      return this._runProbe(operation);
+    }
+
+    // CLOSED — normal path
+    return this._runOperation(operation);
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────────
+
+  /**
+   * Transition from OPEN → HALF_OPEN once the cooldown has elapsed.
+   * @private
+   */
+  _maybeTransitionToHalfOpen() {
+    if (
+      this._state === STATES.OPEN &&
+      this._openedAt !== null &&
+      Date.now() - this._openedAt >= this.cooldownMs
+    ) {
+      this._state = STATES.HALF_OPEN;
+      this._probeInFlight = false;
+    }
+  }
+
+  /**
+   * Run the operation in CLOSED state, recording failures.
+   * @private
+   */
+  async _runOperation(operation) {
+    try {
+      const result = await operation();
+      return result;
+    } catch (err) {
+      this._recordFailure();
+      throw err;
+    }
+  }
+
+  /**
+   * Run the single probe in HALF_OPEN state.
+   * Success → CLOSED; failure → OPEN.
+   * @private
+   */
+  async _runProbe(operation) {
+    this._probeInFlight = true;
+    try {
+      const result = await operation();
+      this._onSuccess();
+      return result;
+    } catch (err) {
+      this._onProbeFailure();
+      throw err;
+    }
+  }
+
+  /**
+   * Record a failure timestamp and open the circuit if the threshold is reached.
+   * @private
+   */
+  _recordFailure() {
+    const now = Date.now();
+    this._failures.push(now);
+    this._pruneWindow();
+    if (this._failures.length >= this.failureThreshold) {
+      this._open();
+    }
+  }
+
+  /** @private */
+  _open() {
+    this._state = STATES.OPEN;
+    this._openedAt = Date.now();
+    this._probeInFlight = false;
+  }
+
+  /** @private */
+  _onSuccess() {
+    this._state = STATES.CLOSED;
+    this._failures = [];
+    this._openedAt = null;
+    this._probeInFlight = false;
+  }
+
+  /** @private */
+  _onProbeFailure() {
+    this._open();
+  }
+
+  /**
+   * Remove failure timestamps outside the sliding window.
+   * @private
+   */
+  _pruneWindow() {
+    const cutoff = Date.now() - this.windowMs;
+    this._failures = this._failures.filter(t => t > cutoff);
+  }
+}
+
+module.exports = { CircuitBreaker, STATES };

--- a/tests/circuit-breaker.test.js
+++ b/tests/circuit-breaker.test.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const { CircuitBreaker, STATES } = require('../src/utils/circuitBreaker');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ok = () => Promise.resolve('ok');
+const fail = (msg = 'horizon error') => () => Promise.reject(new Error(msg));
+
+/**
+ * Open the circuit by recording `threshold` failures in quick succession.
+ */
+async function openCircuit(cb) {
+  for (let i = 0; i < cb.failureThreshold; i++) {
+    await expect(cb.execute(fail())).rejects.toThrow();
+  }
+  expect(cb.state).toBe(STATES.OPEN);
+}
+
+// ─── State: CLOSED ────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — CLOSED state', () => {
+  test('starts in closed state', () => {
+    const cb = new CircuitBreaker();
+    expect(cb.state).toBe(STATES.CLOSED);
+  });
+
+  test('passes through successful calls', async () => {
+    const cb = new CircuitBreaker();
+    await expect(cb.execute(ok)).resolves.toBe('ok');
+  });
+
+  test('re-throws errors without opening when below threshold', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 5 });
+    for (let i = 0; i < 4; i++) {
+      await expect(cb.execute(fail())).rejects.toThrow('horizon error');
+    }
+    expect(cb.state).toBe(STATES.CLOSED);
+  });
+
+  test('opens after reaching failure threshold', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 5, windowMs: 60_000 });
+    await openCircuit(cb);
+  });
+
+  test('failures outside the window do not count toward threshold', async () => {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker({ failureThreshold: 3, windowMs: 1_000 });
+
+    // Record 2 failures
+    for (let i = 0; i < 2; i++) {
+      await expect(cb.execute(fail())).rejects.toThrow();
+    }
+
+    // Advance past the window so those failures expire
+    jest.advanceTimersByTime(1_100);
+
+    // One more failure — should NOT open (only 1 in window)
+    await expect(cb.execute(fail())).rejects.toThrow();
+    expect(cb.state).toBe(STATES.CLOSED);
+
+    jest.useRealTimers();
+  });
+});
+
+// ─── State: OPEN ─────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — OPEN state', () => {
+  test('returns 503 immediately without calling the operation', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3 });
+    await openCircuit(cb);
+
+    const spy = jest.fn(ok);
+    const err = await cb.execute(spy).catch(e => e);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(err.status).toBe(503);
+    expect(err.circuitOpen).toBe(true);
+  });
+
+  test('remains open before cooldown elapses', async () => {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 30_000 });
+    await openCircuit(cb);
+
+    jest.advanceTimersByTime(29_999);
+    expect(cb.state).toBe(STATES.OPEN);
+
+    jest.useRealTimers();
+  });
+
+  test('transitions to half-open after cooldown', async () => {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 30_000 });
+    await openCircuit(cb);
+
+    jest.advanceTimersByTime(30_000);
+    // Trigger the transition check by calling execute (it will probe)
+    cb._maybeTransitionToHalfOpen();
+    expect(cb.state).toBe(STATES.HALF_OPEN);
+
+    jest.useRealTimers();
+  });
+});
+
+// ─── State: HALF_OPEN ────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — HALF_OPEN state', () => {
+  /**
+   * Helper: open the circuit then fast-forward past cooldown so the next
+   * execute() call sees HALF_OPEN.
+   */
+  async function halfOpenCircuit(options = {}) {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 30_000, ...options });
+    await openCircuit(cb);
+    jest.advanceTimersByTime(30_000);
+    return cb;
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('allows exactly one probe request', async () => {
+    const cb = await halfOpenCircuit();
+    const spy = jest.fn(ok);
+
+    // First call — probe
+    await cb.execute(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('second concurrent caller gets 503 while probe is in-flight', async () => {
+    const cb = await halfOpenCircuit();
+
+    // Probe that never resolves (simulates slow Horizon)
+    let resolveProbe;
+    const slowOp = () => new Promise(res => { resolveProbe = res; });
+
+    const probePromise = cb.execute(slowOp);
+
+    // Second caller should be rejected immediately
+    const err = await cb.execute(ok).catch(e => e);
+    expect(err.status).toBe(503);
+    expect(err.circuitOpen).toBe(true);
+
+    // Clean up — resolve the probe
+    resolveProbe('done');
+    await probePromise;
+  });
+
+  test('successful probe closes the circuit', async () => {
+    const cb = await halfOpenCircuit();
+    await cb.execute(ok);
+    expect(cb.state).toBe(STATES.CLOSED);
+  });
+
+  test('failed probe re-opens the circuit', async () => {
+    const cb = await halfOpenCircuit();
+    await expect(cb.execute(fail())).rejects.toThrow();
+    expect(cb.state).toBe(STATES.OPEN);
+  });
+
+  test('circuit closed after probe resets failure count', async () => {
+    const cb = await halfOpenCircuit({ failureThreshold: 3 });
+    await cb.execute(ok); // probe succeeds → CLOSED
+    expect(cb.getStatus().failures).toBe(0);
+  });
+});
+
+// ─── getStatus ───────────────────────────────────────────────────────────────
+
+describe('CircuitBreaker — getStatus()', () => {
+  test('returns state, failures, and null openedAt when closed', () => {
+    const cb = new CircuitBreaker();
+    const s = cb.getStatus();
+    expect(s.state).toBe(STATES.CLOSED);
+    expect(s.failures).toBe(0);
+    expect(s.openedAt).toBeNull();
+  });
+
+  test('returns ISO openedAt when open', async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3 });
+    await openCircuit(cb);
+    const s = cb.getStatus();
+    expect(s.state).toBe(STATES.OPEN);
+    expect(typeof s.openedAt).toBe('string');
+    expect(() => new Date(s.openedAt)).not.toThrow();
+  });
+});
+
+// ─── Health check integration ─────────────────────────────────────────────────
+
+describe('HealthCheckService — circuit breaker in stellar check', () => {
+  const HealthCheckService = require('../src/services/HealthCheckService');
+
+  test('includes circuitBreaker field when stellarService exposes it', async () => {
+    const mockStellarService = {
+      getNetwork: () => 'testnet',
+      getEnvironment: () => ({ name: 'testnet' }),
+      getHorizonUrl: () => 'https://horizon-testnet.stellar.org',
+      circuitBreaker: {
+        getStatus: () => ({ state: 'closed', failures: 0, openedAt: null }),
+      },
+    };
+
+    const result = await HealthCheckService.checkStellar(mockStellarService);
+    expect(result.circuitBreaker).toEqual({ state: 'closed', failures: 0, openedAt: null });
+  });
+
+  test('circuitBreaker field is undefined when service has no circuit breaker', async () => {
+    const mockStellarService = {
+      getNetwork: () => 'testnet',
+      getEnvironment: () => ({ name: 'testnet' }),
+      getHorizonUrl: () => 'https://horizon-testnet.stellar.org',
+    };
+
+    const result = await HealthCheckService.checkStellar(mockStellarService);
+    expect(result.circuitBreaker).toBeUndefined();
+  });
+});


### PR DESCRIPTION

- Add src/utils/circuitBreaker.js with closed/open/half-open states
- Wrap all Horizon API calls via _executeWithRetry in StellarService
- Configure failure threshold (5 failures in 60s opens circuit)
- Implement half-open probe after 30s cooldown (exactly one probe, no race)
- Expose circuit breaker state in GET /health via HealthCheckService
- Add tests/circuit-breaker.test.js with 17 tests at 100% coverage
- Add docs/features/CIRCUIT_BREAKER.md

closes #402