### PR TITLE
feat: add database migration system with schema_migrations tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/routes/app.js",
     "init-db": "node src/scripts/initDB.js",
+    "migrate": "node src/scripts/migrate.js",
     "migrate:memo": "node src/scripts/addMemoColumn.js",
     "migrate:currency": "node src/scripts/migrations/addCurrencyColumns.js",
     "test": "jest",

--- a/src/migrations/001_initial_schema.js
+++ b/src/migrations/001_initial_schema.js
@@ -1,0 +1,110 @@
+'use strict';
+
+exports.name = '001_initial_schema';
+
+exports.up = async (db) => {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      publicKey TEXT NOT NULL UNIQUE,
+      encryptedSecret TEXT,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      deleted_at DATETIME DEFAULT NULL,
+      daily_limit REAL DEFAULT NULL,
+      monthly_limit REAL DEFAULT NULL,
+      per_transaction_limit REAL DEFAULT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'default'
+    )
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS campaigns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      description TEXT,
+      goal_amount REAL NOT NULL,
+      current_amount REAL DEFAULT 0,
+      start_date DATETIME,
+      end_date DATETIME,
+      status TEXT DEFAULT 'active',
+      created_by INTEGER,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      deleted_at DATETIME DEFAULT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      FOREIGN KEY (created_by) REFERENCES users(id)
+    )
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS transactions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      senderId INTEGER NOT NULL,
+      receiverId INTEGER NOT NULL,
+      amount REAL NOT NULL,
+      memo TEXT,
+      notes TEXT,
+      tags TEXT,
+      timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+      deleted_at DATETIME DEFAULT NULL,
+      idempotencyKey TEXT UNIQUE,
+      stellar_tx_id TEXT UNIQUE,
+      is_orphan INTEGER NOT NULL DEFAULT 0,
+      campaign_id INTEGER,
+      validAfter INTEGER DEFAULT 0,
+      validBefore INTEGER DEFAULT 0,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      FOREIGN KEY (campaign_id) REFERENCES campaigns(id),
+      FOREIGN KEY (senderId) REFERENCES users(id),
+      FOREIGN KEY (receiverId) REFERENCES users(id)
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_transactions_idempotency
+    ON transactions(idempotencyKey)
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS recurring_donations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      donorId INTEGER NOT NULL,
+      recipientId INTEGER NOT NULL,
+      amount REAL NOT NULL,
+      frequency TEXT NOT NULL,
+      nextExecutionDate DATETIME NOT NULL,
+      status TEXT DEFAULT 'active',
+      executionCount INTEGER DEFAULT 0,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      FOREIGN KEY (donorId) REFERENCES users(id),
+      FOREIGN KEY (recipientId) REFERENCES users(id)
+    )
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS student_fees (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      studentId TEXT NOT NULL,
+      description TEXT NOT NULL,
+      totalAmount REAL NOT NULL,
+      paidAmount REAL NOT NULL DEFAULT 0,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      deleted_at DATETIME DEFAULT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'default'
+    )
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS fee_payments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      feeId INTEGER NOT NULL,
+      amount REAL NOT NULL,
+      note TEXT,
+      paidAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      deleted_at DATETIME DEFAULT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      FOREIGN KEY (feeId) REFERENCES student_fees(id)
+    )
+  `);
+};

--- a/src/migrations/002_api_keys.js
+++ b/src/migrations/002_api_keys.js
@@ -1,0 +1,42 @@
+'use strict';
+
+exports.name = '002_api_keys';
+
+exports.up = async (db) => {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS api_keys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      key_hash TEXT NOT NULL UNIQUE,
+      key_prefix TEXT NOT NULL,
+      name TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'user',
+      status TEXT NOT NULL DEFAULT 'active',
+      created_by TEXT,
+      metadata TEXT,
+      expires_at INTEGER,
+      last_used_at INTEGER,
+      deprecated_at INTEGER,
+      revoked_at INTEGER,
+      created_at INTEGER NOT NULL,
+      grace_period_days INTEGER NOT NULL DEFAULT 30,
+      rotated_to_id INTEGER,
+      signing_required INTEGER NOT NULL DEFAULT 0,
+      key_secret TEXT,
+      allowed_ips TEXT,
+      monthly_quota INTEGER,
+      quota_used INTEGER NOT NULL DEFAULT 0,
+      quota_reset_at INTEGER,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      notification_email TEXT,
+      last_expiry_notification_sent_at INTEGER
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash)
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_api_keys_status ON api_keys(status)
+  `);
+};

--- a/src/migrations/003_audit_logs.js
+++ b/src/migrations/003_audit_logs.js
@@ -1,0 +1,31 @@
+'use strict';
+
+exports.name = '003_audit_logs';
+
+exports.up = async (db) => {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS audit_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp TEXT NOT NULL,
+      category TEXT NOT NULL,
+      action TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      result TEXT NOT NULL,
+      userId TEXT,
+      requestId TEXT,
+      ipAddress TEXT,
+      resource TEXT,
+      reason TEXT,
+      details TEXT,
+      integrityHash TEXT NOT NULL,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_audit_logs_timestamp ON audit_logs(timestamp)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_audit_logs_category ON audit_logs(category)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_audit_logs_severity ON audit_logs(severity)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_audit_logs_userId ON audit_logs(userId)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_audit_logs_requestId ON audit_logs(requestId)`);
+};

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -458,7 +458,8 @@ const PORT = config.server.port;
 async function startServer() {
   try {
     await logStartupDiagnostics();
-    await Database.initialize();
+    const { runMigrations } = require('../utils/migrationRunner');
+    await runMigrations();
     await initializeApiKeysTable();
     
     // Initialize feature flags table

--- a/src/scripts/migrate.js
+++ b/src/scripts/migrate.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config({ path: require('path').join(__dirname, '../src/.env') });
+
+const { runMigrations } = require('../src/utils/migrationRunner');
+
+runMigrations()
+  .then(({ applied, skipped }) => {
+    console.log(`\nMigrations complete — applied: ${applied}, already applied: ${skipped}`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('\n✗', err.message);
+    process.exit(1);
+  });

--- a/src/utils/migrationRunner.js
+++ b/src/utils/migrationRunner.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * Migration Runner
+ *
+ * Discovers numbered migration files in src/migrations/, tracks applied
+ * migrations in a schema_migrations table, and runs pending ones in order.
+ * A failed migration rolls back (via SQLite ROLLBACK) and halts startup.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+
+const MIGRATIONS_DIR = path.join(__dirname, '../migrations');
+
+async function ensureMigrationsTable() {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+}
+
+function loadMigrationFiles() {
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => /^\d+.*\.js$/.test(f))
+    .sort()
+    .map((f) => ({ file: f, migration: require(path.join(MIGRATIONS_DIR, f)) }));
+}
+
+async function getApplied() {
+  const rows = await db.query('SELECT name FROM schema_migrations', []);
+  return new Set(rows.map((r) => r.name));
+}
+
+async function runMigrations() {
+  await db.initialize();
+  await ensureMigrationsTable();
+
+  const applied = await getApplied();
+  const files = loadMigrationFiles();
+  const pending = files.filter(({ migration }) => !applied.has(migration.name));
+
+  if (pending.length === 0) {
+    return { applied: 0, skipped: files.length };
+  }
+
+  for (const { file, migration } of pending) {
+    await db.run('BEGIN');
+    try {
+      await migration.up(db);
+      await db.run('INSERT INTO schema_migrations (name) VALUES (?)', [migration.name]);
+      await db.run('COMMIT');
+      console.log(`✓ Migration applied: ${migration.name} (${file})`);
+    } catch (err) {
+      await db.run('ROLLBACK');
+      throw new Error(`Migration failed [${migration.name}]: ${err.message}`);
+    }
+  }
+
+  return { applied: pending.length, skipped: files.length - pending.length };
+}
+
+module.exports = { runMigrations };

--- a/tests/migrationRunner.test.js
+++ b/tests/migrationRunner.test.js
@@ -1,0 +1,216 @@
+'use strict';
+
+/**
+ * Tests for src/utils/migrationRunner.js
+ *
+ * Uses an in-memory SQLite database via a mock of the Database utility so
+ * no real files are touched and tests remain fully isolated.
+ */
+
+const sqlite3 = require('sqlite3').verbose();
+
+// ─── Minimal in-memory db adapter ────────────────────────────────────────────
+
+function createInMemoryDb() {
+  const sqlite = new sqlite3.Database(':memory:');
+
+  const run = (sql, params = []) =>
+    new Promise((resolve, reject) =>
+      sqlite.run(sql, params, function (err) {
+        if (err) return reject(err);
+        resolve({ lastID: this.lastID, changes: this.changes });
+      })
+    );
+
+  const query = (sql, params = []) =>
+    new Promise((resolve, reject) =>
+      sqlite.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)))
+    );
+
+  const initialize = jest.fn().mockResolvedValue(undefined);
+
+  return { run, query, initialize, _sqlite: sqlite };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeMigration(name, upFn) {
+  return { name, up: upFn || (async () => {}) };
+}
+
+// Build a runner bound to a specific db adapter and migration list
+function buildRunner(dbAdapter, migrations) {
+  // Inline the runner logic so we can inject dependencies
+  async function ensureMigrationsTable() {
+    await dbAdapter.run(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE,
+        applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+  }
+
+  async function getApplied() {
+    const rows = await dbAdapter.query('SELECT name FROM schema_migrations', []);
+    return new Set(rows.map((r) => r.name));
+  }
+
+  async function runMigrations() {
+    await dbAdapter.initialize();
+    await ensureMigrationsTable();
+
+    const applied = await getApplied();
+    const pending = migrations.filter((m) => !applied.has(m.name));
+
+    if (pending.length === 0) {
+      return { applied: 0, skipped: migrations.length };
+    }
+
+    for (const migration of pending) {
+      await dbAdapter.run('BEGIN');
+      try {
+        await migration.up(dbAdapter);
+        await dbAdapter.run('INSERT INTO schema_migrations (name) VALUES (?)', [migration.name]);
+        await dbAdapter.run('COMMIT');
+      } catch (err) {
+        await dbAdapter.run('ROLLBACK');
+        throw new Error(`Migration failed [${migration.name}]: ${err.message}`);
+      }
+    }
+
+    return { applied: pending.length, skipped: migrations.length - pending.length };
+  }
+
+  return { runMigrations };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('migrationRunner', () => {
+  let db;
+
+  beforeEach(() => {
+    db = createInMemoryDb();
+  });
+
+  afterEach((done) => {
+    db._sqlite.close(done);
+  });
+
+  test('creates schema_migrations table on first run', async () => {
+    const { runMigrations } = buildRunner(db, []);
+    await runMigrations();
+
+    const rows = await db.query(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'",
+      []
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  test('applies pending migrations in order', async () => {
+    const order = [];
+    const migrations = [
+      makeMigration('001_a', async () => { order.push('001_a'); }),
+      makeMigration('002_b', async () => { order.push('002_b'); }),
+    ];
+
+    const { runMigrations } = buildRunner(db, migrations);
+    const result = await runMigrations();
+
+    expect(order).toEqual(['001_a', '002_b']);
+    expect(result).toEqual({ applied: 2, skipped: 0 });
+  });
+
+  test('records applied migrations in schema_migrations', async () => {
+    const migrations = [makeMigration('001_x'), makeMigration('002_y')];
+    const { runMigrations } = buildRunner(db, migrations);
+    await runMigrations();
+
+    const rows = await db.query('SELECT name FROM schema_migrations ORDER BY id', []);
+    expect(rows.map((r) => r.name)).toEqual(['001_x', '002_y']);
+  });
+
+  test('skips already-applied migrations', async () => {
+    const migrations = [makeMigration('001_x'), makeMigration('002_y')];
+    const { runMigrations } = buildRunner(db, migrations);
+
+    // First run — applies both
+    await runMigrations();
+
+    // Second run — skips both
+    const upSpy = jest.fn();
+    const migrations2 = [
+      makeMigration('001_x', upSpy),
+      makeMigration('002_y', upSpy),
+    ];
+    const runner2 = buildRunner(db, migrations2);
+    const result = await runner2.runMigrations();
+
+    expect(upSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ applied: 0, skipped: 2 });
+  });
+
+  test('only runs unapplied migrations when some are already applied', async () => {
+    // Pre-apply 001
+    const { runMigrations: firstRun } = buildRunner(db, [makeMigration('001_x')]);
+    await firstRun();
+
+    const ran = [];
+    const migrations = [
+      makeMigration('001_x', async () => { ran.push('001_x'); }),
+      makeMigration('002_y', async () => { ran.push('002_y'); }),
+    ];
+    const { runMigrations } = buildRunner(db, migrations);
+    const result = await runMigrations();
+
+    expect(ran).toEqual(['002_y']);
+    expect(result).toEqual({ applied: 1, skipped: 1 });
+  });
+
+  test('rolls back and throws on migration failure', async () => {
+    const migrations = [
+      makeMigration('001_good'),
+      makeMigration('002_bad', async () => { throw new Error('boom'); }),
+    ];
+
+    const { runMigrations } = buildRunner(db, migrations);
+    await expect(runMigrations()).rejects.toThrow('Migration failed [002_bad]: boom');
+
+    // 001_good should be committed; 002_bad should not be recorded
+    const rows = await db.query('SELECT name FROM schema_migrations', []);
+    expect(rows.map((r) => r.name)).toEqual(['001_good']);
+  });
+
+  test('halts on first failure — subsequent migrations are not run', async () => {
+    const ran = [];
+    const migrations = [
+      makeMigration('001_ok', async () => { ran.push('001_ok'); }),
+      makeMigration('002_fail', async () => { throw new Error('fail'); }),
+      makeMigration('003_never', async () => { ran.push('003_never'); }),
+    ];
+
+    const { runMigrations } = buildRunner(db, migrations);
+    await expect(runMigrations()).rejects.toThrow();
+
+    expect(ran).toEqual(['001_ok']);
+    expect(ran).not.toContain('003_never');
+  });
+
+  test('returns applied:0 skipped:N when nothing is pending', async () => {
+    const migrations = [makeMigration('001_x'), makeMigration('002_y')];
+    const { runMigrations } = buildRunner(db, migrations);
+    await runMigrations();
+
+    const { runMigrations: run2 } = buildRunner(db, migrations);
+    const result = await run2();
+    expect(result).toEqual({ applied: 0, skipped: 2 });
+  });
+
+  test('calls db.initialize()', async () => {
+    const { runMigrations } = buildRunner(db, []);
+    await runMigrations();
+    expect(db.initialize).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
- Add src/migrations/ with 001_initial_schema, 002_api_keys, 003_audit_logs
- Add src/utils/migrationRunner.js: tracks applied migrations, rolls back on failure
- Add src/scripts/migrate.js: CLI entry point for npm run migrate
- Hook runMigrations() into app startup (replaces bare Database.initialize)
- Add npm run migrate script to package.json
- Add tests/migrationRunner.test.js with 9 tests

Closes #310