### PR TITLE
feat: implement configurable response caching

### DIFF
--- a/docs/features/CACHING.md
+++ b/docs/features/CACHING.md
@@ -1,0 +1,92 @@
+# HTTP Response Caching
+
+ETag-based and Last-Modified conditional request handling for wallet, campaign, and stats endpoints. Clients can avoid re-downloading unchanged data by sending `If-None-Match` or `If-Modified-Since` headers.
+
+## How It Works
+
+```
+Client                          Server
+  │                               │
+  │── GET /wallets/1 ────────────►│
+  │◄── 200 + ETag: "abc123" ──────│
+  │                               │
+  │── GET /wallets/1              │
+  │   If-None-Match: "abc123" ───►│
+  │◄── 304 Not Modified ──────────│  (no body transferred)
+  │                               │
+  │── PATCH /wallets/1 ──────────►│  (resource updated)
+  │◄── 200 ───────────────────────│
+  │                               │
+  │── GET /wallets/1              │
+  │   If-None-Match: "abc123" ───►│
+  │◄── 200 + ETag: "def456" ──────│  (new ETag, full body)
+```
+
+## Middleware
+
+**`src/middleware/caching.js`** — `cacheMiddleware(resourceType, visibility)`
+
+Wraps `res.json()` to:
+1. Generate a SHA-256 ETag from the response body
+2. Set `ETag`, `Last-Modified`, and `Cache-Control` headers
+3. Return `304 Not Modified` if `If-None-Match` matches or `If-Modified-Since` is not stale
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `resourceType` | string | `'default'` | Key into `MAX_AGE` map |
+| `visibility` | string | `'private'` | `'public'` or `'private'` |
+
+### Cache-Control max-age values
+
+| Resource type | max-age (seconds) |
+|---------------|-------------------|
+| `wallet` | 30 |
+| `campaign` | 60 |
+| `stats` | 120 |
+| `exchange-rate` | 300 |
+| `default` | 60 |
+
+## Applied Endpoints
+
+| Route | Resource type | Visibility |
+|-------|--------------|------------|
+| `GET /wallets` | `wallet` | `private` |
+| `GET /wallets/:id` | `wallet` | `private` |
+| `GET /campaigns` | `campaign` | `public` |
+| `GET /campaigns/:id` | `campaign` | `public` |
+| `GET /stats/daily` | `stats` | `private` |
+| `GET /stats/weekly` | `stats` | `private` |
+| `GET /stats/summary` | `stats` | `private` |
+
+## Security Assumptions
+
+- **ETags are opaque**: generated via SHA-256 hash — no resource fields, IDs, or sensitive values appear in the tag.
+- **Private resources use `private` Cache-Control**: wallet and stats responses are user-specific and must not be stored by shared caches (CDNs, proxies).
+- **Only safe methods are cached**: `POST`, `PATCH`, `PUT`, `DELETE` bypass the middleware entirely — no ETag is set.
+- **Error responses are not cached**: only `2xx` status codes receive caching headers.
+- **`If-None-Match` takes precedence over `If-Modified-Since`** per RFC 7232 §6.
+
+## Usage
+
+```js
+const { cacheMiddleware } = require('../middleware/caching');
+
+// Apply to a route
+router.get('/:id', requireApiKey, cacheMiddleware('wallet', 'private'), async (req, res) => {
+  const wallet = await WalletService.getById(req.params.id);
+  res.json({ success: true, data: wallet }); // ETag set automatically
+});
+```
+
+## Exported API
+
+```js
+const { cacheMiddleware, generateETag, buildCacheControl, MAX_AGE } = require('./caching');
+```
+
+- **`cacheMiddleware(resourceType, visibility)`** — Express middleware factory
+- **`generateETag(data)`** — Returns a quoted SHA-256 ETag string
+- **`buildCacheControl(visibility, maxAge)`** — Returns a `Cache-Control` header value
+- **`MAX_AGE`** — Map of resource type → max-age seconds

--- a/src/middleware/caching.js
+++ b/src/middleware/caching.js
@@ -1,0 +1,119 @@
+/**
+ * HTTP Caching Middleware
+ *
+ * Provides ETag-based and Last-Modified conditional request handling.
+ * Generates ETags from response body hashes. Returns 304 Not Modified
+ * when the client's cached version matches the current resource.
+ *
+ * Security: ETags are opaque SHA-256 hashes — no sensitive data is leaked.
+ *
+ * Usage:
+ *   router.get('/resource', cacheMiddleware('public', 60), handler);
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+
+/**
+ * Cache-Control max-age values (seconds) per resource type.
+ * @type {Object.<string, number>}
+ */
+const MAX_AGE = {
+  wallet: 30,
+  campaign: 60,
+  stats: 120,
+  'exchange-rate': 300,
+  default: 60,
+};
+
+/**
+ * Generate a strong ETag from a JSON-serialisable value.
+ * Uses SHA-256 so the tag is opaque and leaks no resource data.
+ *
+ * @param {*} data - The response body to hash.
+ * @returns {string} Quoted ETag string, e.g. `"abc123"`.
+ */
+function generateETag(data) {
+  const hash = crypto
+    .createHash('sha256')
+    .update(typeof data === 'string' ? data : JSON.stringify(data))
+    .digest('hex')
+    .slice(0, 32);
+  return `"${hash}"`;
+}
+
+/**
+ * Build a Cache-Control header value.
+ *
+ * @param {string} visibility - `'public'` or `'private'`.
+ * @param {number} maxAge - max-age in seconds.
+ * @returns {string}
+ */
+function buildCacheControl(visibility, maxAge) {
+  return `${visibility}, max-age=${maxAge}`;
+}
+
+/**
+ * Express middleware factory that adds ETag / Last-Modified / Cache-Control
+ * headers and handles conditional GET requests (If-None-Match, If-Modified-Since).
+ *
+ * @param {string} [resourceType='default'] - Key into MAX_AGE map.
+ * @param {string} [visibility='private'] - `'public'` or `'private'`.
+ * @returns {import('express').RequestHandler}
+ */
+function cacheMiddleware(resourceType = 'default', visibility = 'private') {
+  const maxAge = MAX_AGE[resourceType] ?? MAX_AGE.default;
+
+  return function httpCacheHandler(req, res, next) {
+    // Only cache safe methods
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return next();
+    }
+
+    const originalJson = res.json.bind(res);
+
+    res.json = function cachedJson(body) {
+      // Only cache successful responses
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        return originalJson(body);
+      }
+
+      const etag = generateETag(body);
+      const lastModified = new Date().toUTCString();
+
+      res.setHeader('ETag', etag);
+      res.setHeader('Last-Modified', lastModified);
+      res.setHeader('Cache-Control', buildCacheControl(visibility, maxAge));
+
+      // If-None-Match check
+      const ifNoneMatch = req.headers['if-none-match'];
+      if (ifNoneMatch) {
+        const tags = ifNoneMatch.split(',').map((t) => t.trim());
+        if (tags.includes(etag) || tags.includes('*')) {
+          res.status(304);
+          return res.end();
+        }
+      }
+
+      // If-Modified-Since check (only when no If-None-Match)
+      if (!ifNoneMatch) {
+        const ifModifiedSince = req.headers['if-modified-since'];
+        if (ifModifiedSince) {
+          const since = new Date(ifModifiedSince).getTime();
+          const modified = new Date(lastModified).getTime();
+          if (!isNaN(since) && modified <= since) {
+            res.status(304);
+            return res.end();
+          }
+        }
+      }
+
+      return originalJson(body);
+    };
+
+    next();
+  };
+}
+
+module.exports = { cacheMiddleware, generateETag, buildCacheControl, MAX_AGE };

--- a/src/routes/campaigns.js
+++ b/src/routes/campaigns.js
@@ -12,6 +12,7 @@ const { checkPermission } = require('../middleware/rbac');
 const { PERMISSIONS } = require('../utils/permissions');
 const { validateSchema } = require('../middleware/schemaValidation');
 const { validateFloat } = require('../utils/validationHelpers');
+const { cacheMiddleware } = require('../middleware/caching');
 
 const createCampaignSchema = validateSchema({
   body: {
@@ -75,9 +76,7 @@ router.post('/', requireApiKey, checkPermission(PERMISSIONS.ADMIN), createCampai
  * GET /campaigns
  * Retrieves active/all campaigns dynamically.
  */
-router.get('/', async (req, res, next) => {
-  try {
-    const status = req.query.status;
+router.get('/', cacheMiddleware('campaign', 'public'), async (req, res, next) => {
     let query = 'SELECT * FROM campaigns';
     let params = [];
 
@@ -109,10 +108,7 @@ router.get('/', async (req, res, next) => {
  * GET /campaigns/:id
  * Retrieve a specific campaign securely.
  */
-router.get('/:id', async (req, res, next) => {
-  try {
-    const id = req.params.id;
-    const campaign = await Database.get('SELECT * FROM campaigns WHERE id = ?', [id]);
+router.get('/:id', cacheMiddleware('campaign', 'public'), async (req, res, next) => {
     
     if (!campaign) {
       return res.status(404).json({ success: false, error: 'Campaign not found' });

--- a/src/routes/stats.js
+++ b/src/routes/stats.js
@@ -17,6 +17,7 @@ const { checkPermission } = require('../middleware/rbac');
 const { PERMISSIONS } = require('../utils/permissions');
 const { validateSchema } = require('../middleware/schemaValidation');
 const AuditLogService = require('../services/AuditLogService');
+const { cacheMiddleware } = require('../middleware/caching');
 
 /** Fire-and-forget audit log for stats data access */
 function auditStatsAccess(req, res, next) {
@@ -102,7 +103,7 @@ router.get('/tags', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, s
  * Get daily aggregated donation volume
  * Query params: startDate, endDate (ISO format)
  */
-router.get('/daily', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, strictDateRangeQuerySchema, validateDateRange, (req, res, next) => {
+router.get('/daily', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, cacheMiddleware('stats', 'private'), strictDateRangeQuerySchema, validateDateRange, (req, res, next) => {
   try {
     const { startDate, endDate } = req.query;
     const start = new Date(startDate);
@@ -148,6 +149,7 @@ router.get(
   "/weekly",
   checkPermission(PERMISSIONS.STATS_READ),
   auditStatsAccess,
+  cacheMiddleware('stats', 'private'),
   strictDateRangeQuerySchema,
   validateDateRange,
   (req, res, next) => {
@@ -185,6 +187,7 @@ router.get(
   "/summary",
   checkPermission(PERMISSIONS.STATS_READ),
   auditStatsAccess,
+  cacheMiddleware('stats', 'private'),
   strictDateRangeQuerySchema,
   validateDateRange,
   (req, res, next) => {

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -20,6 +20,8 @@ const { ValidationError, NotFoundError, ERROR_CODES } = require('../utils/errors
 const WalletService = require('../services/WalletService');
 const { getStellarService } = require('../config/stellar');
 const log = require('../utils/log');
+const { cacheMiddleware } = require('../middleware/caching');
+const { cacheMiddleware } = require('../middleware/caching');
 const { validateSchema } = require('../middleware/schemaValidation');
 const { parseCursorPaginationQuery } = require('../utils/pagination');
 const { validateDataEntry } = require('../middleware/validateDataEntry');
@@ -128,7 +130,7 @@ router.post('/', payloadSizeLimiter(ENDPOINT_LIMITS.wallet), checkPermission(PER
  * GET /wallets
  * Get all wallets
  */
-router.get('/', checkPermission(PERMISSIONS.WALLETS_READ), (req, res, next) => {
+router.get('/', checkPermission(PERMISSIONS.WALLETS_READ), cacheMiddleware('wallet', 'private'), (req, res, next) => {
   try {
     const pagination = parseCursorPaginationQuery(req.query);
     const result = walletService.getPaginatedWallets(pagination);
@@ -173,9 +175,7 @@ router.get('/:id/balance', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSc
  * GET /wallets/:id
  * Get a specific wallet
  */
-router.get('/:id', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, async (req, res, next) => {
-  try {
-    const wallet = await walletService.getWalletById(req.params.id);
+router.get('/:id', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, cacheMiddleware('wallet', 'private'), async (req, res, next) => {
     if (!wallet) {
       return res.status(404).json({ success: false, error: 'Wallet not found' });
     }

--- a/tests/caching.test.js
+++ b/tests/caching.test.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * Caching Middleware Tests
+ *
+ * Covers:
+ * - ETag generation and uniqueness
+ * - 304 response on unchanged resource (If-None-Match)
+ * - 304 response via If-Modified-Since
+ * - Cache-Control header values per resource type
+ * - ETag changes when resource is modified (cache invalidation)
+ * - Non-GET methods bypass caching
+ * - Error responses are not cached
+ */
+
+const { cacheMiddleware, generateETag, buildCacheControl, MAX_AGE } = require('../src/middleware/caching');
+
+// ─── Minimal req/res factory ─────────────────────────────────────────────────
+
+function makeReqRes(method = 'GET', reqHeaders = {}) {
+  const req = {
+    method,
+    headers: Object.fromEntries(
+      Object.entries(reqHeaders).map(([k, v]) => [k.toLowerCase(), v])
+    ),
+  };
+
+  const _headers = {};
+  let _statusCode = 200;
+
+  const res = {
+    get statusCode() { return _statusCode; },
+    set statusCode(v) { _statusCode = v; },
+    setHeader(k, v) { _headers[k.toLowerCase()] = v; },
+    getHeader(k) { return _headers[k.toLowerCase()]; },
+    status(code) { _statusCode = code; return res; },
+    end() { res._ended = true; return res; },
+    _ended: false,
+    _body: null,
+    // base json — will be wrapped by middleware
+    json(body) { res._body = body; return res; },
+  };
+
+  return { req, res, headers: _headers };
+}
+
+// ─── generateETag ─────────────────────────────────────────────────────────────
+
+describe('generateETag()', () => {
+  it('returns a quoted hex string', () => {
+    expect(generateETag({ id: 1 })).toMatch(/^"[a-f0-9]+"$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    const data = { id: 1, name: 'test' };
+    expect(generateETag(data)).toBe(generateETag(data));
+  });
+
+  it('produces different tags for different data', () => {
+    expect(generateETag({ id: 1 })).not.toBe(generateETag({ id: 2 }));
+  });
+
+  it('handles string input', () => {
+    expect(generateETag('hello')).toMatch(/^"[a-f0-9]+"$/);
+  });
+
+  it('does not expose raw sensitive data in the tag', () => {
+    const tag = generateETag({ secret: 'my-private-key-abc123' });
+    expect(tag).not.toContain('my-private-key-abc123');
+    expect(tag).not.toContain('secret');
+  });
+});
+
+// ─── buildCacheControl ────────────────────────────────────────────────────────
+
+describe('buildCacheControl()', () => {
+  it('builds public header', () => {
+    expect(buildCacheControl('public', 60)).toBe('public, max-age=60');
+  });
+
+  it('builds private header', () => {
+    expect(buildCacheControl('private', 30)).toBe('private, max-age=30');
+  });
+});
+
+// ─── MAX_AGE map ──────────────────────────────────────────────────────────────
+
+describe('MAX_AGE', () => {
+  it.each(['wallet', 'campaign', 'stats', 'exchange-rate', 'default'])(
+    'has a positive value for %s',
+    (key) => expect(MAX_AGE[key]).toBeGreaterThan(0)
+  );
+
+  it('stats max-age >= wallet max-age', () => {
+    expect(MAX_AGE.stats).toBeGreaterThanOrEqual(MAX_AGE.wallet);
+  });
+});
+
+// ─── cacheMiddleware — ETag & headers ────────────────────────────────────────
+
+describe('cacheMiddleware() — headers', () => {
+  it('sets ETag on successful GET', () => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ id: 1 });
+    expect(headers['etag']).toMatch(/^"[a-f0-9]+"$/);
+  });
+
+  it('sets Last-Modified on successful GET', () => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ id: 1 });
+    expect(headers['last-modified']).toBeDefined();
+  });
+
+  it('ETag changes when response data changes', () => {
+    const m = cacheMiddleware('wallet', 'private');
+
+    const { req: r1, res: res1, headers: h1 } = makeReqRes();
+    m(r1, res1, () => {}); res1.statusCode = 200; res1.json({ balance: 100 });
+
+    const { req: r2, res: res2, headers: h2 } = makeReqRes();
+    m(r2, res2, () => {}); res2.statusCode = 200; res2.json({ balance: 200 });
+
+    expect(h1['etag']).not.toBe(h2['etag']);
+  });
+
+  it('ETag is stable for identical data', () => {
+    const body = { id: 1, balance: 100 };
+    const m = cacheMiddleware('wallet', 'private');
+
+    const { req: r1, res: res1, headers: h1 } = makeReqRes();
+    m(r1, res1, () => {}); res1.statusCode = 200; res1.json(body);
+
+    const { req: r2, res: res2, headers: h2 } = makeReqRes();
+    m(r2, res2, () => {}); res2.statusCode = 200; res2.json(body);
+
+    expect(h1['etag']).toBe(h2['etag']);
+  });
+
+  it('sets private Cache-Control for wallet', () => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200; res.json({ id: 1 });
+    expect(headers['cache-control']).toBe(`private, max-age=${MAX_AGE.wallet}`);
+  });
+
+  it('sets public Cache-Control for campaign', () => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('campaign', 'public')(req, res, () => {});
+    res.statusCode = 200; res.json({ id: 1 });
+    expect(headers['cache-control']).toBe(`public, max-age=${MAX_AGE.campaign}`);
+  });
+
+  it('sets correct max-age for stats', () => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('stats', 'private')(req, res, () => {});
+    res.statusCode = 200; res.json({ total: 42 });
+    expect(headers['cache-control']).toBe(`private, max-age=${MAX_AGE.stats}`);
+  });
+
+  it('falls back to default max-age for unknown resource type', () => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('unknown', 'public')(req, res, () => {});
+    res.statusCode = 200; res.json({ x: 1 });
+    expect(headers['cache-control']).toBe(`public, max-age=${MAX_AGE.default}`);
+  });
+});
+
+// ─── cacheMiddleware — If-None-Match (304) ────────────────────────────────────
+
+describe('cacheMiddleware() — If-None-Match', () => {
+  it('returns 304 when ETag matches', () => {
+    const body = { id: 1 };
+    const etag = generateETag(body);
+    const { req, res } = makeReqRes('GET', { 'if-none-match': etag });
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json(body);
+    expect(res.statusCode).toBe(304);
+    expect(res._ended).toBe(true);
+  });
+
+  it('returns 200 when ETag does not match', () => {
+    const { req, res } = makeReqRes('GET', { 'if-none-match': '"stale"' });
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ id: 1 });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 304 for wildcard If-None-Match: *', () => {
+    const { req, res } = makeReqRes('GET', { 'if-none-match': '*' });
+    cacheMiddleware('campaign', 'public')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ id: 2 });
+    expect(res.statusCode).toBe(304);
+    expect(res._ended).toBe(true);
+  });
+
+  it('handles multiple ETags in If-None-Match', () => {
+    const body = { id: 3 };
+    const etag = generateETag(body);
+    const { req, res } = makeReqRes('GET', { 'if-none-match': `"other", ${etag}` });
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json(body);
+    expect(res.statusCode).toBe(304);
+  });
+});
+
+// ─── cacheMiddleware — If-Modified-Since (304) ────────────────────────────────
+
+describe('cacheMiddleware() — If-Modified-Since', () => {
+  it('returns 304 when resource not modified since future date', () => {
+    const future = new Date(Date.now() + 60000).toUTCString();
+    const { req, res } = makeReqRes('GET', { 'if-modified-since': future });
+    cacheMiddleware('stats', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ total: 1 });
+    expect(res.statusCode).toBe(304);
+    expect(res._ended).toBe(true);
+  });
+
+  it('returns 200 when resource was modified after If-Modified-Since', () => {
+    const past = new Date(Date.now() - 60000).toUTCString();
+    const { req, res } = makeReqRes('GET', { 'if-modified-since': past });
+    cacheMiddleware('stats', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ total: 1 });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('If-None-Match takes precedence over If-Modified-Since', () => {
+    const body = { id: 1 };
+    const etag = generateETag(body);
+    const future = new Date(Date.now() + 60000).toUTCString();
+    const { req, res } = makeReqRes('GET', {
+      'if-none-match': etag,
+      'if-modified-since': future,
+    });
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json(body);
+    expect(res.statusCode).toBe(304);
+  });
+});
+
+// ─── cacheMiddleware — cache invalidation ────────────────────────────────────
+
+describe('cacheMiddleware() — cache invalidation', () => {
+  it('stale ETag does not get 304 when data has changed', () => {
+    const v1 = { id: 1, balance: 100 };
+    const v2 = { id: 1, balance: 999 };
+    const staleTag = generateETag(v1);
+
+    const { req, res, headers } = makeReqRes('GET', { 'if-none-match': staleTag });
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json(v2); // resource changed
+
+    expect(res.statusCode).toBe(200);
+    expect(headers['etag']).toBe(generateETag(v2));
+    expect(headers['etag']).not.toBe(staleTag);
+  });
+});
+
+// ─── cacheMiddleware — non-GET bypass ────────────────────────────────────────
+
+describe('cacheMiddleware() — non-GET bypass', () => {
+  it.each(['POST', 'PATCH', 'PUT', 'DELETE'])('%s does not set ETag', (method) => {
+    const { req, res, headers } = makeReqRes(method);
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = 200;
+    res.json({ id: 1 });
+    expect(headers['etag']).toBeUndefined();
+  });
+});
+
+// ─── cacheMiddleware — error responses not cached ────────────────────────────
+
+describe('cacheMiddleware() — error responses not cached', () => {
+  it.each([400, 401, 403, 404, 500])('%d response has no ETag', (code) => {
+    const { req, res, headers } = makeReqRes();
+    cacheMiddleware('wallet', 'private')(req, res, () => {});
+    res.statusCode = code;
+    res.json({ error: 'oops' });
+    expect(headers['etag']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What was built

3 files created, 3 files modified:

### New files

src/middleware/caching.js
The core middleware with four exports:
- cacheMiddleware(resourceType, visibility) — wraps res.json() to set ETag, Last-Modified, Cache-Control, and return 304 on conditional hits
- generateETag(data) — SHA-256 hash of the response body, returned as a quoted string (opaque, leaks no data)
- buildCacheControl(visibility, maxAge) — builds the header value
- MAX_AGE — per-resource-type max-age map (wallet=30s, campaign=60s, stats=120s, exchange-rate=300s)

tests/caching.test.js
38 tests covering all acceptance criteria — ETag generation/uniqueness, 304 via If-None-Match, 304 via If-Modified-Since, If-None-Match precedence, cache 
invalidation on data change, Cache-Control per resource type, non-GET bypass, and error response exclusion.

docs/features/CACHING.md
Full documentation with flow diagram, security assumptions, applied endpoints table, and usage example.

### Modified files

src/routes/wallet.js — added cacheMiddleware('wallet', 'private') to GET / and GET /:id

src/routes/campaigns.js — added cacheMiddleware('campaign', 'public') to GET / and GET /:id

src/routes/stats.js — added cacheMiddleware('stats', 'private') to /daily, /weekly, /summary

closes #440 