### PR TITLE
fix(security): #703 mask all secret key variants in logs across all s…

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -21,6 +21,7 @@
 const { AppError, ERROR_CODES } = require("../utils/errors");
 const log = require('../utils/log');
 const { parseLanguage, getMessage } = require('../utils/i18n');
+const { maskSensitiveData } = require('../utils/dataMasker');
 
 /**
  * Production-safe message sanitizer
@@ -119,7 +120,7 @@ function errorHandler(err, req, res, next) {
       numericCode: err.numericCode,
       statusCode: err.statusCode || err.status,
       ...(!isProduction && { stack: err.stack }),
-      ...(err.details && { details: err.details }),
+      ...(err.details && { details: maskSensitiveData(err.details) }),
     },
     ...(req.get && { userAgent: req.get("User-Agent") }),
     ...(req.ip && { ip: req.ip }),

--- a/src/middleware/requestLogger.js
+++ b/src/middleware/requestLogger.js
@@ -14,30 +14,14 @@
 
 const log = require('../utils/log');
 const config = require('../config');
+const { maskSensitiveData, SENSITIVE_PATTERNS } = require('../utils/dataMasker');
 
 /**
- * Sensitive field patterns that should never appear in logs
+ * Sensitive field patterns — sourced from the canonical dataMasker list so
+ * both systems stay in sync automatically.
  * @type {string[]}
  */
-const DEFAULT_SENSITIVE_FIELDS = [
-  'password',
-  'secret',
-  'secretkey',
-  'secret_key',
-  'privatekey',
-  'private_key',
-  'token',
-  'authorization',
-  'apikey',
-  'api_key',
-  'api-key',
-  'creditcard',
-  'credit_card',
-  'ssn',
-  'social_security',
-  'encryptionkey',
-  'encryption_key'
-];
+const DEFAULT_SENSITIVE_FIELDS = SENSITIVE_PATTERNS;
 
 /**
  * Parse comma-separated path patterns from environment variable
@@ -241,12 +225,12 @@ class ConfigurableRequestLogger {
   }
 
   /**
-   * Sanitize sensitive data from object
+   * Sanitize sensitive data from object using the canonical dataMasker
    * @param {Object} data - Data to sanitize
    * @returns {Object} Sanitized data
    */
   sanitize(data) {
-    return sanitizeObject(data, this.sensitiveFields);
+    return maskSensitiveData(data);
   }
 
   /**

--- a/src/utils/dataMasker.js
+++ b/src/utils/dataMasker.js
@@ -43,6 +43,12 @@ const SENSITIVE_PATTERNS = [
   'source_secret',
   'destinationsecret',
   'destination_secret',
+  'claimantsecret',
+  'claimant_secret',
+  'secretkey',
+  'secret_key',
+  'signingkey',
+  'signing_key',
   'seed',
   'mnemonic',
   


### PR DESCRIPTION
…inks


closes #703 
Three coordinated changes to ensure Stellar secret keys and related sensitive field names can never appear in plaintext in any log output.

src/utils/dataMasker.js
- Added missing Stellar-specific patterns to SENSITIVE_PATTERNS: claimantsecret, claimant_secret, secretkey, secret_key, signingkey, signing_key
- VALUE_PATTERNS already catches raw S-key values by regex (S[A-Z2-7]{55}) so any secret key that slips through a field-name check is still redacted.

src/middleware/requestLogger.js
- Removed the logger's own hard-coded DEFAULT_SENSITIVE_FIELDS list, which was out of sync with dataMasker and missing sourcesecret, signingkey, etc.
- Now imports SENSITIVE_PATTERNS directly from dataMasker so both systems share a single source of truth and stay in sync automatically.
- Replaced sanitizeObject() in ConfigurableRequestLogger.sanitize() with maskSensitiveData() from dataMasker, which also catches sensitive values by regex (e.g. a raw S-key stored under an unexpected field name).

src/middleware/errorHandler.js
- Imported maskSensitiveData from dataMasker.
- Applied maskSensitiveData(err.details) before writing err.details to the error log, preventing secrets from leaking via error detail payloads (e.g. a ValidationError thrown with a body field containing a secret).