### PR TITLE
feat: Webhook Signature Verification SDK (Issue #398)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,9 @@ dist/
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Python artifacts
+sdk/python/__pycache__/
+sdk/python/.coverage
+*.pyc
+.pytest_cache/

--- a/docs/features/WEBHOOK_SDK.md
+++ b/docs/features/WEBHOOK_SDK.md
@@ -1,0 +1,116 @@
+# Webhook Signature Verification SDK
+
+Verify `X-Webhook-Signature` headers on incoming webhook requests using HMAC-SHA256.
+
+## How It Works
+
+When the API dispatches a webhook it computes:
+
+```
+HMAC-SHA256(raw_request_body, shared_secret)  →  hex string
+```
+
+and sends the result in the `X-Webhook-Signature` header. Your server must recompute the same digest from the **raw body** and compare it in constant time.
+
+> **Security assumption**: Secrets must be stored in environment variables, never hardcoded in source code.
+
+---
+
+## Quick Start — Express.js (Node)
+
+```js
+const express = require('express');
+const { verifySignature } = require('./sdk/js/webhookVerifier');
+
+const app = express();
+
+// Capture the raw body BEFORE express.json() parses it.
+app.use(
+  express.json({
+    verify: (req, _res, buf) => { req.rawBody = buf; },
+  })
+);
+
+app.post('/webhooks', (req, res) => {
+  const sig = req.headers['x-webhook-signature'];
+  const secret = process.env.WEBHOOK_SECRET; // never hardcode
+
+  if (!verifySignature(req.rawBody, sig, secret)) {
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  // Safe to process req.body here
+  res.sendStatus(200);
+});
+```
+
+---
+
+## Quick Start — Flask (Python)
+
+```python
+import os
+from flask import Flask, request, abort
+from sdk.python.webhook_verifier import verify_signature
+
+app = Flask(__name__)
+
+@app.post('/webhooks')
+def webhook():
+    sig = request.headers.get('X-Webhook-Signature', '')
+    secret = os.environ['WEBHOOK_SECRET']  # never hardcode
+
+    # request.get_data() returns the raw bytes before Flask parses JSON.
+    if not verify_signature(request.get_data(), sig, secret):
+        abort(401)
+
+    payload = request.get_json()
+    # Safe to process payload here
+    return '', 200
+```
+
+---
+
+## Why Raw Body Matters
+
+JSON parsers may reorder keys, strip whitespace, or normalise values. If you verify the signature against `request.body` (the parsed object) instead of the raw bytes, the digest will not match what the server computed — even for a legitimate request.
+
+Always capture the raw body **before** any middleware touches it.
+
+---
+
+## API Reference
+
+### JavaScript — `verifySignature(payload, signature, secret)`
+
+| Parameter   | Type              | Description                                      |
+|-------------|-------------------|--------------------------------------------------|
+| `payload`   | `string\|Buffer`  | Raw request body                                 |
+| `signature` | `string`          | Hex-encoded value of `X-Webhook-Signature`       |
+| `secret`    | `string`          | Shared secret (from environment variable)        |
+
+Returns `boolean`.
+
+### Python — `verify_signature(payload, signature, secret)`
+
+| Parameter   | Type          | Description                                      |
+|-------------|---------------|--------------------------------------------------|
+| `payload`   | `str\|bytes`  | Raw request body                                 |
+| `signature` | `str`         | Hex-encoded value of `X-Webhook-Signature`       |
+| `secret`    | `str`         | Shared secret (from environment variable)        |
+
+Returns `bool`.
+
+---
+
+## Test Vectors
+
+Shared vectors live in `sdk/test-vectors/vectors.json` and are consumed by both SDK test suites to guarantee cross-language parity.
+
+```bash
+# JavaScript
+npx jest tests/webhook-sdk.test.js
+
+# Python
+python -m pytest sdk/python/test_webhook_verifier.py -v
+```

--- a/sdk/js/webhookVerifier.js
+++ b/sdk/js/webhookVerifier.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const crypto = require('crypto');
+
+/**
+ * Verifies an X-Webhook-Signature header against a raw request payload.
+ *
+ * @param {string|Buffer} payload  - The raw request body (before JSON parsing).
+ * @param {string}        signature - The hex-encoded HMAC-SHA256 signature from the header.
+ * @param {string}        secret    - The shared secret used to sign the webhook.
+ * @returns {boolean} `true` if the signature is valid, `false` otherwise.
+ *
+ * @example
+ * const { verifySignature } = require('./webhookVerifier');
+ * const isValid = verifySignature(req.rawBody, req.headers['x-webhook-signature'], process.env.WEBHOOK_SECRET);
+ */
+function verifySignature(payload, signature, secret) {
+  if (typeof signature !== 'string' || typeof secret !== 'string') {
+    return false;
+  }
+
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex');
+
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const receivedBuf = Buffer.from(signature, 'hex');
+
+  if (expectedBuf.length !== receivedBuf.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expectedBuf, receivedBuf);
+}
+
+module.exports = { verifySignature };

--- a/sdk/python/test_webhook_verifier.py
+++ b/sdk/python/test_webhook_verifier.py
@@ -1,0 +1,69 @@
+"""
+Tests for sdk/python/webhook_verifier.py
+
+Run with:  python -m pytest sdk/python/test_webhook_verifier.py -v --tb=short
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+from webhook_verifier import verify_signature  # noqa: E402
+
+# ── Load shared test vectors ────────────────────────────────────────────────
+_VECTORS_PATH = os.path.join(os.path.dirname(__file__), '..', 'test-vectors', 'vectors.json')
+with open(_VECTORS_PATH) as f:
+    _VECTORS = json.load(f)['vectors']
+
+
+# ── Test-vector parity ──────────────────────────────────────────────────────
+@pytest.mark.parametrize('v', _VECTORS, ids=[v['description'] for v in _VECTORS])
+def test_valid_vectors(v):
+    assert verify_signature(v['payload'], v['expected_signature'], v['secret']) is True
+
+
+# ── Valid signature (string payload) ───────────────────────────────────────
+def test_valid_string_payload():
+    v = _VECTORS[0]
+    assert verify_signature(v['payload'], v['expected_signature'], v['secret']) is True
+
+
+# ── Valid signature (bytes payload) ────────────────────────────────────────
+def test_valid_bytes_payload():
+    v = _VECTORS[0]
+    assert verify_signature(v['payload'].encode(), v['expected_signature'], v['secret']) is True
+
+
+# ── Tampered payload ────────────────────────────────────────────────────────
+def test_tampered_payload():
+    v = _VECTORS[0]
+    assert verify_signature(v['payload'] + ' tampered', v['expected_signature'], v['secret']) is False
+
+
+# ── Wrong secret ────────────────────────────────────────────────────────────
+def test_wrong_secret():
+    v = _VECTORS[0]
+    assert verify_signature(v['payload'], v['expected_signature'], 'wrong-secret') is False
+
+
+# ── Wrong signature ─────────────────────────────────────────────────────────
+def test_wrong_signature():
+    assert verify_signature('hello world', 'deadbeef' * 8, 'my-secret-key') is False
+
+
+# ── Type guards ─────────────────────────────────────────────────────────────
+def test_non_string_signature_returns_false():
+    assert verify_signature('payload', None, 'secret') is False
+
+
+def test_non_string_secret_returns_false():
+    assert verify_signature('payload', 'abc', None) is False
+
+
+# ── All vectors fail with wrong secret ─────────────────────────────────────
+@pytest.mark.parametrize('v', _VECTORS, ids=[v['description'] for v in _VECTORS])
+def test_all_vectors_fail_wrong_secret(v):
+    assert verify_signature(v['payload'], v['expected_signature'], 'wrong') is False

--- a/sdk/python/webhook_verifier.py
+++ b/sdk/python/webhook_verifier.py
@@ -1,0 +1,38 @@
+"""
+Webhook signature verification SDK for Python.
+
+Verifies the X-Webhook-Signature header against a raw request payload
+using HMAC-SHA256 and a shared secret.
+"""
+
+import hashlib
+import hmac
+
+
+def verify_signature(payload: str | bytes, signature: str, secret: str) -> bool:
+    """
+    Verify an X-Webhook-Signature header against a raw request payload.
+
+    Args:
+        payload:   The raw request body (str or bytes) before any parsing.
+        signature: The hex-encoded HMAC-SHA256 signature from the header.
+        secret:    The shared secret used to sign the webhook.
+
+    Returns:
+        True if the signature is valid, False otherwise.
+
+    Example::
+
+        import os
+        from webhook_verifier import verify_signature
+
+        is_valid = verify_signature(request.get_data(), request.headers.get('X-Webhook-Signature'), os.environ['WEBHOOK_SECRET'])
+    """
+    if not isinstance(signature, str) or not isinstance(secret, str):
+        return False
+
+    if isinstance(payload, str):
+        payload = payload.encode()
+
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)

--- a/sdk/test-vectors/vectors.json
+++ b/sdk/test-vectors/vectors.json
@@ -1,0 +1,22 @@
+{
+  "vectors": [
+    {
+      "description": "basic ASCII payload",
+      "payload": "hello world",
+      "secret": "my-secret-key",
+      "expected_signature": "90eb182d8396f16d4341d582047f45c0a97d73388c5377d9ced478a2212295ad"
+    },
+    {
+      "description": "JSON payload",
+      "payload": "{\"amount\":\"10\",\"recipient\":\"GABC\"}",
+      "secret": "webhook-secret-xyz",
+      "expected_signature": "5bc28bfa08d800517b78dc187f85e17e0b81ace89c1908d690f063735a055986"
+    },
+    {
+      "description": "empty payload",
+      "payload": "",
+      "secret": "secret",
+      "expected_signature": "f9e66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169"
+    }
+  ]
+}

--- a/tests/webhook-sdk.test.js
+++ b/tests/webhook-sdk.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { verifySignature } = require('../sdk/js/webhookVerifier');
+const vectors = require('../sdk/test-vectors/vectors.json');
+
+describe('webhookVerifier', () => {
+  // ── Test-vector parity ──────────────────────────────────────────────────
+  describe('shared test vectors', () => {
+    vectors.vectors.forEach(({ description, payload, secret, expected_signature }) => {
+      it(`validates: ${description}`, () => {
+        expect(verifySignature(payload, expected_signature, secret)).toBe(true);
+      });
+    });
+  });
+
+  // ── Valid signature ─────────────────────────────────────────────────────
+  it('returns true for a correct signature', () => {
+    const { vectors: [v] } = vectors;
+    expect(verifySignature(v.payload, v.expected_signature, v.secret)).toBe(true);
+  });
+
+  // ── Tampered payload ────────────────────────────────────────────────────
+  it('returns false when payload is tampered', () => {
+    const { vectors: [v] } = vectors;
+    expect(verifySignature(v.payload + ' tampered', v.expected_signature, v.secret)).toBe(false);
+  });
+
+  // ── Wrong secret ────────────────────────────────────────────────────────
+  it('returns false for an incorrect secret', () => {
+    const { vectors: [v] } = vectors;
+    expect(verifySignature(v.payload, v.expected_signature, 'wrong-secret')).toBe(false);
+  });
+
+  // ── Wrong signature ─────────────────────────────────────────────────────
+  it('returns false for a completely wrong signature', () => {
+    expect(verifySignature('hello world', 'deadbeef'.repeat(8), 'my-secret-key')).toBe(false);
+  });
+
+  // ── Mismatched length (not valid hex of same length) ────────────────────
+  it('returns false when signature has wrong length', () => {
+    expect(verifySignature('hello', 'abc123', 'secret')).toBe(false);
+  });
+
+  // ── Buffer payload ──────────────────────────────────────────────────────
+  it('accepts a Buffer payload', () => {
+    const { vectors: [v] } = vectors;
+    expect(verifySignature(Buffer.from(v.payload), v.expected_signature, v.secret)).toBe(true);
+  });
+
+  // ── Type guards ─────────────────────────────────────────────────────────
+  it('returns false when signature is not a string', () => {
+    expect(verifySignature('payload', null, 'secret')).toBe(false);
+  });
+
+  it('returns false when secret is not a string', () => {
+    expect(verifySignature('payload', 'abc', null)).toBe(false);
+  });
+
+  // ── All test vectors return false with wrong secret ─────────────────────
+  describe('all vectors fail with wrong secret', () => {
+    vectors.vectors.forEach(({ description, payload, expected_signature }) => {
+      it(`rejects tampered secret for: ${description}`, () => {
+        expect(verifySignature(payload, expected_signature, 'wrong')).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #398 

Implements a lightweight, client-side webhook signature verification SDK in both JavaScript and Python, resolving #398.

## Changes

| File | Description |
|------|-------------|
| `sdk/js/webhookVerifier.js` | JS SDK — `verifySignature(payload, signature, secret)` |
| `sdk/python/webhook_verifier.py` | Python SDK — `verify_signature(payload, signature, secret)` |
| `sdk/test-vectors/vectors.json` | Shared HMAC-SHA256 test vectors consumed by both test suites |
| `tests/webhook-sdk.test.js` | JS tests — 14 cases, **100% coverage** |
| `sdk/python/test_webhook_verifier.py` | Python tests — 13 cases, **100% coverage** |
| `docs/features/WEBHOOK_SDK.md` | Quick-start guide for Express.js and Flask |

## Security

- **Algorithm**: HMAC-SHA256, hex-encoded output
- **Timing-safe comparison**: `crypto.timingSafeEqual` (JS) / `hmac.compare_digest` (Python) — prevents timing attacks
- **Raw body**: SDKs accept `string | Buffer` (JS) and `str | bytes` (Python) — must be called before JSON middleware parses the body
- **Secrets**: Documented as environment-variable-only; never hardcoded

## Testing

bash
# JavaScript (14 tests, 100% coverage)
npx jest tests/webhook-sdk.test.js --coverage

# Python (13 tests, 100% coverage)
cd sdk/python && python -m pytest test_webhook_verifier.py -v --cov=webhook_verifier

## Parity Check

Both test suites load `sdk/test-vectors/vectors.json` — confirming that a signature produced by the backend is accepted by both SDK implementations.

