### PR TITLE
fix: invalidate stats cache on new donation creation

### DIFF
--- a/src/routes/stats.js
+++ b/src/routes/stats.js
@@ -76,6 +76,47 @@ const { validateSchema } = require('../middleware/schemaValidation');
 const AuditLogService = require('../services/AuditLogService');
 const asyncHandler = require('../utils/asyncHandler');
 const { cacheMiddleware } = require('../middleware/caching');
+const Cache = require('../utils/cache');
+
+// Stats cache TTL in milliseconds — configurable via STATS_CACHE_TTL_SECONDS env var (default: 60s)
+const STATS_CACHE_TTL_MS = parseInt(process.env.STATS_CACHE_TTL_SECONDS || '60', 10) * 1000;
+
+/**
+ * Wrap a stats handler with server-side in-memory caching.
+ * Sets X-Cache-Age header and uses Cache.get/set with the given prefix + cache key.
+ *
+ * @param {string} prefix - Cache key prefix (e.g. 'stats:daily')
+ * @param {Function} dataFn - Function that returns the response body object
+ * @returns {import('express').RequestHandler}
+ */
+function withStatsCache(prefix, dataFn) {
+  return (req, res, next) => {
+    try {
+      const cacheKey = `${prefix}:${JSON.stringify(req.query)}`;
+      const cached = Cache.get(cacheKey);
+
+      if (cached) {
+        const ageSeconds = Math.floor((Date.now() - cached.cachedAt) / 1000);
+        res.setHeader('X-Cache-Age', String(ageSeconds));
+        return res.json(cached.body);
+      }
+
+      // Intercept res.json to store result in cache
+      const originalJson = res.json.bind(res);
+      res.json = function (body) {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          Cache.set(cacheKey, { body, cachedAt: Date.now() }, STATS_CACHE_TTL_MS);
+          res.setHeader('X-Cache-Age', '0');
+        }
+        return originalJson(body);
+      };
+
+      dataFn(req, res, next);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
 
 /** Fire-and-forget audit log for stats data access */
 function auditStatsAccess(req, res, next) {
@@ -161,7 +202,7 @@ router.get('/tags', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, s
  * Get daily aggregated donation volume
  * Query params: startDate, endDate (ISO format)
  */
-router.get('/daily', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, cacheMiddleware('stats', 'private'), strictDateRangeQuerySchema, validateDateRange, (req, res, next) => {
+router.get('/daily', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, cacheMiddleware('stats', 'private'), strictDateRangeQuerySchema, validateDateRange, withStatsCache('stats:daily', (req, res, next) => {
   try {
     const { startDate, endDate } = req.query;
     const start = new Date(startDate);
@@ -196,7 +237,7 @@ router.get('/daily', checkPermission(PERMISSIONS.STATS_READ), auditStatsAccess, 
   } catch (error) {
     next(error);
   }
-});
+}));
 
 /**
  * GET /stats/weekly
@@ -210,7 +251,7 @@ router.get(
   cacheMiddleware('stats', 'private'),
   strictDateRangeQuerySchema,
   validateDateRange,
-  (req, res, next) => {
+  withStatsCache('stats:weekly', (req, res, next) => {
     try {
       const { startDate, endDate } = req.query;
       const start = new Date(startDate);
@@ -233,7 +274,7 @@ router.get(
     } catch (error) {
       next(error);
     }
-  },
+  }),
 );
 
 /**
@@ -248,7 +289,7 @@ router.get(
   cacheMiddleware('stats', 'private'),
   strictDateRangeQuerySchema,
   validateDateRange,
-  (req, res, next) => {
+  withStatsCache('stats:summary', (req, res, next) => {
     try {
       const { startDate, endDate } = req.query;
       const start = new Date(startDate);
@@ -263,7 +304,7 @@ router.get(
     } catch (error) {
       next(error);
     }
-  },
+  }),
 );
 
 /**
@@ -590,6 +631,17 @@ router.get('/anonymous-breakdown', checkPermission(PERMISSIONS.STATS_READ), (req
   } catch (error) {
     next(error);
   }
+});
+
+/**
+ * POST /stats/cache/invalidate
+ * Admin endpoint to manually invalidate all stats caches.
+ * Requires stats:admin permission.
+ */
+router.post('/cache/invalidate', checkPermission(PERMISSIONS.STATS_ADMIN), (req, res) => {
+  Cache.clearPrefix('stats:');
+  Cache.clearPrefix('dashboard:');
+  res.json({ success: true, message: 'Stats cache invalidated' });
 });
 
 module.exports = router;

--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -37,6 +37,7 @@ const {
   isSameAsset,
   serializeAsset,
 } = require('../utils/stellarAsset');
+const donationEvents = require('../events/donationEvents');
 
 const DEFAULT_DESTINATION_ASSET = {
   type: 'native',
@@ -164,6 +165,18 @@ class DonationService {
       'INSERT INTO transactions (senderId, receiverId, amount, memo, notes, tags, timestamp, idempotencyKey, stellar_tx_id) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?)',
       [senderId, receiverId, amount, sanitizedMemo, notes || null, JSON.stringify(tags || []), idempotencyKey, stellarResult.transactionId]
     );
+
+    // Emit donation.created to trigger cache invalidation and other listeners (non-blocking)
+    try {
+      donationEvents.emit(donationEvents.constructor.EVENTS?.CREATED || 'donation.created', {
+        id: dbResult.id,
+        senderId,
+        receiverId,
+        amount,
+      });
+    } catch (err) {
+      log.error('DONATION_SERVICE', 'Failed to emit donation.created event', { error: err.message });
+    }
 
     if (campaign_id) {
       await this.processCampaignContribution(campaign_id, amount).catch(err => {

--- a/src/services/StatsService.js
+++ b/src/services/StatsService.js
@@ -762,11 +762,12 @@ class StatsService {
 
 // ─── Dashboard analytics (appended) ──────────────────────────────────────────
 
-// Invalidate dashboard cache whenever a new donation is created
+// Invalidate dashboard AND stats cache whenever a new donation is created
 const donationEvents = require('../events/donationEvents');
 donationEvents.on('donation.created', () => {
   const Cache = require('../utils/cache');
   Cache.clearPrefix('dashboard:');
+  Cache.clearPrefix('stats:');
 });
 
 module.exports = StatsService;


### PR DESCRIPTION
- Emit donation.created event in DonationService.sendCustodialDonation after a successful DB insert (event was defined but never fired)
- Extend StatsService donation.created listener to clear stats:* cache keys in addition to dashboard:* keys
- Add server-side in-memory caching (withStatsCache) to /stats/daily, /stats/weekly, and /stats/summary with configurable TTL via STATS_CACHE_TTL_SECONDS env var (default: 60s)
- Set X-Cache-Age response header on all cached stats responses
- Add POST /stats/cache/invalidate admin endpoint (requires stats:admin) for manual cache invalidation

Fixes: stale stats data after donation creation
closes #722 