### PR TITLE
fix(security): #705 remove sourceSecret from request bodies, accept p…

### DIFF
--- a/docs/MIGRATION_REMOVE_SOURCE_SECRET.md
+++ b/docs/MIGRATION_REMOVE_SOURCE_SECRET.md
@@ -1,0 +1,165 @@
+# Migration Guide: Removing `sourceSecret` from API Request Bodies
+
+**Issue:** #705  
+**Severity:** SECURITY — BREAKING CHANGE  
+**Affected versions:** All versions prior to this fix
+
+---
+
+## Why This Change Was Made
+
+Sending a Stellar private key (`sourceSecret`) in an HTTP request body is a severe security anti-pattern:
+
+- The server holds private keys in memory, logs, and potentially in error reports or crash dumps.
+- Any server compromise exposes all users' Stellar private keys.
+- Keys transmitted over the network exist in server memory even when TLS is used.
+- This pattern is incompatible with hardware wallets and secure key management systems.
+
+**The server should never receive or handle users' private keys.** All transaction signing must happen client-side.
+
+---
+
+## Affected Endpoints
+
+| Endpoint | Old field | New field |
+|---|---|---|
+| `POST /offers` | `sourceSecret` | `signedXDR` |
+| `DELETE /offers/:id` | `sourceSecret` | `signedXDR` |
+| `POST /donations/claimable` | `sourceSecret` | `signedXDR` |
+| `POST /donations/claimable/:id/claim` | `claimantSecret` | `signedXDR` |
+| `POST /donations/cross-asset` | `sourceSecret` | `signedXDR` |
+| `PATCH /wallets/:id/inflation-destination` | `sourceSecret` | `signedXDR` |
+| `PUT /wallets/:id/inflation-destination` | `sourceSecret` | `signedXDR` |
+
+---
+
+## New Client-Side Signing Workflow
+
+Instead of sending your secret key to the server, you now:
+
+1. **Fetch the transaction parameters** from the server (or construct them locally).
+2. **Build the transaction** client-side using the Stellar SDK.
+3. **Sign the transaction** with your secret key — locally, never leaving your device.
+4. **Submit the signed XDR** to the API.
+
+### JavaScript Example (using `stellar-sdk`)
+
+```js
+const StellarSdk = require('stellar-sdk');
+
+const server = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org');
+const networkPassphrase = StellarSdk.Networks.TESTNET;
+
+// 1. Load the source account to get the current sequence number
+const sourceKeypair = StellarSdk.Keypair.fromSecret('SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+
+// 2. Build the transaction (example: manage sell offer)
+const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+  fee: await server.fetchBaseFee(),
+  networkPassphrase,
+})
+  .addOperation(StellarSdk.Operation.manageSellOffer({
+    selling: StellarSdk.Asset.native(),
+    buying: new StellarSdk.Asset('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'),
+    amount: '100',
+    price: '0.5',
+    offerId: 0,
+  }))
+  .setTimeout(30)
+  .build();
+
+// 3. Sign locally — the secret key never leaves this client
+transaction.sign(sourceKeypair);
+
+// 4. Get the signed XDR envelope
+const signedXDR = transaction.toEnvelope().toXDR('base64');
+
+// 5. Submit to the API
+const response = await fetch('https://your-api/offers', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'X-API-Key': 'your-api-key' },
+  body: JSON.stringify({
+    signedXDR,
+    sellingAsset: 'XLM',
+    buyingAsset: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    amount: '100',
+    price: '0.5',
+  }),
+});
+```
+
+### Python Example (using `stellar-sdk`)
+
+```python
+from stellar_sdk import Keypair, Network, Server, TransactionBuilder, Asset, Operation
+import requests, base64
+
+server = Server("https://horizon-testnet.stellar.org")
+keypair = Keypair.from_secret("SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+
+# Load account
+account = server.load_account(keypair.public_key)
+
+# Build and sign transaction
+transaction = (
+    TransactionBuilder(
+        source_account=account,
+        network_passphrase=Network.TESTNET_NETWORK_PASSPHRASE,
+        base_fee=100,
+    )
+    .append_manage_sell_offer_op(
+        selling=Asset.native(),
+        buying=Asset("USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
+        amount="100",
+        price="0.5",
+        offer_id=0,
+    )
+    .set_timeout(30)
+    .build()
+)
+transaction.sign(keypair)
+signed_xdr = transaction.to_xdr()
+
+# Submit to API
+resp = requests.post(
+    "https://your-api/offers",
+    json={
+        "signedXDR": signed_xdr,
+        "sellingAsset": "XLM",
+        "buyingAsset": "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        "amount": "100",
+        "price": "0.5",
+    },
+    headers={"X-API-Key": "your-api-key"},
+)
+```
+
+---
+
+## Endpoint-Specific Notes
+
+### `POST /donations/claimable`
+
+Build a `createClaimableBalance` operation client-side, sign it, and submit the XDR. The `claimants` and `amount` fields are still required in the request body for server-side record-keeping.
+
+### `POST /donations/claimable/:id/claim`
+
+Build a `claimClaimableBalance` operation with the balance ID, sign it with the claimant's keypair, and submit the XDR.
+
+### `POST /donations/cross-asset`
+
+Use `GET /donations/cross-asset/paths` to discover available DEX paths first, then build a `pathPaymentStrictSend` or `pathPaymentStrictReceive` operation, sign it, and submit the XDR.
+
+### `PUT /wallets/:id/inflation-destination`
+
+Build a `setOptions` operation with `inflationDest` set, sign it, and submit the XDR along with `destinationPublicKey` for validation.
+
+---
+
+## Security Best Practices
+
+- **Never log or store secret keys** — not in files, environment variables accessible to the server, or request bodies.
+- **Use hardware wallets** where possible — the new XDR-based flow is fully compatible.
+- **Validate XDR on the client** before submitting to catch construction errors early.
+- **Set transaction timeouts** (`setTimeout(30)`) to prevent replay attacks with stale transactions.

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -545,7 +545,7 @@ router.post('/:id/refund', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_
 const createClaimableSchema = validateSchema({
   body: {
     fields: {
-      sourceSecret: { type: 'string', required: true },
+      signedXDR: { type: 'string', required: true },
       amount: { type: 'numberString', required: true, min: 0.0000001 },
       claimants: { type: 'array', required: true },
       predicate: { type: 'object', required: false, nullable: true },
@@ -556,7 +556,7 @@ const createClaimableSchema = validateSchema({
 /**
  * POST /donations/claimable
  * Create a claimable balance (XLM held until claimed by an eligible account).
- * Supports time-based predicates (notBefore / notAfter as Unix ms timestamps).
+ * The transaction must be signed client-side and submitted as a pre-signed XDR envelope.
  */
 router.post(
   '/claimable',
@@ -566,7 +566,7 @@ router.post(
   createClaimableSchema,
   async (req, res, next) => {
     try {
-      const { sourceSecret, amount, claimants, predicate } = req.body;
+      const { signedXDR, amount, claimants, predicate } = req.body;
 
       if (!Array.isArray(claimants) || claimants.length === 0) {
         return res.status(400).json({
@@ -575,12 +575,7 @@ router.post(
         });
       }
 
-      const result = await stellarService.createClaimableBalance({
-        sourceSecret,
-        amount,
-        claimants,
-        predicate: predicate || null,
-      });
+      const result = await stellarService.submitSignedTransaction(signedXDR);
 
       // Store claimable balance ID in transaction records
       Transaction.create({
@@ -606,6 +601,7 @@ router.post(
 /**
  * POST /donations/claimable/:id/claim
  * Claim a claimable balance by its ID.
+ * The claim transaction must be signed client-side and submitted as a pre-signed XDR envelope.
  */
 router.post(
   '/claimable/:id/claim',
@@ -615,19 +611,16 @@ router.post(
   async (req, res, next) => {
     try {
       const { id } = req.params;
-      const { claimantSecret } = req.body;
+      const { signedXDR } = req.body;
 
-      if (!claimantSecret) {
+      if (!signedXDR) {
         return res.status(400).json({
           success: false,
-          error: { code: 'VALIDATION_ERROR', message: 'claimantSecret is required' },
+          error: { code: 'VALIDATION_ERROR', message: 'signedXDR is required' },
         });
       }
 
-      const result = await stellarService.claimBalance({
-        balanceId: id,
-        claimantSecret,
-      });
+      const result = await stellarService.submitSignedTransaction(signedXDR);
 
       if (req.markLifecycleStage) req.markLifecycleStage(LIFECYCLE_STAGES.PROCESSED);
 
@@ -687,7 +680,7 @@ router.get('/:id/impact', checkPermission(PERMISSIONS.DONATIONS_READ), donationI
 const crossAssetSchema = validateSchema({
   body: {
     fields: {
-      sourceSecret: { type: 'string', required: true },
+      signedXDR: { type: 'string', required: true },
       sendAsset: { types: ['string', 'object'], required: true },
       destPublicKey: { type: 'string', required: true },
       destAsset: { types: ['string', 'object'], required: true },
@@ -725,13 +718,12 @@ const crossAssetPathsSchema = validateSchema({
  * POST /donations/cross-asset
  * Execute a cross-asset donation via Stellar DEX path payment.
  *
- * Strict-send: provide sendAmount — sends exactly that amount, recipient gets at least
- *   sendAmount * (1 - slippageTolerance) of destAsset.
- * Strict-receive: provide destAmount — recipient gets exactly that amount, sender spends
- *   at most destAmount / rate * (1 + slippageTolerance) of sendAsset.
+ * The transaction must be built and signed client-side, then submitted as a
+ * pre-signed XDR envelope. Use GET /donations/cross-asset/paths to discover
+ * available conversion paths before building the transaction.
  *
  * Body:
- *   - sourceSecret {string} required
+ *   - signedXDR {string} required — pre-signed transaction XDR envelope
  *   - sendAsset {string|object} required — "native" or {code, issuer}
  *   - sendAmount {string} — for strict-send
  *   - destPublicKey {string} required
@@ -743,30 +735,19 @@ const crossAssetPathsSchema = validateSchema({
 router.post('/cross-asset', payloadSizeLimiter(ENDPOINT_LIMITS.singleDonation), donationRateLimiter, requireApiKey, requireIdempotency, crossAssetSchema, async (req, res, next) => {
   try {
     const {
-      sourceSecret,
-      sendAsset: rawSendAsset,
-      sendAmount,
+      signedXDR,
       destPublicKey,
-      destAsset: rawDestAsset,
-      destAmount,
-      slippageTolerance = 0.01,
-      memo,
     } = req.body;
 
-    if (!sourceSecret || !destPublicKey) {
+    if (!signedXDR || !destPublicKey) {
       return res.status(400).json(
         buildErrorResponse([{ code: 'MISSING_REQUIRED_FIELDS', receivedValue: null }])
       );
     }
 
     const stellarService = getStellarService();
-    const sendAsset = parseAssetInput(rawSendAsset);
-    const destAsset = parseAssetInput(rawDestAsset);
 
-    const result = await stellarService.pathPayment(
-      sourceSecret, sendAsset, sendAmount, destPublicKey, destAsset, destAmount,
-      { slippageTolerance, memo }
-    );
+    const result = await stellarService.submitSignedTransaction(signedXDR);
 
     return res.status(201).json({ success: true, data: result });
   } catch (error) {

--- a/src/routes/offers.js
+++ b/src/routes/offers.js
@@ -44,7 +44,7 @@ function normaliseAsset(asset) {
  * Create a new DEX sell offer.
  *
  * Body:
- *   sourceSecret  {string} - Seller's Stellar secret key
+ *   signedXDR     {string} - Pre-signed transaction XDR envelope
  *   sellingAsset  {string} - Asset to sell ('XLM' or 'CODE:ISSUER')
  *   buyingAsset   {string} - Asset to buy  ('XLM' or 'CODE:ISSUER')
  *   amount        {string} - Amount of selling asset
@@ -52,23 +52,16 @@ function normaliseAsset(asset) {
  */
 router.post('/', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_CREATE), async (req, res) => {
   try {
-    const { sourceSecret, sellingAsset, buyingAsset, amount, price } = req.body;
+    const { signedXDR, sellingAsset, buyingAsset, amount, price } = req.body;
 
-    if (!sourceSecret) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'sourceSecret is required' } });
+    if (!signedXDR) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'signedXDR is required' } });
     if (!amount) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'amount is required' } });
     if (!price) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'price is required' } });
 
     const normSelling = normaliseAsset(sellingAsset);
     const normBuying = normaliseAsset(buyingAsset);
 
-    const result = await stellarService.createOffer({
-      sourceSecret,
-      sellingAsset: normSelling,
-      buyingAsset: normBuying,
-      amount: amount.toString(),
-      price: price.toString(),
-      offerId: 0,
-    });
+    const result = await stellarService.submitSignedTransaction(signedXDR);
 
     // Persist metadata for listing
     offerStore.set(result.offerId, {
@@ -104,7 +97,7 @@ router.get('/', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_READ), (req
  * Cancel an existing DEX offer.
  *
  * Body:
- *   sourceSecret  {string} - Seller's Stellar secret key
+ *   signedXDR     {string} - Pre-signed transaction XDR envelope
  *   sellingAsset  {string} - Asset being sold in the offer
  *   buyingAsset   {string} - Asset being bought in the offer
  */
@@ -113,13 +106,13 @@ router.delete('/:id', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_CREAT
     const offerId = parseInt(req.params.id, 10);
     if (isNaN(offerId)) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'Offer ID must be an integer' } });
 
-    const { sourceSecret, sellingAsset, buyingAsset } = req.body;
-    if (!sourceSecret) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'sourceSecret is required' } });
+    const { signedXDR, sellingAsset, buyingAsset } = req.body;
+    if (!signedXDR) return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'signedXDR is required' } });
 
     const normSelling = normaliseAsset(sellingAsset);
     const normBuying = normaliseAsset(buyingAsset);
 
-    const result = await stellarService.cancelOffer({ sourceSecret, sellingAsset: normSelling, buyingAsset: normBuying, offerId });
+    const result = await stellarService.submitSignedTransaction(signedXDR);
 
     const stored = offerStore.get(offerId);
     if (stored) stored.status = 'cancelled';

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -20,10 +20,10 @@ const { buildErrorResponse } = require('../utils/validationErrorFormatter');
 // Inflation destination schema for PATCH
 const inflationDestinationSchema = {
   type: 'object',
-  required: ['destination', 'sourceSecret'],
+  required: ['destination', 'signedXDR'],
   properties: {
     destination: { type: 'string' },
-    sourceSecret: { type: 'string' }
+    signedXDR: { type: 'string' }
   }
 };
 
@@ -36,10 +36,10 @@ router.patch(
   async (req, res, next) => {
     try {
       const { id } = req.params;
-      const { destination, sourceSecret } = req.body;
+      const { destination, signedXDR } = req.body;
       const wallet = await WalletService.getWalletById(id);
       if (!wallet) return res.status(404).json({ error: 'Wallet not found' });
-      const result = await StellarService.setInflationDestination(sourceSecret, destination);
+      const result = await StellarService.submitSignedTransaction(signedXDR);
       // Optionally log audit here
       res.status(200).json({ success: true, inflationDestination: destination, result });
     } catch (err) {
@@ -68,14 +68,14 @@ router.get(
 /**
  * PUT /wallets/:id/inflation-destination
  * Set the inflation destination for a wallet's Stellar account.
- * Body: { destinationPublicKey: string, sourceSecret: string }
+ * Body: { destinationPublicKey: string, signedXDR: string }
  * Requires wallets:write permission.
  */
 router.put('/:id/inflation-destination', checkPermission(PERMISSIONS.WALLETS_UPDATE), walletIdSchema, async (req, res, next) => {
   try {
-    const { destinationPublicKey, sourceSecret } = req.body;
-    if (!destinationPublicKey || !sourceSecret) {
-      return res.status(400).json({ success: false, error: 'Missing required fields: destinationPublicKey, sourceSecret' });
+    const { destinationPublicKey, signedXDR } = req.body;
+    if (!destinationPublicKey || !signedXDR) {
+      return res.status(400).json({ success: false, error: 'Missing required fields: destinationPublicKey, signedXDR' });
     }
     // Validate destination public key format (G...)
     if (!/^G[A-Z2-7]{55}$/.test(destinationPublicKey)) {
@@ -92,7 +92,7 @@ router.put('/:id/inflation-destination', checkPermission(PERMISSIONS.WALLETS_UPD
     const stellarSvc = getStellarService();
     let result;
     try {
-      result = await stellarSvc.setInflationDestination(sourceSecret, destinationPublicKey);
+      result = await stellarSvc.submitSignedTransaction(signedXDR);
     } catch (err) {
       if (err && err.name === 'ValidationError') return next(err);
       return res.status(502).json({ success: false, error: 'Stellar network error while setting inflation destination' });

--- a/src/services/MockStellarService.js
+++ b/src/services/MockStellarService.js
@@ -29,6 +29,24 @@ const NATIVE_ASSET = { type: 'native', code: 'XLM', issuer: null };
 
 class MockStellarService extends StellarServiceInterface {
     /**
+     * Submit a pre-signed transaction XDR envelope to the (mock) network.
+     * @param {string} signedXDR - Base64-encoded signed transaction envelope XDR
+     * @returns {Promise<{transactionId: string, ledger: number, hash: string}>}
+     */
+    async submitSignedTransaction(signedXDR) {
+      await this._simulateNetworkDelay();
+      this._checkRateLimit();
+      this._simulateFailure();
+      if (!signedXDR || typeof signedXDR !== 'string') {
+        throw new ValidationError('signedXDR must be a non-empty string');
+      }
+      const transactionId = `mock_tx_${crypto.randomBytes(8).toString('hex')}`;
+      const hash = `mock_hash_${crypto.randomBytes(16).toString('hex')}`;
+      const ledger = Math.floor(Math.random() * 1000000) + 1;
+      return { transactionId, hash, ledger, offerId: Math.floor(Math.random() * 100000) + 1 };
+    }
+
+    /**
      * Set the inflation destination for a mock wallet.
      * @param {string} sourceSecret - Secret key of the source account
      * @param {string} destinationPublicKey - Public key to set as inflation destination

--- a/src/services/StellarService.js
+++ b/src/services/StellarService.js
@@ -29,6 +29,30 @@ const {
 
 class StellarService extends StellarServiceInterface {
       /**
+       * Submit a pre-signed transaction XDR envelope to the Stellar network.
+       * @param {string} signedXDR - Base64-encoded signed transaction envelope XDR
+       * @returns {Promise<{transactionId: string, hash: string, ledger: number}>}
+       */
+      async submitSignedTransaction(signedXDR) {
+        return StellarErrorHandler.wrap(async () => {
+          if (!signedXDR || typeof signedXDR !== 'string') {
+            const { ValidationError } = require('../utils/errors');
+            throw new ValidationError('signedXDR must be a non-empty string');
+          }
+          const transaction = StellarSdk.TransactionBuilder.fromXDR(signedXDR, this.networkPassphrase);
+          const response = await this._executeWithRetry(
+            () => this.server.submitTransaction(transaction),
+            'submitSignedTransaction'
+          );
+          return {
+            transactionId: response.id,
+            hash: response.hash,
+            ledger: response.ledger,
+          };
+        }, 'submitSignedTransaction');
+      }
+
+      /**
        * List claimable balances claimable by the given public key.
        * @param {string} publicKey - Stellar public key
        * @returns {Promise<Array>} List of claimable balances

--- a/src/services/interfaces/StellarServiceInterface.js
+++ b/src/services/interfaces/StellarServiceInterface.js
@@ -45,6 +45,16 @@ class StellarServiceInterface {
     throw new Error('getTransaction() must be implemented');
   }
 
+  /**
+   * Submit a pre-signed transaction XDR envelope to the Stellar network.
+   * @param {string} _signedXDR - Base64-encoded signed transaction envelope XDR
+   * @returns {Promise<{transactionId: string, hash: string, ledger: number}>}
+   */
+  async submitSignedTransaction(_signedXDR) {
+    void _signedXDR;
+    throw new Error('submitSignedTransaction() must be implemented');
+  }
+
   async buildAndSubmitFeeBumpTransaction(envelopeXdr, newFeeStroops, feeSourceSecret) {
     throw new Error('buildAndSubmitFeeBumpTransaction() must be implemented');
   }


### PR DESCRIPTION
...re-signed XDR

closes #705 
BREAKING CHANGE: All endpoints that previously accepted a Stellar secret key (sourceSecret / claimantSecret) in the request body now require a pre-signed transaction XDR envelope (signedXDR) instead.

Transmitting private keys over HTTP — even over TLS — is a severe security anti-pattern. The server should never receive or handle users' private keys. Any server compromise would expose all users' Stellar private keys, and keys may appear in logs, error reports, or crash dumps.

Affected endpoints:
  - POST   /offers                          sourceSecret  -> signedXDR
  - DELETE /offers/:id                      sourceSecret  -> signedXDR
  - POST   /donations/claimable             sourceSecret  -> signedXDR
  - POST   /donations/claimable/:id/claim   claimantSecret -> signedXDR
  - POST   /donations/cross-asset           sourceSecret  -> signedXDR
  - PATCH  /wallets/:id/inflation-destination sourceSecret -> signedXDR
  - PUT    /wallets/:id/inflation-destination sourceSecret -> signedXDR

Service layer changes:
  - Added submitSignedTransaction(signedXDR) to StellarServiceInterface
  - Implemented submitSignedTransaction in StellarService (submits via Horizon)
  - Implemented submitSignedTransaction in MockStellarService (returns mock result)

Documentation:
  - Added docs/MIGRATION_REMOVE_SOURCE_SECRET.md with full migration guide, client-side signing workflow, and JavaScript + Python code examples

Clients must now build and sign transactions locally using the Stellar SDK, then submit the base64-encoded XDR envelope to the API. This is fully compatible with hardware wallets and secure key management systems.

See docs/MIGRATION_REMOVE_SOURCE_SECRET.md for migration instructions.