### PR TITLE
fix(security): #702 apply rate limiting, audit logging, and sunset wa…

### DIFF
--- a/docs/MIGRATION_LEGACY_API_KEYS.md
+++ b/docs/MIGRATION_LEGACY_API_KEYS.md
@@ -1,0 +1,71 @@
+# Migration Guide: Legacy API Keys → Database-Backed Keys
+
+**Issue:** #702  
+**Sunset date: 2026-12-31** — `API_KEYS` environment variable support will be removed.
+
+---
+
+## What Changed
+
+Legacy API keys (set via the `API_KEYS` environment variable) now have the same security controls as database-backed keys:
+
+| Control | Before | After |
+|---|---|---|
+| Rate limiting | ❌ Bypassed | ✅ 100 req/60 s (default) |
+| Audit logging | ❌ None | ✅ `LEGACY_KEY_USED` logged on every request |
+| Deprecation warning | ❌ None | ✅ `Warning` + `X-API-Key-Legacy: true` response headers |
+| Startup warning (production) | ❌ None | ✅ Emitted at server start |
+| Revocation without restart | ❌ Impossible | ❌ Still impossible — migrate to DB keys |
+
+---
+
+## Why You Should Migrate
+
+- Legacy keys **cannot be revoked** without restarting the server.
+- Legacy keys have **no expiration** and no per-key quota tracking.
+- Legacy keys are **incompatible** with key rotation, TOTP second-factor, and fine-grained scopes.
+- Support will be **removed on 2026-12-31**.
+
+---
+
+## Migration Steps
+
+### 1. Create a database-backed key
+
+```bash
+npm run keys:create -- --name "My Service Key" --role user --expires 365
+```
+
+This prints the new key value once. Store it securely.
+
+### 2. Update your client
+
+Replace the old key in your `X-API-Key` header with the new one.
+
+### 3. Verify the new key works
+
+```bash
+curl -H "X-API-Key: <new-key>" http://localhost:3000/health
+```
+
+### 4. Remove `API_KEYS` from your environment
+
+```bash
+# .env — remove or comment out:
+# API_KEYS=old-key-1,old-key-2
+```
+
+Restart the server. The startup warning will no longer appear.
+
+---
+
+## Available Key Management Commands
+
+```bash
+npm run keys:create -- --name "Name" --role user --expires 365   # create
+npm run keys:list                                                  # list all keys
+npm run keys -- deprecate --id <id>                               # deprecate (grace period)
+npm run keys -- revoke --id <id>                                   # hard revoke
+```
+
+For full documentation see [API Key Rotation Guide](./API_KEY_ROTATION.md).

--- a/src/middleware/rbac.js
+++ b/src/middleware/rbac.js
@@ -16,6 +16,8 @@ const { validateApiKey } = require('../models/apiKeys');
 const config = require('../config');
 const AuditLogService = require('../services/AuditLogService');
 const perKeyRateLimit = require('./perKeyRateLimit');
+const { checkRateLimit, buildRateLimitHeaders, DEFAULT_RATE_LIMIT, DEFAULT_WINDOW_SECONDS } = require('./perKeyRateLimit');
+const crypto = require('crypto');
 const { tierMeetsMinimum } = require('../config/permissionMatrix');
 
 /**
@@ -396,13 +398,52 @@ exports.attachUserRole = () => {
           }
           // Priority 3: Legacy Environment variable support
           else if (legacyKeys.includes(apiKey)) {
+            // Derive a stable, non-reversible ID for rate-limiting without storing the raw key
+            const legacyKeyId = 'legacy-' + crypto.createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
+
+            // Apply the same default rate limit as DB-backed keys
+            const rlResult = checkRateLimit(legacyKeyId, DEFAULT_RATE_LIMIT, DEFAULT_WINDOW_SECONDS);
+            const rlHeaders = buildRateLimitHeaders(rlResult.limit, rlResult.remaining, rlResult.resetAt);
+            res.set(rlHeaders);
+            res.set('X-API-Key-Legacy', 'true');
+            res.set('Warning', '299 - "Legacy API key in use. Migrate to database-backed keys before 2026-12-31. See docs/MIGRATION_LEGACY_API_KEYS.md"');
+
+            if (!rlResult.allowed) {
+              res.set('Retry-After', String(Math.ceil((rlResult.resetAt - Date.now()) / 1000)));
+              return res.status(429).json({
+                success: false,
+                error: {
+                  code: 'RATE_LIMIT_EXCEEDED',
+                  message: 'Rate limit exceeded. Please retry after the reset time.',
+                  retryAfter: Math.ceil((rlResult.resetAt - Date.now()) / 1000),
+                },
+              });
+            }
+
             req.user = {
-              id: `apikey-${apiKey}`,
+              id: legacyKeyId,
               role: apiKey.startsWith('admin-') ? 'admin' : 'user',
               name: 'Legacy API Key User',
               scopes: [],
               isLegacy: true
             };
+
+            // Audit every legacy key usage
+            AuditLogService.log({
+              category: AuditLogService.CATEGORY.AUTHENTICATION,
+              action: AuditLogService.ACTION.LEGACY_KEY_USED,
+              severity: AuditLogService.SEVERITY.HIGH,
+              result: 'SUCCESS',
+              userId: legacyKeyId,
+              requestId: req.id,
+              ipAddress: req.ip,
+              resource: req.path,
+              details: {
+                method: req.method,
+                keyIdHash: legacyKeyId,
+                sunsetDate: '2026-12-31',
+              },
+            }).catch(() => {});
           }
           // Default: Unauthenticated Guest access
           else {

--- a/src/utils/startupChecks.js
+++ b/src/utils/startupChecks.js
@@ -64,7 +64,17 @@ function checkApiKeys() {
     fail('API_KEYS', 'set but contains no valid keys');
     return false;
   }
-  pass('API_KEYS', `${keys.length} key(s) configured`);
+  if (process.env.NODE_ENV === 'production') {
+    warn(
+      'API_KEYS (legacy)',
+      `${keys.length} legacy key(s) detected in production. ` +
+      'Legacy keys bypass quota tracking and cannot be revoked without a restart. ' +
+      'Migrate to database-backed keys before 2026-12-31. ' +
+      'See docs/MIGRATION_LEGACY_API_KEYS.md'
+    );
+  } else {
+    pass('API_KEYS', `${keys.length} legacy key(s) configured (non-production)`);
+  }
   return true;
 }
 


### PR DESCRIPTION
…rning to legacy API keys


closes #702 
Legacy keys validated via the API_KEYS environment variable previously bypassed all security controls that database-backed keys go through. This commit closes that gap without removing backward compatibility before the sunset date.

Changes:

src/middleware/rbac.js
- Import checkRateLimit, buildRateLimitHeaders, and DEFAULT_* constants from perKeyRateLimit, and crypto for key hashing.
- Legacy key path now:
  1. Derives a stable, non-reversible keyId via SHA-256(key).slice(0,16) so the raw secret is never stored or logged.
  2. Applies the same default rate limit (100 req / 60 s) as DB-backed keys using checkRateLimit(); returns HTTP 429 with Retry-After when exceeded.
  3. Sets Warning and X-API-Key-Legacy: true response headers on every request to signal deprecation to clients.
  4. Fires AuditLogService.log(LEGACY_KEY_USED) on every successful request so legacy key usage is fully auditable.

src/utils/startupChecks.js
- checkApiKeys() now emits a warn() (not pass()) in production when API_KEYS is set, including the sunset date (2026-12-31) and a reference to the migration guide, so operators are alerted at every server start.

docs/MIGRATION_LEGACY_API_KEYS.md (new)
- Before/after security controls table.
- Step-by-step migration instructions (create DB key, swap header, remove env var).
- Sunset date: 2026-12-31.