### PR TITLE
fix(security): refuse startup when ENCRYPTION_KEY is not set (#701)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,12 +150,20 @@ LOG_VERBOSE=false
 
 
 # =====================================
-# Encryption (Optional for Local, Required in Production)
+# Encryption (REQUIRED — all environments)
 # =====================================
 
-# App uses a development fallback when this is unset outside production.
-# In production, ENCRYPTION_KEY must be provided.
-# ENCRYPTION_KEY=local_dev_encryption_key_change_me
+# A stable 32-byte (64 hex char) key used to encrypt sensitive data such as
+# wallet secret keys stored in the database.
+#
+# ⚠️  The server will REFUSE TO START if this is not set.
+# ⚠️  Changing this key makes all previously encrypted data unrecoverable.
+#
+# Generate a key:
+#   npm run generate-key
+#
+# Then paste the output below (or let the script write it automatically).
+ENCRYPTION_KEY=<run `npm run generate-key` and paste the output here>
 # =====================================
 # Stellar Federation Server (Optional)
 # =====================================

--- a/docs/features/WALLET_FIELD_ENCRYPTION.md
+++ b/docs/features/WALLET_FIELD_ENCRYPTION.md
@@ -11,7 +11,7 @@ Wallet `label` and `notes` fields are encrypted with AES-256-GCM before being wr
 | `ENCRYPTION_KEY_N` | Key for version N (e.g. `ENCRYPTION_KEY_2`) |
 | `ENCRYPTION_KEY_VERSION` | Active key version for new writes (default: `1`) |
 
-When neither `ENCRYPTION_KEY` nor `ENCRYPTION_KEY_1` is set, fields are stored as plaintext (development mode).
+When neither `ENCRYPTION_KEY` nor `ENCRYPTION_KEY_1` is set, the server will **refuse to start**. Run `npm run generate-key` to create a stable key and add it to your `.env` file.
 
 ## Ciphertext Format
 

--- a/docs/guides/PRE_DEPLOYMENT_CHECKLIST.md
+++ b/docs/guides/PRE_DEPLOYMENT_CHECKLIST.md
@@ -6,7 +6,7 @@ This checklist ensures the Stellar Micro-Donation API is production-ready before
 
 ### Required Environment Variables
 - [ ] `API_KEYS` - Set with strong, randomly generated keys (use `openssl rand -hex 32`)
-- [ ] `ENCRYPTION_KEY` - Required for production environment (32+ character random string)
+- [ ] `ENCRYPTION_KEY` - Required in all environments (32+ character random string — run `npm run generate-key`)
 - [ ] `NODE_ENV` - Set to `production`
 - [ ] `STELLAR_NETWORK` - Set to `mainnet` for production (or `testnet` for staging)
 - [ ] `PORT` - Configured (default: 3000, must be 1-65535)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "keys:create": "node src/scripts/manageApiKeys.js create",
     "keys:list": "node src/scripts/manageApiKeys.js list",
     "keys:help": "node src/scripts/manageApiKeys.js help",
+    "generate-key": "node src/scripts/generateKey.js",
     "validate:rbac": "node scripts/validate-rbac.js",
     "openapi:generate": "node scripts/generate-openapi.js",
     "openapi:check": "node scripts/check-openapi-sync.js",

--- a/src/config/securityConfig.js
+++ b/src/config/securityConfig.js
@@ -136,13 +136,6 @@ const SECURITY_CONFIGS = {
 };
 
 /**
- * Generate a secure development encryption key
- */
-function generateDevEncryptionKey() {
-  return crypto.randomBytes(32).toString('hex');
-}
-
-/**
  * Load and validate security configuration with safe defaults
  */
 function loadSecurityConfig() {
@@ -201,20 +194,10 @@ function loadSecurityConfig() {
       }
     }
 
-    // Special handling for encryption key
-    if (key === 'ENCRYPTION_KEY' && !finalValue && !isProduction) {
-      finalValue = generateDevEncryptionKey();
-      misconfigurations.push({
-        config: key,
-        issue: 'Generated development encryption key',
-        severity: 'INFO',
-        usedDefault: true,
-        isGenerated: true
-      });
-      log.info('SECURITY_CONFIG', 'Generated development encryption key', {
-        config: key,
-        keyLength: finalValue.length
-      });
+    // ENCRYPTION_KEY must always be explicitly set — never auto-generate
+    if (key === 'ENCRYPTION_KEY' && !finalValue) {
+      log.error('SECURITY_CONFIG', 'ENCRYPTION_KEY is not set. Run `npm run generate-key` to create one, then add it to your .env file.');
+      process.exit(1);
     }
 
     config[key] = finalValue;

--- a/src/scripts/generateKey.js
+++ b/src/scripts/generateKey.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * generate-key — generate a stable ENCRYPTION_KEY and write it to .env
+ *
+ * Usage:
+ *   npm run generate-key            # writes/updates ENCRYPTION_KEY in .env
+ *   npm run generate-key -- --print # only prints the key, does not write
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const ENV_PATH = path.join(__dirname, '../../.env');
+const key = crypto.randomBytes(32).toString('hex');
+const printOnly = process.argv.includes('--print');
+
+if (printOnly) {
+  console.log(key);
+  process.exit(0);
+}
+
+// Write or update ENCRYPTION_KEY in .env
+if (fs.existsSync(ENV_PATH)) {
+  let content = fs.readFileSync(ENV_PATH, 'utf8');
+  if (/^ENCRYPTION_KEY\s*=/m.test(content)) {
+    content = content.replace(/^ENCRYPTION_KEY\s*=.*/m, `ENCRYPTION_KEY=${key}`);
+    console.log('✔ Updated ENCRYPTION_KEY in .env');
+  } else {
+    content += `\nENCRYPTION_KEY=${key}\n`;
+    console.log('✔ Added ENCRYPTION_KEY to .env');
+  }
+  fs.writeFileSync(ENV_PATH, content);
+} else {
+  fs.writeFileSync(ENV_PATH, `ENCRYPTION_KEY=${key}\n`);
+  console.log('✔ Created .env with ENCRYPTION_KEY');
+}
+
+console.log('\n⚠️  Keep this key secret and never commit it to version control.');
+console.log('   Changing it will make all previously encrypted data unrecoverable.\n');

--- a/src/utils/startupChecks.js
+++ b/src/utils/startupChecks.js
@@ -37,12 +37,8 @@ function fail(name, detail) {
 function checkEncryptionKey() {
   const key = process.env.ENCRYPTION_KEY;
   if (!key || !key.trim()) {
-    if (process.env.NODE_ENV === 'production') {
-      fail('ENCRYPTION_KEY', 'not set — required in production');
-      return false;
-    }
-    warn('ENCRYPTION_KEY', 'not set — using auto-generated key (not safe for production)');
-    return true;
+    fail('ENCRYPTION_KEY', 'not set — run `npm run generate-key` and add it to your .env file');
+    return false;
   }
   if (key.length < 32) {
     fail('ENCRYPTION_KEY', `too short (${key.length} chars, minimum 32)`);

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -2,6 +2,7 @@
 process.env.MOCK_STELLAR = 'true';
 process.env.API_KEYS = 'test-key-1,test-key-2,test-key,admin-test-key';
 process.env.NODE_ENV = 'test';
+process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'test_encryption_key_fixed_32bytes_hex_value_here_00';
 
 module.exports = async () => {
   // Delete stale DB file so tables are always created fresh with correct schema

--- a/tests/security/security-config.test.js
+++ b/tests/security/security-config.test.js
@@ -15,6 +15,8 @@ describe('Security Configuration', () => {
     securityVars.forEach(varName => {
       delete process.env[varName];
     });
+    // Always set a fixed test key so loadSecurityConfig() doesn't exit
+    process.env.ENCRYPTION_KEY = 'test_encryption_key_fixed_32bytes_hex_value_here_00';
   });
 
   afterEach(() => {
@@ -30,19 +32,18 @@ describe('Security Configuration', () => {
       expect(config.STELLAR_NETWORK).toBe('testnet');
       expect(config.MOCK_STELLAR).toBe('true');
       expect(config.RATE_LIMIT).toBe('100');
-      expect(config.ENCRYPTION_KEY).toBeTruthy(); // Should generate dev key
+      expect(config.ENCRYPTION_KEY).toBe(process.env.ENCRYPTION_KEY); // Must be explicitly set
       expect(config.HORIZON_URL).toBeNull();
       expect(config.SERVICE_SECRET_KEY).toBeNull();
       expect(config.STELLAR_SECRET).toBeNull();
     });
 
-    test('should generate development encryption key when not provided', () => {
-      delete process.env.ENCRYPTION_KEY;
+    test('should use the provided ENCRYPTION_KEY without modification', () => {
       const config = loadSecurityConfig();
       
       expect(config.ENCRYPTION_KEY).toBeTruthy();
       expect(typeof config.ENCRYPTION_KEY).toBe('string');
-      expect(config.ENCRYPTION_KEY.length).toBe(64); // 32 bytes as hex
+      expect(config.ENCRYPTION_KEY.length).toBeGreaterThanOrEqual(32);
     });
 
     test('should use testnet as safe default when Stellar network', () => {
@@ -170,12 +171,14 @@ describe('Security Configuration', () => {
       process.env.NODE_ENV = 'production';
     });
 
-    test('should require encryption key in production', () => {
+    test('should exit when ENCRYPTION_KEY is not set', () => {
+      const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
       delete process.env.ENCRYPTION_KEY;
       
-      expect(() => {
-        loadSecurityConfig();
-      }).not.toThrow(); // Should not throw, but will log error
+      loadSecurityConfig();
+      
+      expect(mockExit).toHaveBeenCalledWith(1);
+      mockExit.mockRestore();
     });
 
     test('should accept valid encryption key in production', () => {
@@ -202,26 +205,16 @@ describe('Security Configuration', () => {
       expect(summary.STELLAR_NETWORK).toBe('testnet');
     });
 
-    test('should show CONFIGURED when encryption key and NOT SET when missing secrets', () => {
-      // This test verifies the summary function behavior
-      // Since encryption key is auto-generated, it will show as CONFIGURED
-      // Empty API_KEYS should show as NOT SET, but due to caching might show differently
-      
+    test('should show CONFIGURED when encryption key is set and NOT SET when missing secrets', () => {
       // Clear API keys and secrets to test NOT SET behavior
       process.env.API_KEYS = '';
       delete process.env.SERVICE_SECRET_KEY;
       delete process.env.STELLAR_SECRET;
+      // ENCRYPTION_KEY is set in beforeEach
       
-      // Clear the module cache to force reload
-      delete require.cache[require.resolve('../src/config/securityConfig')];
-      
-      // Get a fresh summary
-      const { getSecuritySummary } = require('../../src/config/securityConfig');
       const summary = getSecuritySummary();
       
-      // ENCRYPTION_KEY is always generated, so shows as CONFIGURED
       expect(summary.ENCRYPTION_KEY).toBe('[CONFIGURED]');
-      // SERVICE_SECRET_KEY should be NOT SET when not provided
       expect(summary.SERVICE_SECRET_KEY).toBe('[NOT SET]');
       expect(summary.STELLAR_SECRET).toBe('[NOT SET]');
     });
@@ -255,12 +248,12 @@ describe('Security Configuration', () => {
   describe('Edge Cases', () => {
     test('should handle null and undefined values gracefully', () => {
       process.env.API_KEYS = null;
-      process.env.ENCRYPTION_KEY = undefined;
+      // ENCRYPTION_KEY is set in beforeEach; keep it so the server doesn't exit
       
       const config = loadSecurityConfig();
       
       expect(config.API_KEYS).toEqual([]);
-      expect(config.ENCRYPTION_KEY).toBeTruthy(); // Generated
+      expect(config.ENCRYPTION_KEY).toBeTruthy();
     });
 
     test('should handle whitespace-only values', () => {
@@ -275,12 +268,12 @@ describe('Security Configuration', () => {
 
     test('should handle empty string values', () => {
       process.env.API_KEYS = '';
-      process.env.ENCRYPTION_KEY = '';
+      // ENCRYPTION_KEY is set in beforeEach; keep it so the server doesn't exit
       
       const config = loadSecurityConfig();
       
       expect(config.API_KEYS).toEqual([]);
-      expect(config.ENCRYPTION_KEY).toBeTruthy(); // Generated
+      expect(config.ENCRYPTION_KEY).toBeTruthy();
     });
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -2,6 +2,8 @@
 process.env.MOCK_STELLAR = 'true';
 process.env.API_KEYS = 'test-key-1,test-key-2,test-key,admin-test-key';
 process.env.NODE_ENV = 'test';
+// Fixed test key — must be set before any module that imports securityConfig is loaded
+process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'test_encryption_key_fixed_32bytes_hex_value_here_00';
 
 // Polyfill for legacy test patterns
 if (typeof jest !== 'undefined') {


### PR DESCRIPTION
closes #701 


Root cause
----------
securityConfig.js generated a new random ENCRYPTION_KEY on every startup when the env var was not set. This silently corrupted all encrypted wallet secrets on every server restart because the key changed between sessions. startupChecks.js only warned (not failed) in non-production environments, so the problem went unnoticed.

Changes
-------
src/config/securityConfig.js
  - Remove generateDevEncryptionKey() and the auto-generation block.
  - Call process.exit(1) with a clear error message when ENCRYPTION_KEY is absent, in all environments (not just production).

src/utils/startupChecks.js
  - checkEncryptionKey(): change warn → fail when key is missing so the startup check also blocks the server from accepting traffic.

src/scripts/generateKey.js  (new)
  - Generates a cryptographically secure 32-byte (64 hex char) key.
  - Writes/updates ENCRYPTION_KEY in .env automatically.
  - Supports --print flag to only print the key without writing.

package.json
  - Add "generate-key" script: node src/scripts/generateKey.js

.env.example
  - Replace the commented-out placeholder with an uncommented ENCRYPTION_KEY entry and clear instructions to run generate-key.

tests/setup.js / tests/globalSetup.js
  - Set a fixed ENCRYPTION_KEY before any module is loaded so the test suite does not trigger the new exit(1) guard.

tests/security/security-config.test.js
  - beforeEach: set a fixed test key instead of relying on auto-generation.
  - Replace "should generate development encryption key" test with "should use the provided ENCRYPTION_KEY without modification".
  - Production Requirements: mock process.exit and assert it is called with code 1 when ENCRYPTION_KEY is absent.
  - Edge Cases: stop unsetting ENCRYPTION_KEY in tests that previously expected a generated fallback.
  - Security Summary: remove stale comment about auto-generation.

docs/features/WALLET_FIELD_ENCRYPTION.md
  - Update the note about missing keys: server now refuses to start instead of falling back to plaintext storage.

docs/guides/PRE_DEPLOYMENT_CHECKLIST.md
  - Mark ENCRYPTION_KEY as required in all environments (not just prod).

Acceptance criteria (from issue #701)
--------------------------------------
✅ Server refuses to start with a clear error if ENCRYPTION_KEY is not set ✅ .env.example includes a placeholder with instructions to generate a key ✅ npm run generate-key generates a stable key and writes it to .env ✅ Documentation explains key management requirements ✅ Tests use a fixed test key, not a randomly generated one