### PR TITLE
fix: resolve issues #718, #719, #720, #721 — scheduler reliability, idempotency, route ordering, access logging

### DIFF
--- a/src/middleware/accessLog.js
+++ b/src/middleware/accessLog.js
@@ -1,0 +1,83 @@
+/**
+ * Access Log Middleware (#721)
+ *
+ * Produces exactly one structured JSON access log entry per request on completion.
+ * Log level is determined by HTTP status code:
+ *   - 5xx → ERROR
+ *   - 4xx → WARN
+ *   - 2xx/3xx → INFO
+ *
+ * Log format:
+ * {
+ *   "level": "INFO",
+ *   "service": "stellar-micro-donation-api",
+ *   "type": "access",
+ *   "requestId": "abc-123",
+ *   "method": "POST",
+ *   "path": "/donations",
+ *   "statusCode": 201,
+ *   "responseTimeMs": 245,
+ *   "userId": "apikey-5",
+ *   "ip": "1.2.3.4",
+ *   "userAgent": "curl/8.5.0"
+ * }
+ *
+ * Health check endpoints (/health, /health/live, /health/ready) are excluded by default.
+ * Set ACCESS_LOG_INCLUDE_HEALTH=true to include them.
+ */
+
+const log = require('../utils/log');
+
+const EXCLUDED_PATHS = ['/health', '/health/live', '/health/ready'];
+
+/**
+ * @param {Object} [options]
+ * @param {string[]} [options.excludePaths] - Additional paths to exclude from access logs
+ * @returns {import('express').RequestHandler}
+ */
+function accessLogMiddleware(options = {}) {
+  const excludePaths = [
+    ...(process.env.ACCESS_LOG_INCLUDE_HEALTH === 'true' ? [] : EXCLUDED_PATHS),
+    ...(options.excludePaths || []),
+  ];
+
+  return (req, res, next) => {
+    const startTime = Date.now();
+
+    res.on('finish', () => {
+      const path = req.path || req.url;
+
+      if (excludePaths.some(p => path === p || path.startsWith(p + '/'))) {
+        return;
+      }
+
+      const responseTimeMs = Date.now() - startTime;
+      const statusCode = res.statusCode;
+
+      const entry = {
+        service: 'stellar-micro-donation-api',
+        type: 'access',
+        requestId: req.id,
+        method: req.method,
+        path: req.originalUrl || req.url,
+        statusCode,
+        responseTimeMs,
+        userId: req.apiKeyId || req.userId || null,
+        ip: req.ip || (req.connection && req.connection.remoteAddress) || 'unknown',
+        userAgent: req.get('User-Agent') || null,
+      };
+
+      if (statusCode >= 500) {
+        log.error('ACCESS', `${req.method} ${entry.path} ${statusCode} ${responseTimeMs}ms`, entry);
+      } else if (statusCode >= 400) {
+        log.warn('ACCESS', `${req.method} ${entry.path} ${statusCode} ${responseTimeMs}ms`, entry);
+      } else {
+        log.info('ACCESS', `${req.method} ${entry.path} ${statusCode} ${responseTimeMs}ms`, entry);
+      }
+    });
+
+    next();
+  };
+}
+
+module.exports = accessLogMiddleware;

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -190,6 +190,9 @@ app.use(require('../middleware/blockCheck'));
 // Request/Response logging middleware
 app.use(logger.middleware());
 
+// Structured access log middleware (#721) — one entry per request with requestId, timing, status
+app.use(require('../middleware/accessLog')());
+
 // Abuse detection (observability only - no blocking)
 app.use(abuseDetectionMiddleware);
 

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -405,6 +405,28 @@ router.get('/:id/certificate', checkPermission(PERMISSIONS.DONATIONS_READ), dona
 });
 
 /**
+ * GET /donations/recent
+ * Get recent donations, ordered by creation date descending.
+ * Must be registered before /:id to prevent Express matching "recent" as an id.
+ *
+ * Query params:
+ *   - limit {integer} max results to return (default 10, max 100)
+ */
+router.get('/recent', checkPermission(PERMISSIONS.DONATIONS_READ), async (req, res, next) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit, 10) || 10, 100);
+    const Database = require('../utils/database');
+    const rows = await Database.query(
+      `SELECT * FROM transactions ORDER BY timestamp DESC LIMIT ?`,
+      [limit]
+    );
+    res.json({ success: true, data: rows, count: rows.length });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
  * GET /donations/:id
  * Get a specific donation
  */

--- a/src/services/RecurringDonationScheduler.js
+++ b/src/services/RecurringDonationScheduler.js
@@ -164,6 +164,34 @@ class RecurringDonationScheduler {
       try {
         const now = new Date().toISOString();
 
+        // Detect orphaned schedules (donor or recipient no longer exists) and suspend them
+        const orphanedSchedules = await Database.query(
+          `SELECT rd.id
+           FROM recurring_donations rd
+           WHERE rd.status = ?
+             AND (
+               NOT EXISTS (SELECT 1 FROM users WHERE id = rd.donorId)
+               OR NOT EXISTS (SELECT 1 FROM users WHERE id = rd.recipientId)
+             )`,
+          [SCHEDULE_STATUS.ACTIVE]
+        );
+
+        for (const orphan of orphanedSchedules) {
+          const reason = 'Donor or recipient user no longer exists';
+          await Database.run(
+            `UPDATE recurring_donations
+             SET status = 'orphaned', lastFailureReason = ?
+             WHERE id = ?`,
+            [reason, orphan.id]
+          );
+          log.warn('RECURRING_SCHEDULER', 'Schedule marked as orphaned', {
+            scheduleId: orphan.id,
+            reason,
+            correlationId,
+            traceId,
+          });
+        }
+
         const dueSchedules = await Database.query(
           `SELECT
             rd.id,
@@ -295,7 +323,7 @@ class RecurringDonationScheduler {
             }
           }
 
-          await this.handleFailedExecution(schedule, lastError);
+          await this.handlePersistentFailure(schedule, lastError);
         } finally {
           this.executingSchedules.delete(schedule.id);
         }
@@ -325,26 +353,49 @@ class RecurringDonationScheduler {
       const { correlationId, traceId } = getCorrelationSummary();
 
       try {
-        // 1. Send payment
-        const txResult = await this.stellarService.sendPayment(
-          schedule.donorPublicKey,
-          schedule.recipientPublicKey,
-          schedule.amount,
-          `Recurring donation (Schedule #${schedule.id})`
+        // 1. Generate deterministic idempotency key for this execution cycle
+        const executionDate = schedule.nextExecutionDate
+          ? new Date(schedule.nextExecutionDate).toISOString().split('T')[0]
+          : new Date().toISOString().split('T')[0];
+        const idempotencyKey = `recurring-${schedule.id}-${executionDate}`;
+
+        // Check if this execution was already submitted (idempotency guard)
+        const existing = await Database.get(
+          `SELECT id FROM transactions WHERE memo = ? AND senderId = ? AND receiverId = ?`,
+          [idempotencyKey, schedule.donorId, schedule.recipientId]
         );
 
-        // 2. Record transaction
-        await Database.run(
-          `INSERT INTO transactions (senderId, receiverId, amount, memo, timestamp)
-           VALUES (?, ?, ?, ?, ?)`,
-          [
-            schedule.donorId,
-            schedule.recipientId,
+        let txResult;
+        if (existing) {
+          log.info('RECURRING_SCHEDULER', 'Idempotency key already used — skipping Stellar payment', {
+            scheduleId: schedule.id,
+            idempotencyKey,
+            correlationId,
+            traceId,
+          });
+          txResult = { hash: null };
+        } else {
+          // 2. Send payment
+          txResult = await this.stellarService.sendPayment(
+            schedule.donorPublicKey,
+            schedule.recipientPublicKey,
             schedule.amount,
-            `Recurring donation (Schedule #${schedule.id})`,
-            new Date().toISOString(),
-          ]
-        );
+            `Recurring donation (Schedule #${schedule.id})`
+          );
+
+          // 3. Record transaction with idempotency key as memo
+          await Database.run(
+            `INSERT INTO transactions (senderId, receiverId, amount, memo, timestamp)
+             VALUES (?, ?, ?, ?, ?)`,
+            [
+              schedule.donorId,
+              schedule.recipientId,
+              schedule.amount,
+              idempotencyKey,
+              new Date().toISOString(),
+            ]
+          );
+        }
 
         // 3. Calculate next execution date
         const nextDate = this.calculateNextExecutionDate(


### PR DESCRIPTION
## Summary

### #718 — Orphaned recurring donation schedules silently skipped

**Problem:** The scheduler used an `INNER JOIN` to fetch due schedules. If a donor or recipient user was deleted after a schedule was created, the JOIN returned no rows for that schedule — it was silently skipped with no error or notification.

**Fix:** Added a pre-pass query in `processSchedules()` that detects active schedules whose `donorId` or `recipientId` no longer exists in the `users` table. Each orphaned schedule is immediately updated to `status='orphaned'` with a `lastFailureReason` explaining why, and a `WARN`-level log entry is emitted so admins are notified on every scheduler tick.

**Files changed:** `src/services/RecurringDonationScheduler.js`

Closes #718 

---

### #719 — Duplicate Stellar charges on scheduler retry

**Problem:** If the Stellar payment succeeded but the subsequent DB update failed, the scheduler would retry on the next tick and submit a second payment — charging the donor twice.

**Fix:** Before submitting to Stellar, a deterministic idempotency key is generated: `recurring-{scheduleId}-{YYYY-MM-DD}`. The scheduler checks whether a transaction with that key already exists in the DB. If it does, the Stellar call is skipped and only the schedule metadata is updated. The key is stored as the transaction memo.

Also fixed a method name mismatch: `handleFailedExecution` → `handlePersistentFailure` (the method was defined under the latter name but called under the former, causing an uncaught TypeError on persistent failure).

**Idempotency key format:** `recurring-{scheduleId}-{YYYY-MM-DD}`

**Files changed:** `src/services/RecurringDonationScheduler.js`

Closes #719 

---

### #720 — `GET /donations/recent` returns 404

**Problem:** Express matches routes in registration order. `GET /:id` was registered before any `/recent` route, so `GET /donations/recent` was captured by `/:id` with `id='recent'`, resulting in a "donation not found" error.

**Fix:** Added `GET /donations/recent` route immediately before `GET /:id` in `donation.js`. Returns up to 100 recent transactions ordered by `timestamp DESC`. Limit is configurable via `?limit=N` (default 10, max 100).

**Files changed:** `src/routes/donation.js`

Closes #720 

---

### #721 — No structured access log per request

**Problem:** The existing logger captured request/response details but did not produce a single, structured access log entry per request suitable for log aggregation or latency analysis.

**Fix:** Added `src/middleware/accessLog.js`. On every request completion it emits one JSON log entry containing: `requestId`, `method`, `path`, `statusCode`, `responseTimeMs`, `userId`, `ip`, `userAgent`. Log level is `ERROR` for 5xx, `WARN` for 4xx, `INFO` for 2xx/3xx. Health check endpoints (`/health`, `/health/live`, `/health/ready`) are excluded by default; set `ACCESS_LOG_INCLUDE_HEALTH=true` to include them. Registered in `app.js` immediately after `logger.middleware()`.

**Files changed:** `src/middleware/accessLog.js`, `src/routes/app.js`

Closes #721 

---

## Testing

- `GET /donations/recent` now returns the most recent transactions instead of a 404.
- Orphaned schedules are marked `orphaned` on the next scheduler tick rather than silently skipped.
- Retrying a recurring donation execution after a partial failure no longer submits a duplicate Stellar transaction.
- Every HTTP request produces exactly one access log entry at the appropriate log level.
