### PR TITLE
feat: implement database connection pool health monitoring

### DIFF
--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -38,24 +38,15 @@ const DEFAULT_SLOW_QUERY_BUFFER_SIZE = 100;
 const MAX_SLOW_QUERY_ENTRIES = 1000;
 const SLOW_QUERY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
-<<<<<<< fix/issues-686-689
-// Issue #688: Use DB_PATH from environment or config, with sensible default
-const getDbPath = () => {
-=======
 // Resolve database path from environment or use default
 const getDBPath = () => {
->>>>>>> main
   if (process.env.DB_PATH) {
     return process.env.DB_PATH;
   }
   return path.join(__dirname, '../../data/stellar_donations.db');
 };
 
-<<<<<<< fix/issues-686-689
-const DB_PATH = getDbPath();
-=======
 const DB_PATH = getDBPath();
->>>>>>> main
 
 class Database {
   static get poolState() {
@@ -71,6 +62,7 @@ class Database {
         nextConnectionId: 1,
         pendingCreations: 0,
         queueDrainInProgress: false,
+        staleConnectionsReplaced: 0,
       };
     }
 
@@ -864,6 +856,7 @@ class Database {
       waiting: state.waitQueue.length,
       size: state.poolSize,
       acquireTimeout: state.acquireTimeout,
+      staleConnectionsReplaced: state.staleConnectionsReplaced || 0,
     };
   }
 
@@ -910,18 +903,74 @@ class Database {
   }
 
   /**
-   * Ping the database with a lightweight query. On failure, attempt reconnect.
+   * Run a SELECT 1 health check on each idle connection.
+   * Stale connections are removed from the pool and replaced with a fresh one.
+   * @private
+   */
+  static async _checkIdleConnections() {
+    const state = this.poolState;
+    // Snapshot idle connections — avoid mutating while iterating
+    const idleConnections = state.connections.filter(c => !c.inUse);
+
+    for (const connection of idleConnections) {
+      if (state.closing) break;
+
+      try {
+        await withTimeout(
+          new Promise((resolve, reject) => {
+            connection.db.get('SELECT 1 AS ping', [], (err) => {
+              if (err) reject(err); else resolve();
+            });
+          }),
+          TIMEOUT_DEFAULTS.DATABASE,
+          'health_check_ping'
+        );
+      } catch (err) {
+        // Connection is stale — remove it
+        const index = state.connections.findIndex(c => c.id === connection.id);
+        if (index !== -1) {
+          state.connections.splice(index, 1);
+        }
+        try {
+          await this.closeConnectionRecord(connection);
+        } catch (_) {
+          // best-effort close
+        }
+
+        state.staleConnectionsReplaced = (state.staleConnectionsReplaced || 0) + 1;
+        log.warn('DATABASE', 'Stale connection detected and removed from pool', {
+          connectionId: connection.id,
+          error: err.message,
+          staleConnectionsReplaced: state.staleConnectionsReplaced,
+        });
+
+        // Replace with a fresh connection if pool capacity allows
+        if (!state.closing && this.canCreateConnection()) {
+          try {
+            const fresh = await this.createConnectionRecord();
+            fresh.inUse = false;
+            log.info('DATABASE', 'Replaced stale connection with fresh connection', {
+              newConnectionId: fresh.id,
+            });
+          } catch (createErr) {
+            log.warn('DATABASE', 'Failed to create replacement connection', {
+              error: createErr.message,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Ping idle connections individually, then check for pool exhaustion.
    * Emits 'database.degraded' when the pool wait queue is exhausted.
    * @private
    */
   static async _runHealthCheck() {
     if (!this.poolState.initialized || this.poolState.closing) return;
-    try {
-      await this.get('SELECT 1 AS ping');
-    } catch (err) {
-      log.warn('DATABASE', 'Health check failed — attempting reconnect', { error: err.message });
-      await this._reconnectWithBackoff();
-    }
+
+    await this._checkIdleConnections();
 
     // Emit degraded event when pool is exhausted
     const state = this.poolState;
@@ -1020,6 +1069,7 @@ class Database {
     state.nextConnectionId = 1;
     state.pendingCreations = 0;
     state.queueDrainInProgress = false;
+    state.staleConnectionsReplaced = 0;
     state.closing = false;
     this.resetPerformanceMetrics();
   }

--- a/tests/utils/database-pool-health.test.js
+++ b/tests/utils/database-pool-health.test.js
@@ -1,0 +1,175 @@
+/**
+ * Tests: Database Connection Pool Health Monitoring
+ *
+ * Verifies stale connection detection, replacement, counter tracking,
+ * and that getPoolMetrics exposes staleConnectionsReplaced.
+ */
+
+const Database = require('../../src/utils/database');
+
+// Helper: build a fake connection record with a controllable db stub
+function makeFakeConnection(id, { failPing = false } = {}) {
+  return {
+    id,
+    inUse: false,
+    db: {
+      get: jest.fn((_sql, _params, cb) => {
+        if (failPing) {
+          cb(new Error('SQLITE_IOERR: disk I/O error'));
+        } else {
+          cb(null, { ping: 1 });
+        }
+      }),
+      close: jest.fn((cb) => cb(null)),
+    },
+  };
+}
+
+beforeEach(async () => {
+  // Reset pool state between tests
+  await Database.close();
+  Database.poolState = {
+    initialized: true,
+    initializing: null,
+    closing: false,
+    poolSize: 5,
+    poolMin: 1,
+    poolMax: 10,
+    acquireTimeout: 5000,
+    connections: [],
+    waitQueue: [],
+    nextConnectionId: 10,
+    pendingCreations: 0,
+    queueDrainInProgress: false,
+    staleConnectionsReplaced: 0,
+  };
+});
+
+afterAll(async () => {
+  await Database.close();
+});
+
+describe('_checkIdleConnections', () => {
+  it('leaves healthy idle connections in the pool', async () => {
+    const conn = makeFakeConnection(1);
+    Database.poolState.connections = [conn];
+
+    await Database._checkIdleConnections();
+
+    expect(Database.poolState.connections).toHaveLength(1);
+    expect(Database.poolState.staleConnectionsReplaced).toBe(0);
+  });
+
+  it('removes a stale idle connection and increments staleConnectionsReplaced', async () => {
+    const stale = makeFakeConnection(2, { failPing: true });
+    Database.poolState.connections = [stale];
+
+    // Mock createConnectionRecord to avoid real SQLite and push to connections
+    const fresh = makeFakeConnection(99);
+    jest.spyOn(Database, 'createConnectionRecord').mockImplementation(async () => {
+      Database.poolState.connections.push(fresh);
+      return fresh;
+    });
+
+    await Database._checkIdleConnections();
+
+    expect(Database.poolState.staleConnectionsReplaced).toBe(1);
+    expect(Database.poolState.connections.find(c => c.id === 2)).toBeUndefined();
+    expect(Database.poolState.connections.find(c => c.id === 99)).toBeDefined();
+  });
+
+  it('does not check connections that are in use', async () => {
+    const active = makeFakeConnection(3, { failPing: true });
+    active.inUse = true;
+    Database.poolState.connections = [active];
+
+    await Database._checkIdleConnections();
+
+    // Active connection is never pinged
+    expect(active.db.get).not.toHaveBeenCalled();
+    expect(Database.poolState.staleConnectionsReplaced).toBe(0);
+    expect(Database.poolState.connections).toHaveLength(1);
+  });
+
+  it('replaces multiple stale connections and counts each one', async () => {
+    const stale1 = makeFakeConnection(4, { failPing: true });
+    const stale2 = makeFakeConnection(5, { failPing: true });
+    const healthy = makeFakeConnection(6);
+    Database.poolState.connections = [stale1, stale2, healthy];
+
+    let freshId = 100;
+    jest.spyOn(Database, 'createConnectionRecord').mockImplementation(async () =>
+      makeFakeConnection(freshId++)
+    );
+
+    await Database._checkIdleConnections();
+
+    expect(Database.poolState.staleConnectionsReplaced).toBe(2);
+    expect(Database.poolState.connections.find(c => c.id === 4)).toBeUndefined();
+    expect(Database.poolState.connections.find(c => c.id === 5)).toBeUndefined();
+    expect(Database.poolState.connections.find(c => c.id === 6)).toBeDefined();
+  });
+
+  it('does not replace when pool is at capacity', async () => {
+    const stale = makeFakeConnection(7, { failPing: true });
+    Database.poolState.connections = [stale];
+    Database.poolState.poolSize = 0; // no capacity
+
+    await Database._checkIdleConnections();
+
+    expect(Database.poolState.staleConnectionsReplaced).toBe(1);
+    // No replacement created
+    expect(Database.poolState.connections).toHaveLength(0);
+  });
+});
+
+describe('getPoolMetrics', () => {
+  it('includes staleConnectionsReplaced in metrics', () => {
+    Database.poolState.staleConnectionsReplaced = 3;
+    const metrics = Database.getPoolMetrics();
+    expect(metrics).toHaveProperty('staleConnectionsReplaced', 3);
+  });
+
+  it('defaults staleConnectionsReplaced to 0', () => {
+    Database.poolState.staleConnectionsReplaced = 0;
+    const metrics = Database.getPoolMetrics();
+    expect(metrics.staleConnectionsReplaced).toBe(0);
+  });
+});
+
+describe('_runHealthCheck', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls _checkIdleConnections when pool is initialized and not closing', async () => {
+    const spy = jest.spyOn(Database, '_checkIdleConnections').mockResolvedValue();
+    Database.poolState.initialized = true;
+    Database.poolState.closing = false;
+    await Database._runHealthCheck();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips when pool is closing', async () => {
+    Database.poolState.initialized = true;
+    Database.poolState.closing = true;
+    const spy = jest.spyOn(Database, '_checkIdleConnections').mockResolvedValue();
+    await Database._runHealthCheck();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('skips when pool is not initialized', async () => {
+    Database.poolState.initialized = false;
+    Database.poolState.closing = false;
+    const spy = jest.spyOn(Database, '_checkIdleConnections').mockResolvedValue();
+    await Database._runHealthCheck();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('staleConnectionsReplaced counter reset on close', () => {
+  it('resets to 0 after close()', async () => {
+    Database.poolState.staleConnectionsReplaced = 7;
+    await Database.close();
+    // After close, poolState is reset — re-read it
+    expect(Database.poolState.staleConnectionsReplaced).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements per-connection health monitoring for the SQLite connection pool.

## Changes

- **`src/utils/database.js`**
  - Added `_checkIdleConnections()` — runs `SELECT 1` directly on each idle connection every 30s via the existing `_runHealthCheck` interval
  - Stale connections are removed from the pool, a warning is logged, and a fresh replacement is created if capacity allows
  - Added `staleConnectionsReplaced` counter to `poolState`
  - Exposed `staleConnectionsReplaced` in `getPoolMetrics()` (visible in the `/health` endpoint response)
  - Counter resets to `0` on `close()`
  - Fixed pre-existing merge conflict markers

- **`tests/utils/database-pool-health.test.js`** (new)
  - 11 tests covering: healthy connection passthrough, stale detection & replacement, in-use connection skipping, multiple stale connections, capacity limits, metrics exposure, guard conditions, and counter reset

## Acceptance Criteria

- [x] Pool runs `SELECT 1` health check on idle connections every 30s
- [x] Stale connections are removed and replaced
- [x] Warning log emitted on replacement with `staleConnectionsReplaced` count
- [x] `getPoolMetrics()` includes `staleConnectionsReplaced` counter
- [x] Health check endpoint reflects pool health via existing `pool` field
- [x] Tests verify stale connection detection and replacement

closes #723 