### PR TITLE
feat: add Stellar transaction history synchronization (#386)

### DIFF
--- a/docs/features/ADD_STELLAR_TRANSACTION_HISTORY_SYNCHRONIZATION.md
+++ b/docs/features/ADD_STELLAR_TRANSACTION_HISTORY_SYNCHRONIZATION.md
@@ -1,0 +1,168 @@
+# Add Stellar Transaction History Synchronization
+
+**Issue #386** — Scheduled background sync of wallet transactions from the Stellar Horizon network.
+
+## Overview
+
+This feature adds a robust, scheduled background service that keeps local wallet transaction records in sync with the Stellar Horizon network using incremental (cursor-based) pagination.
+
+## Architecture
+
+```
+TransactionSyncScheduler (setInterval, default 15 min)
+  └── TransactionSyncService.syncWalletTransactions(publicKey)
+        ├── Reads wallet.last_cursor  → passes to Horizon as cursor param
+        ├── Fetches only NEW transactions (asc order from cursor)
+        ├── Creates local Transaction records for unseen txs
+        └── Updates wallet.last_cursor + wallet.last_synced_at
+```
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `src/services/TransactionSyncScheduler.js` | Background scheduler service |
+| `tests/add-stellar-transaction-history-synchronization.test.js` | Feature test suite |
+| `docs/features/ADD_STELLAR_TRANSACTION_HISTORY_SYNCHRONIZATION.md` | This document |
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `src/routes/models/wallet.js` | Added `last_synced_at` and `last_cursor` fields |
+| `src/services/TransactionSyncService.js` | Incremental sync using `last_cursor`; updates both fields on success |
+| `src/config/serviceContainer.js` | Registers `TransactionSyncScheduler` singleton |
+| `src/routes/app.js` | Starts/stops scheduler; adds `POST /admin/sync`; adds `transactionSync` to `/health` |
+
+## Schema Changes
+
+Two new fields are added to the `Wallet` model (JSON file store):
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `last_synced_at` | ISO 8601 string \| null | `null` | Timestamp of the last successful sync attempt |
+| `last_cursor` | string \| null | `null` | Horizon paging token of the last synced transaction |
+
+## API
+
+### `POST /admin/sync`
+
+Triggers an immediate full sync for all registered wallets. Requires admin role.
+
+**Request:** No body required.
+
+**Response `200 OK`:**
+```json
+{
+  "success": true,
+  "message": "Transaction sync complete",
+  "data": {
+    "wallets": 5,
+    "synced": 12,
+    "errors": 0,
+    "completedAt": "2026-03-27T22:50:18.409Z"
+  }
+}
+```
+
+**Response `403 Forbidden`:** Non-admin API key.
+
+### `GET /health` — `transactionSync` field
+
+The health endpoint now includes a `transactionSync` object:
+
+```json
+{
+  "status": "healthy",
+  "transactionSync": {
+    "lastSyncAt": "2026-03-27T22:50:18.409Z",
+    "lastSyncResult": {
+      "wallets": 5,
+      "synced": 12,
+      "errors": 0,
+      "completedAt": "2026-03-27T22:50:18.409Z"
+    }
+  }
+}
+```
+
+`lastSyncAt` and `lastSyncResult` are `null` until the first sync completes.
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `TX_SYNC_INTERVAL_MS` | `900000` (15 min) | How often the scheduler runs a full sync pass |
+
+## JSDoc Reference
+
+### `TransactionSyncScheduler`
+
+```js
+/**
+ * @class TransactionSyncScheduler
+ * @param {Object} stellarService - StellarService or MockStellarService instance
+ * @param {Object} [options]
+ * @param {number} [options.intervalMs] - Override sync interval in milliseconds
+ */
+
+/**
+ * Start the scheduler. Runs an immediate sync, then repeats on every intervalMs.
+ * @method start
+ * @returns {void}
+ */
+
+/**
+ * Stop the scheduler and clear the interval.
+ * @method stop
+ * @returns {void}
+ */
+
+/**
+ * Trigger an immediate sync for all wallets. Safe to call from admin endpoints.
+ * @method syncAllWallets
+ * @returns {Promise<{wallets: number, synced: number, errors: number, completedAt: string}>}
+ */
+
+/**
+ * Return the status of the last global sync for health reporting.
+ * @method getSyncStatus
+ * @returns {{lastSyncAt: string|null, lastSyncResult: Object|null}}
+ */
+```
+
+### `TransactionSyncService.syncWalletTransactions` (updated)
+
+```js
+/**
+ * Sync wallet transactions from Stellar network to local database.
+ * Fetches only transactions AFTER the wallet's last_cursor (incremental sync).
+ * On success, updates wallet's last_cursor and last_synced_at.
+ *
+ * @param {string} publicKey - Stellar public key to sync
+ * @param {number} [maxTransactions=500] - Upper bound on transactions fetched per call
+ * @returns {Promise<{synced: number, transactions: Array}>}
+ */
+```
+
+## Partial Failure Handling
+
+If one wallet fails to sync (e.g. Horizon timeout, account not found), the scheduler:
+
+1. Logs the error with `walletId`, `address`, and `error.message`
+2. Increments the `errors` counter in the result
+3. **Continues** to the next wallet — the entire pass is never aborted
+
+This ensures a single bad wallet cannot block synchronization for all others.
+
+## Testing
+
+```bash
+# Run the feature tests
+npm test tests/add-stellar-transaction-history-synchronization.test.js
+
+# Run with coverage
+npm run test:coverage -- --testPathPattern=add-stellar-transaction-history-synchronization
+```
+
+All tests use `MockStellarService` — no live Stellar network calls are made.

--- a/src/config/serviceContainer.js
+++ b/src/config/serviceContainer.js
@@ -15,6 +15,7 @@ const RecurringDonationScheduler = require('../services/RecurringDonationSchedul
 const TransactionReconciliationService = require('../services/TransactionReconciliationService');
 const IdempotencyService = require('../services/IdempotencyService');
 const TransactionSyncService = require('../services/TransactionSyncService');
+const TransactionSyncScheduler = require('../services/TransactionSyncScheduler');
 const NetworkStatusService = require('../services/NetworkStatusService');
 const FeeBumpService = require('../services/FeeBumpService');
 const AuditLogService = require('../services/AuditLogService');
@@ -57,6 +58,10 @@ class ServiceContainer {
       this.stellarService
     );
 
+    this.transactionSyncScheduler = new TransactionSyncScheduler(
+      this.stellarService
+    );
+
     // Initialize Network Status Service
     this.networkStatusService = new NetworkStatusService(this.stellarService);
 
@@ -91,6 +96,10 @@ class ServiceContainer {
 
   getTransactionSyncService() {
     return this.transactionSyncService;
+  }
+
+  getTransactionSyncScheduler() {
+    return this.transactionSyncScheduler;
   }
 
   getNetworkStatusService() {

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -83,6 +83,7 @@ const stellarService = serviceContainer.getStellarService();
 const reconciliationService = serviceContainer.getTransactionReconciliationService();
 const recurringDonationScheduler = serviceContainer.getRecurringDonationScheduler();
 const networkStatusService = serviceContainer.getNetworkStatusService();
+const transactionSyncScheduler = serviceContainer.getTransactionSyncScheduler();
 
 // Initialize replay detection cleanup timer (will be started in startServer)
 let replayCleanupTimer = null;
@@ -279,6 +280,7 @@ app.get('/health', async (req, res) => {
   health.clientIp = req.ip;
   health.protocol = req.protocol;
   health.requestId = req.id;
+  health.transactionSync = transactionSyncScheduler.getSyncStatus();
   
   const httpStatus = health.status === 'unhealthy' ? 503 : 200;
   return res.status(httpStatus).json(health);
@@ -475,6 +477,20 @@ app.post('/admin/reconcile', require('../middleware/rbac').requireAdmin(), async
   }
 });
 
+// Admin sync endpoint — triggers immediate transaction sync for all wallets
+app.post('/admin/sync', require('../middleware/rbac').requireAdmin(), async (req, res, next) => {
+  try {
+    const result = await transactionSyncScheduler.syncAllWallets();
+    res.json({
+      success: true,
+      message: 'Transaction sync complete',
+      data: result,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // Orphaned transactions stats (admin only)
 app.get('/admin/orphaned-transactions', require('../middleware/rbac').requireAdmin(), async (req, res, next) => {
   try {
@@ -543,6 +559,7 @@ async function startServer() {
       recurringDonationScheduler.start();
       reconciliationService.start();
       auditLogRetentionService.start();
+      transactionSyncScheduler.start();
       
       // Start quota reset job
       const stopQuotaResetJob = startQuotaResetJob();
@@ -621,6 +638,7 @@ async function startServer() {
           recurringDonationScheduler.stop();
           reconciliationService.stop();
           auditLogRetentionService.stop();
+          transactionSyncScheduler.stop();
           require('../workers/expiryWorker').stop();
           
           // Stop quota reset job

--- a/src/routes/models/wallet.js
+++ b/src/routes/models/wallet.js
@@ -38,6 +38,8 @@ class Wallet {
       ownerName: walletData.ownerName || null,
       createdAt: new Date().toISOString(),
       deletedAt: null, // Initialized for soft-delete support
+      last_synced_at: null,
+      last_cursor: null,
       ...walletData
     };
     wallets.push(newWallet);

--- a/src/services/TransactionSyncScheduler.js
+++ b/src/services/TransactionSyncScheduler.js
@@ -1,0 +1,134 @@
+/**
+ * Transaction Sync Scheduler - Background Synchronization Service
+ *
+ * RESPONSIBILITY: Periodically syncs all registered wallets with the Stellar network
+ * OWNER: Backend Team
+ * DEPENDENCIES: TransactionSyncService, Wallet model
+ *
+ * Runs on a configurable interval (default: 15 minutes) and syncs each wallet
+ * incrementally using the last_cursor stored on the wallet record.
+ * Partial failures are logged and skipped — the scheduler continues to the next wallet.
+ */
+
+const Wallet = require('../routes/models/wallet');
+const TransactionSyncService = require('./TransactionSyncService');
+const log = require('../utils/log');
+
+/** Default sync interval: 15 minutes */
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
+
+class TransactionSyncScheduler {
+  /**
+   * @param {Object} stellarService - StellarService or MockStellarService instance
+   * @param {Object} [options]
+   * @param {number} [options.intervalMs] - Override sync interval in milliseconds
+   */
+  constructor(stellarService, options = {}) {
+    this.syncService = new TransactionSyncService(stellarService);
+    this.intervalMs = options.intervalMs
+      || parseInt(process.env.TX_SYNC_INTERVAL_MS, 10)
+      || DEFAULT_INTERVAL_MS;
+    this.intervalId = null;
+    this.isRunning = false;
+
+    /** Timestamp of the last completed global sync (ISO string or null) */
+    this.lastSyncAt = null;
+    /** Result summary of the last completed global sync */
+    this.lastSyncResult = null;
+  }
+
+  /**
+   * Start the scheduler.
+   * Runs an immediate sync, then repeats on every intervalMs.
+   * @returns {void}
+   */
+  start() {
+    if (this.isRunning) return;
+    this.isRunning = true;
+    log.info('TX_SYNC_SCHEDULER', 'Scheduler started', {
+      intervalMs: this.intervalMs,
+    });
+    this._runSync();
+    this.intervalId = setInterval(() => this._runSync(), this.intervalMs);
+  }
+
+  /**
+   * Stop the scheduler.
+   * @returns {void}
+   */
+  stop() {
+    if (!this.isRunning) return;
+    this.isRunning = false;
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    log.info('TX_SYNC_SCHEDULER', 'Scheduler stopped');
+  }
+
+  /**
+   * Trigger an immediate sync for all wallets.
+   * Safe to call manually (e.g. from the admin endpoint).
+   * @returns {Promise<{wallets: number, synced: number, errors: number, completedAt: string}>}
+   */
+  async syncAllWallets() {
+    return this._runSync();
+  }
+
+  /**
+   * Return the status of the last global sync for health reporting.
+   * @returns {{lastSyncAt: string|null, lastSyncResult: Object|null}}
+   */
+  getSyncStatus() {
+    return {
+      lastSyncAt: this.lastSyncAt,
+      lastSyncResult: this.lastSyncResult,
+    };
+  }
+
+  // ─── Private ─────────────────────────────────────────────────────────────
+
+  /**
+   * Execute one full sync pass over all registered wallets.
+   * Logs and continues on per-wallet errors (partial failure handling).
+   * @returns {Promise<{wallets: number, synced: number, errors: number, completedAt: string}>}
+   */
+  async _runSync() {
+    const wallets = Wallet.getAll();
+    let totalSynced = 0;
+    let errorCount = 0;
+
+    log.info('TX_SYNC_SCHEDULER', 'Starting sync pass', { walletCount: wallets.length });
+
+    for (const wallet of wallets) {
+      try {
+        const result = await this.syncService.syncWalletTransactions(wallet.address);
+        totalSynced += result.synced;
+      } catch (err) {
+        errorCount++;
+        log.error('TX_SYNC_SCHEDULER', 'Failed to sync wallet', {
+          walletId: wallet.id,
+          address: wallet.address,
+          error: err.message,
+        });
+        // Continue to next wallet — partial failure handling
+      }
+    }
+
+    const completedAt = new Date().toISOString();
+    const result = {
+      wallets: wallets.length,
+      synced: totalSynced,
+      errors: errorCount,
+      completedAt,
+    };
+
+    this.lastSyncAt = completedAt;
+    this.lastSyncResult = result;
+
+    log.info('TX_SYNC_SCHEDULER', 'Sync pass complete', result);
+    return result;
+  }
+}
+
+module.exports = TransactionSyncScheduler;

--- a/src/services/TransactionSyncService.js
+++ b/src/services/TransactionSyncService.js
@@ -33,8 +33,9 @@ class TransactionSyncService {
   }
 
   /**
-   * Sync wallet transactions from Stellar network to local database
-   * Fetches transactions from Horizon and creates local records for new ones
+   * Sync wallet transactions from Stellar network to local database.
+   * Fetches only transactions AFTER the wallet's last_cursor (incremental sync).
+   * On success, updates wallet's last_cursor and last_synced_at.
    * @param {string} publicKey - Stellar public key to sync
    * @param {number} maxTransactions - Limit for unbounded fetching
    * @returns {Promise<{synced: number, transactions: Array}>} Sync results
@@ -42,14 +43,14 @@ class TransactionSyncService {
   async syncWalletTransactions(publicKey, maxTransactions = 500) {
     const startTime = Date.now();
     const wallet = Wallet.getByAddress(publicKey);
-    const lastCursor = wallet ? wallet.last_synced_cursor : undefined;
+    const lastCursor = wallet ? (wallet.last_cursor || wallet.last_synced_cursor) : undefined;
 
     const horizonTxs = await this._fetchHorizonTransactions(publicKey, maxTransactions, lastCursor);
     const syncedTxs = [];
 
     // Horizon returns asc when fetching forward from cursor
     for (const tx of horizonTxs) {
-      const existing = Transaction.getByField('stellarTxId', tx.id);
+      const existing = Transaction.getByStellarTxId(tx.id);
       if (!existing) {
         const newTx = Transaction.create({
           stellarTxId: tx.id,
@@ -66,7 +67,13 @@ class TransactionSyncService {
       // Update the cursor using the latest transaction fetched
       // Txs are in asc order, so the last one is the newest
       const latestTx = horizonTxs[horizonTxs.length - 1];
-      Wallet.update(wallet.id, { last_synced_cursor: latestTx.paging_token });
+      Wallet.update(wallet.id, {
+        last_cursor: latestTx.paging_token,
+        last_synced_at: new Date().toISOString(),
+      });
+    } else if (wallet) {
+      // Even if no new txs, update last_synced_at to record the sync attempt
+      Wallet.update(wallet.id, { last_synced_at: new Date().toISOString() });
     }
 
     const duration = Date.now() - startTime;

--- a/tests/add-stellar-transaction-history-synchronization.test.js
+++ b/tests/add-stellar-transaction-history-synchronization.test.js
@@ -1,0 +1,524 @@
+/**
+ * Tests: Add Stellar Transaction History Synchronization (Issue #386)
+ *
+ * Coverage targets:
+ *  - TransactionSyncService incremental sync (last_cursor / last_synced_at)
+ *  - TransactionSyncScheduler lifecycle, partial-failure handling, getSyncStatus
+ *  - Wallet model last_synced_at / last_cursor fields
+ *  - POST /admin/sync endpoint (auth + response shape)
+ *  - GET /health transactionSync field
+ *
+ * All Stellar interactions use MockStellarService — no live network calls.
+ */
+
+'use strict';
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+// ─── Isolate file-based models to a temp directory ───────────────────────────
+let tmpDir;
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tx-sync-test-'));
+  process.env.DB_JSON_PATH = path.join(tmpDir, 'donations.json');
+  process.env.WALLETS_DB_PATH = path.join(tmpDir, 'wallets.json');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Imports (after env is set) ───────────────────────────────────────────────
+const MockStellarService = require('../src/services/MockStellarService');
+const TransactionSyncService = require('../src/services/TransactionSyncService');
+const TransactionSyncScheduler = require('../src/services/TransactionSyncScheduler');
+const Wallet = require('../src/routes/models/wallet');
+const Transaction = require('../src/routes/models/transaction');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a minimal Horizon-style transaction record */
+function makeTx(id, pagingToken) {
+  return {
+    id,
+    paging_token: pagingToken || id,
+    created_at: new Date().toISOString(),
+    memo: null,
+    source_account: 'GSOURCE',
+    successful: true,
+  };
+}
+
+/** Reset file-based stores between tests */
+function resetStores() {
+  fs.writeFileSync(process.env.DB_JSON_PATH, '[]');
+  const walletsPath = process.env.WALLETS_DB_PATH || path.join(tmpDir, 'wallets.json');
+  fs.writeFileSync(walletsPath, '[]');
+}
+
+// Patch Wallet to use the temp path
+const WALLETS_DB_PATH_ORIG = './data/wallets.json';
+beforeEach(() => {
+  resetStores();
+  // Override the path constant used by Wallet
+  Wallet.__testWalletsPath = path.join(tmpDir, 'wallets.json');
+});
+
+// Monkey-patch Wallet to use the temp path for all tests
+const _origLoad = Wallet.loadWallets.bind(Wallet);
+const _origSave = Wallet.saveWallets.bind(Wallet);
+Wallet.loadWallets = function () {
+  const p = path.join(tmpDir, 'wallets.json');
+  if (!fs.existsSync(p)) return [];
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return []; }
+};
+Wallet.saveWallets = function (wallets) {
+  fs.writeFileSync(path.join(tmpDir, 'wallets.json'), JSON.stringify(wallets, null, 2));
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Wallet model — schema fields
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Wallet model — last_synced_at and last_cursor fields', () => {
+  test('new wallet has null last_synced_at and last_cursor', () => {
+    const w = Wallet.create({ address: 'GABC1', label: 'test' });
+    expect(w.last_synced_at).toBeNull();
+    expect(w.last_cursor).toBeNull();
+  });
+
+  test('update sets last_synced_at and last_cursor', () => {
+    const w = Wallet.create({ address: 'GABC2' });
+    const now = new Date().toISOString();
+    const updated = Wallet.update(w.id, { last_synced_at: now, last_cursor: 'cursor-abc' });
+    expect(updated.last_synced_at).toBe(now);
+    expect(updated.last_cursor).toBe('cursor-abc');
+  });
+
+  test('getByAddress returns wallet with sync fields', () => {
+    Wallet.create({ address: 'GABC3', last_synced_at: '2024-01-01T00:00:00.000Z', last_cursor: 'tok1' });
+    const found = Wallet.getByAddress('GABC3');
+    expect(found.last_synced_at).toBe('2024-01-01T00:00:00.000Z');
+    expect(found.last_cursor).toBe('tok1');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. TransactionSyncService — incremental sync logic
+// ─────────────────────────────────────────────────────────────────────────────
+describe('TransactionSyncService — incremental sync', () => {
+  let service;
+  let mockStellar;
+
+  beforeEach(() => {
+    mockStellar = new MockStellarService();
+    service = new TransactionSyncService(mockStellar);
+  });
+
+  test('full sync (no cursor): fetches transactions and updates last_synced_at', async () => {
+    const wallet = Wallet.create({ address: 'GFULL1' });
+    const txs = [makeTx('tx1', 'pt1'), makeTx('tx2', 'pt2')];
+    service._fetchHorizonTransactions = jest.fn().mockResolvedValue(txs);
+
+    const result = await service.syncWalletTransactions('GFULL1');
+
+    expect(result.synced).toBe(2);
+    expect(service._fetchHorizonTransactions).toHaveBeenCalledWith('GFULL1', 500, undefined);
+
+    const updated = Wallet.getByAddress('GFULL1');
+    expect(updated.last_cursor).toBe('pt2');
+    expect(updated.last_synced_at).not.toBeNull();
+  });
+
+  test('incremental sync: passes last_cursor to _fetchHorizonTransactions', async () => {
+    Wallet.create({ address: 'GINC1', last_cursor: 'cursor-prev', last_synced_at: '2024-01-01T00:00:00.000Z' });
+    const txs = [makeTx('tx3', 'pt3')];
+    service._fetchHorizonTransactions = jest.fn().mockResolvedValue(txs);
+
+    await service.syncWalletTransactions('GINC1');
+
+    expect(service._fetchHorizonTransactions).toHaveBeenCalledWith('GINC1', 500, 'cursor-prev');
+    const updated = Wallet.getByAddress('GINC1');
+    expect(updated.last_cursor).toBe('pt3');
+  });
+
+  test('no new transactions: last_synced_at is still updated', async () => {
+    const wallet = Wallet.create({ address: 'GEMPTY1' });
+    service._fetchHorizonTransactions = jest.fn().mockResolvedValue([]);
+
+    const before = new Date().toISOString();
+    await service.syncWalletTransactions('GEMPTY1');
+    const after = new Date().toISOString();
+
+    const updated = Wallet.getByAddress('GEMPTY1');
+    expect(updated.last_synced_at).not.toBeNull();
+    expect(updated.last_synced_at >= before).toBe(true);
+    expect(updated.last_synced_at <= after).toBe(true);
+    // cursor unchanged (no txs)
+    expect(updated.last_cursor).toBeNull();
+  });
+
+  test('skips duplicate transactions (already in local store)', async () => {
+    Wallet.create({ address: 'GDUP1' });
+    // Pre-create a transaction with the same stellarTxId
+    Transaction.create({ stellarTxId: 'tx-dup', status: 'confirmed', amount: '1', donor: 'A', recipient: 'B' });
+
+    const txs = [makeTx('tx-dup', 'pt-dup'), makeTx('tx-new', 'pt-new')];
+    service._fetchHorizonTransactions = jest.fn().mockResolvedValue(txs);
+
+    const result = await service.syncWalletTransactions('GDUP1');
+    // Only the new one should be synced
+    expect(result.synced).toBe(1);
+  });
+
+  test('unknown wallet: sync still runs without crashing', async () => {
+    service._fetchHorizonTransactions = jest.fn().mockResolvedValue([makeTx('tx-x', 'pt-x')]);
+    const result = await service.syncWalletTransactions('GUNKNOWN');
+    expect(result.synced).toBe(1);
+  });
+
+  test('Horizon 404 returns empty array (account not found)', async () => {
+    Wallet.create({ address: 'G404' });
+    // Simulate 404 from Horizon
+    service._fetchHorizonTransactions = jest.fn().mockRejectedValue(
+      Object.assign(new Error('Not Found'), { response: { status: 404 } })
+    );
+
+    // The service itself doesn't catch 404 in syncWalletTransactions — it propagates
+    // But _fetchHorizonTransactions handles 404 internally and returns []
+    // Let's test the internal method directly
+    const realService = new TransactionSyncService(mockStellar);
+    realService.server = {
+      transactions: () => ({
+        forAccount: () => ({
+          limit: () => ({
+            order: () => ({
+              call: () => Promise.reject(Object.assign(new Error('Not Found'), { response: { status: 404 } })),
+            }),
+          }),
+        }),
+      }),
+    };
+    const txs = await realService._fetchHorizonTransactions('G404', 10, undefined);
+    expect(txs).toEqual([]);
+  });
+
+  test('Horizon non-404 error propagates', async () => {
+    Wallet.create({ address: 'GERR1' });
+    service._fetchHorizonTransactions = jest.fn().mockRejectedValue(new Error('Network timeout'));
+    await expect(service.syncWalletTransactions('GERR1')).rejects.toThrow('Network timeout');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. TransactionSyncScheduler — lifecycle and partial failure
+// ─────────────────────────────────────────────────────────────────────────────
+describe('TransactionSyncScheduler', () => {
+  let scheduler;
+  let mockStellar;
+
+  beforeEach(() => {
+    mockStellar = new MockStellarService();
+    scheduler = new TransactionSyncScheduler(mockStellar, { intervalMs: 999999 });
+    // Prevent actual Horizon calls
+    scheduler.syncService._fetchHorizonTransactions = jest.fn().mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    scheduler.stop();
+  });
+
+  test('starts and stops without error', () => {
+    scheduler.start();
+    expect(scheduler.isRunning).toBe(true);
+    scheduler.stop();
+    expect(scheduler.isRunning).toBe(false);
+    expect(scheduler.intervalId).toBeNull();
+  });
+
+  test('double start is idempotent', () => {
+    scheduler.start();
+    const id1 = scheduler.intervalId;
+    scheduler.start(); // second call should be no-op
+    expect(scheduler.intervalId).toBe(id1);
+    scheduler.stop();
+  });
+
+  test('double stop is idempotent', () => {
+    scheduler.start();
+    scheduler.stop();
+    expect(() => scheduler.stop()).not.toThrow();
+  });
+
+  test('syncAllWallets returns correct shape', async () => {
+    Wallet.create({ address: 'GSCHED1' });
+    Wallet.create({ address: 'GSCHED2' });
+
+    const result = await scheduler.syncAllWallets();
+
+    expect(result).toMatchObject({
+      wallets: 2,
+      synced: expect.any(Number),
+      errors: 0,
+      completedAt: expect.any(String),
+    });
+  });
+
+  test('getSyncStatus returns null before first sync', () => {
+    const status = scheduler.getSyncStatus();
+    expect(status.lastSyncAt).toBeNull();
+    expect(status.lastSyncResult).toBeNull();
+  });
+
+  test('getSyncStatus is populated after syncAllWallets', async () => {
+    await scheduler.syncAllWallets();
+    const status = scheduler.getSyncStatus();
+    expect(status.lastSyncAt).not.toBeNull();
+    expect(status.lastSyncResult).not.toBeNull();
+  });
+
+  test('partial failure: one wallet error does not stop others', async () => {
+    Wallet.create({ address: 'GFAIL1' });
+    Wallet.create({ address: 'GOK1' });
+
+    let callCount = 0;
+    scheduler.syncService.syncWalletTransactions = jest.fn().mockImplementation(async (addr) => {
+      callCount++;
+      if (addr === 'GFAIL1') throw new Error('Simulated Horizon error');
+      return { synced: 1, transactions: [] };
+    });
+
+    const result = await scheduler.syncAllWallets();
+
+    expect(callCount).toBe(2); // both wallets attempted
+    expect(result.errors).toBe(1);
+    expect(result.synced).toBe(1);
+  });
+
+  test('all wallets fail: errors counted, no throw', async () => {
+    Wallet.create({ address: 'GFAIL2' });
+    scheduler.syncService.syncWalletTransactions = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const result = await scheduler.syncAllWallets();
+    expect(result.errors).toBe(1);
+    expect(result.synced).toBe(0);
+  });
+
+  test('intervalMs defaults to env var TX_SYNC_INTERVAL_MS', () => {
+    process.env.TX_SYNC_INTERVAL_MS = '30000';
+    const s = new TransactionSyncScheduler(mockStellar);
+    expect(s.intervalMs).toBe(30000);
+    delete process.env.TX_SYNC_INTERVAL_MS;
+  });
+
+  test('intervalMs defaults to 15 minutes when env not set', () => {
+    delete process.env.TX_SYNC_INTERVAL_MS;
+    const s = new TransactionSyncScheduler(mockStellar);
+    expect(s.intervalMs).toBe(15 * 60 * 1000);
+  });
+
+  test('intervalMs option overrides env var', () => {
+    process.env.TX_SYNC_INTERVAL_MS = '60000';
+    const s = new TransactionSyncScheduler(mockStellar, { intervalMs: 5000 });
+    expect(s.intervalMs).toBe(5000);
+    delete process.env.TX_SYNC_INTERVAL_MS;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. POST /admin/sync endpoint — handler logic (no HTTP layer)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /admin/sync — handler logic', () => {
+  let mockStellar;
+  let scheduler;
+
+  /** Minimal req/res/next stubs */
+  function makeReqRes(role = 'admin') {
+    const req = { user: { id: 'u1', role } };
+    const res = {
+      _status: 200,
+      _body: null,
+      status(code) { this._status = code; return this; },
+      json(body) { this._body = body; return this; },
+    };
+    const next = jest.fn();
+    return { req, res, next };
+  }
+
+  /** The actual handler extracted from app.js logic */
+  async function adminSyncHandler(req, res, next, sched) {
+    try {
+      if (!req.user || req.user.role !== 'admin') {
+        return res.status(403).json({ success: false, error: { code: 'FORBIDDEN' } });
+      }
+      const result = await sched.syncAllWallets();
+      res.json({ success: true, message: 'Transaction sync complete', data: result });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  beforeEach(() => {
+    mockStellar = new MockStellarService();
+    scheduler = new TransactionSyncScheduler(mockStellar, { intervalMs: 999999 });
+    scheduler.syncService._fetchHorizonTransactions = jest.fn().mockResolvedValue([]);
+  });
+
+  afterEach(() => scheduler.stop());
+
+  test('admin role: returns success with sync result', async () => {
+    Wallet.create({ address: 'GADMIN1' });
+    const { req, res, next } = makeReqRes('admin');
+    await adminSyncHandler(req, res, next, scheduler);
+    expect(res._status).toBe(200);
+    expect(res._body.success).toBe(true);
+    expect(res._body.data).toMatchObject({
+      wallets: expect.any(Number),
+      synced: expect.any(Number),
+      errors: expect.any(Number),
+      completedAt: expect.any(String),
+    });
+  });
+
+  test('non-admin role: returns 403', async () => {
+    const { req, res, next } = makeReqRes('user');
+    await adminSyncHandler(req, res, next, scheduler);
+    expect(res._status).toBe(403);
+    expect(res._body.success).toBe(false);
+  });
+
+  test('sync error: calls next with error', async () => {
+    scheduler.syncAllWallets = jest.fn().mockRejectedValue(new Error('DB exploded'));
+    const { req, res, next } = makeReqRes('admin');
+    await adminSyncHandler(req, res, next, scheduler);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'DB exploded' }));
+  });
+
+  test('response includes message field', async () => {
+    const { req, res, next } = makeReqRes('admin');
+    await adminSyncHandler(req, res, next, scheduler);
+    expect(res._body.message).toBe('Transaction sync complete');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. GET /health — transactionSync field
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /health — transactionSync field', () => {
+  /** Simulate the health handler logic */
+  function getHealthBody(scheduler) {
+    return {
+      status: 'healthy',
+      transactionSync: scheduler.getSyncStatus(),
+    };
+  }
+
+  let mockStellar;
+  let scheduler;
+
+  beforeEach(() => {
+    mockStellar = new MockStellarService();
+    scheduler = new TransactionSyncScheduler(mockStellar, { intervalMs: 999999 });
+    scheduler.syncService._fetchHorizonTransactions = jest.fn().mockResolvedValue([]);
+  });
+
+  afterEach(() => scheduler.stop());
+
+  test('health includes transactionSync with null values before first sync', () => {
+    const body = getHealthBody(scheduler);
+    expect(body.transactionSync).toBeDefined();
+    expect(body.transactionSync.lastSyncAt).toBeNull();
+    expect(body.transactionSync.lastSyncResult).toBeNull();
+  });
+
+  test('health includes transactionSync with populated values after sync', async () => {
+    await scheduler.syncAllWallets();
+    const body = getHealthBody(scheduler);
+    expect(body.transactionSync.lastSyncAt).not.toBeNull();
+    expect(body.transactionSync.lastSyncResult).not.toBeNull();
+  });
+
+  test('transactionSync.lastSyncResult has expected shape', async () => {
+    await scheduler.syncAllWallets();
+    const body = getHealthBody(scheduler);
+    expect(body.transactionSync.lastSyncResult).toMatchObject({
+      wallets: expect.any(Number),
+      synced: expect.any(Number),
+      errors: expect.any(Number),
+      completedAt: expect.any(String),
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. _fetchHorizonTransactions — cursor and order logic
+// ─────────────────────────────────────────────────────────────────────────────
+describe('TransactionSyncService._fetchHorizonTransactions', () => {
+  let service;
+  let mockStellar;
+
+  beforeEach(() => {
+    mockStellar = new MockStellarService();
+    service = new TransactionSyncService(mockStellar);
+  });
+
+  test('with cursor: uses asc order', async () => {
+    let capturedOrder;
+    service.server = {
+      transactions: () => ({
+        forAccount: () => ({
+          limit: () => ({
+            cursor: () => ({
+              order: (o) => {
+                capturedOrder = o;
+                return { call: () => Promise.resolve({ records: [] }) };
+              },
+            }),
+          }),
+        }),
+      }),
+    };
+    await service._fetchHorizonTransactions('GTEST', 10, 'some-cursor');
+    expect(capturedOrder).toBe('asc');
+  });
+
+  test('without cursor: uses desc order', async () => {
+    let capturedOrder;
+    service.server = {
+      transactions: () => ({
+        forAccount: () => ({
+          limit: () => ({
+            order: (o) => {
+              capturedOrder = o;
+              return { call: () => Promise.resolve({ records: [] }) };
+            },
+          }),
+        }),
+      }),
+    };
+    await service._fetchHorizonTransactions('GTEST', 10, undefined);
+    expect(capturedOrder).toBe('desc');
+  });
+
+  test('paginates until maxTransactions reached', async () => {
+    const page1 = { records: [makeTx('t1'), makeTx('t2')], next: jest.fn() };
+    const page2 = { records: [makeTx('t3')], next: jest.fn() };
+    page1.next.mockResolvedValue(page2);
+    page2.next.mockResolvedValue({ records: [] });
+
+    service.server = {
+      transactions: () => ({
+        forAccount: () => ({
+          limit: () => ({
+            cursor: () => ({
+              order: () => ({ call: () => Promise.resolve(page1) }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const txs = await service._fetchHorizonTransactions('GTEST', 3, 'cursor');
+    expect(txs.length).toBe(3);
+  });
+});


### PR DESCRIPTION
closes #386 
Implements Issue #386 — a robust, scheduled background service that keeps local wallet transaction records in sync with the Stellar Horizon network using incremental cursor-based pagination.

## Changes

### New Files
- `src/services/TransactionSyncScheduler.js` — Background scheduler (setInterval, default 15 min)
- `tests/add-stellar-transaction-history-synchronization.test.js` — 31 tests, all passing
- `docs/features/ADD_STELLAR_TRANSACTION_HISTORY_SYNCHRONIZATION.md` — Feature documentation

### Modified Files
- `src/routes/models/wallet.js` — Added `last_synced_at` and `last_cursor` fields
- `src/services/TransactionSyncService.js` — Incremental sync using `last_cursor`; updates both fields on success
- `src/config/serviceContainer.js` — Registers `TransactionSyncScheduler` singleton
- `src/routes/app.js` — Wires scheduler lifecycle, adds `POST /admin/sync`, adds `transactionSync` to `/health`

## New API

### `POST /admin/sync`
Triggers an immediate sync for all wallets. Requires admin role.

json
{
 "success": true,
 "message": "Transaction sync complete",
 "data": { "wallets": 5, "synced": 12, "errors": 0, "completedAt": "..." }
}

### `GET /health` — new `transactionSync` field
json
{
 "transactionSync": {
   "lastSyncAt": "2026-03-27T22:50:18.409Z",
   "lastSyncResult": { "wallets": 5, "synced": 12, "errors": 0, 
"completedAt": "..." }
 }
}

## Configuration

| Variable | Default | Description |
|---|---|---|
| `TX_SYNC_INTERVAL_MS` | `900000` (15 min) | Scheduler interval |

## Testing

- 31 tests covering: incremental sync, cursor tracking, scheduler lifecycle, partial failure handling, admin endpoint, health field
- All Stellar interactions use `MockStellarService` — no live network calls
- Partial failure: if one wallet errors, the scheduler logs it and continues to the next wallet

## Checklist
- [x] Tests pass (`npm test tests/add-stellar-transaction-history-synchronization.test.js`)
- [x] No live network calls in tests
- [x] Partial failure handled (per-wallet errors logged, sync continues)
- [x] Scheduler starts/stops with server lifecycle
- [x] Admin endpoint secured with `requireAdmin()` middleware
- [x] Documentation added

- Add last_synced_at and last_cursor fields to Wallet model
- Update TransactionSyncService for incremental cursor-based sync
- Add TransactionSyncScheduler background service (default 15 min, configurable via TX_SYNC_INTERVAL_MS)
- Add POST /admin/sync endpoint (admin-only) for on-demand sync
- Expose transactionSync status in GET /health response
- Register scheduler in ServiceContainer with start/stop lifecycle
- Add 31 tests (all passing) using MockStellarService
- Add feature documentation

