### PR TITLE
fix(security): #704 register requestTimeout middleware in app.js

### DIFF
--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -68,6 +68,7 @@ const requestId = require('../middleware/requestId');
 const { attachLifecycleTracking } = require('../middleware/requestLifecycle');
 const serviceContainer = require('../config/serviceContainer');
 const { payloadSizeLimiter } = require('../middleware/payloadSizeLimiter');
+const { requestTimeout, TIMEOUTS } = require('../middleware/requestTimeout');
 const { createCorsMiddleware } = require('../middleware/cors');
 const { createCspMiddleware, cspReportRouter } = require('../middleware/csp');
 const { responseFormatterMiddleware } = require('../utils/responseFormatter');
@@ -229,6 +230,15 @@ app.use(createDeduplicationMiddleware());
 
 // Response field filtering (?fields=id,amount,status)
 app.use(fieldFilterMiddleware());
+
+// Global request timeout — exempt SSE, WebSocket, and stream endpoints
+// Configurable via REQUEST_TIMEOUT_MS env var (default 30 s).
+const GLOBAL_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || TIMEOUTS.donation;
+const STREAMING_PATH_RE = /\/(stream|sse|events|ws|websocket|subscribe)(\/|$)/i;
+app.use((req, res, next) => {
+  if (STREAMING_PATH_RE.test(req.path)) return next();
+  return requestTimeout(GLOBAL_TIMEOUT_MS)(req, res, next);
+});
 
 // Routes
 app.use('/wallets', walletRoutes);


### PR DESCRIPTION
requestTimeout.js existed but was never wired into the middleware chain, leaving all connections open indefinitely on slow/hung Stellar network calls or database queries — a resource exhaustion vector under adversarial load.

src/routes/app.js
- Import { requestTimeout, TIMEOUTS } from the existing middleware module.
- Register a global timeout middleware immediately before the route handlers (after auth and quota tracking so request context is available for logging).
- Default timeout: 30 s (TIMEOUTS.donation), overridable via REQUEST_TIMEOUT_MS environment variable.
- SSE, WebSocket, and stream paths are exempted via STREAMING_PATH_RE so long-lived connections are not incorrectly terminated.
- Timed-out requests receive HTTP 503 with Retry-After: 5 (implemented in the existing requestTimeout factory).

closes #704 