### PR TITLE
fix: graceful shutdown waits for in-progress recurring donation scheduler executions

### DIFF
--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -719,12 +719,13 @@ async function startServer() {
           log.error("SHUTDOWN", "Error flushing webhooks", { error: err.message });
         }
 
-        // Stop recurring donation scheduler and wait for running job
+        // Stop recurring donation scheduler and wait for in-progress executions
         try {
-          await recurringDonationScheduler.stopGracefully
-            ? recurringDonationScheduler.stopGracefully()
-            : recurringDonationScheduler.stop();
-          log.info("SHUTDOWN", "Scheduler stopped");
+          const schedulerResult = await recurringDonationScheduler.stopGracefully(timeoutMs);
+          log.info("SHUTDOWN", "Scheduler stopped", {
+            waited: schedulerResult?.waited ?? 0,
+            interrupted: schedulerResult?.interrupted ?? 0,
+          });
         } catch (err) {
           log.error("SHUTDOWN", "Error stopping scheduler", { error: err.message });
         }

--- a/src/services/RecurringDonationScheduler.js
+++ b/src/services/RecurringDonationScheduler.js
@@ -101,38 +101,91 @@ class RecurringDonationScheduler {
   }
 
   /**
-   * Gracefully stop the scheduler, waiting for any running job to complete.
-   * @param {number} [timeoutMs=10000] - Max wait time for running job
-   * @returns {Promise<void>}
+   * Gracefully stop the scheduler, waiting for any in-progress executions to complete.
+   *
+   * - Clears the polling interval immediately so no new executions are started.
+   * - Waits up to `timeoutMs` for all in-progress executions to finish.
+   * - Any executions still running after the timeout are logged as interrupted and
+   *   marked with status 'interrupted' in the DB for manual review.
+   *
+   * @param {number} [timeoutMs=30000] - Max wait time in ms (default 30 s)
+   * @returns {Promise<{waited: number, interrupted: number}>}
    */
-  async stopGracefully(timeoutMs = 10000) {
-    if (!this.isRunning) return;
+  async stopGracefully(timeoutMs = 30000) {
+    if (!this.isRunning) return { waited: 0, interrupted: 0 };
 
     clearInterval(this.intervalId);
     this.intervalId = null;
     this.isRunning = false;
 
     const { correlationId, traceId } = getCorrelationSummary();
+    const inProgressCount = this.executingSchedules.size;
 
-    if (this.executingSchedules.size > 0) {
-      log.info('RECURRING_SCHEDULER', 'Waiting for running jobs to complete', {
-        running: this.executingSchedules.size,
+    if (inProgressCount === 0) {
+      log.info('RECURRING_SCHEDULER', 'Scheduler stopped gracefully', {
+        waited: 0,
+        interrupted: 0,
+        correlationId,
+        traceId,
+      });
+      return { waited: 0, interrupted: 0 };
+    }
+
+    log.info('RECURRING_SCHEDULER', 'Waiting for in-progress executions to complete', {
+      inProgress: inProgressCount,
+      timeoutMs,
+      correlationId,
+      traceId,
+    });
+
+    const deadline = Date.now() + timeoutMs;
+    await new Promise((resolve) => {
+      const check = setInterval(() => {
+        if (this.executingSchedules.size === 0 || Date.now() >= deadline) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 100);
+    });
+
+    const interrupted = this.executingSchedules.size;
+    const waited = inProgressCount - interrupted;
+
+    if (interrupted > 0) {
+      const interruptedIds = [...this.executingSchedules];
+      log.error('RECURRING_SCHEDULER', 'Shutdown timeout reached — executions interrupted', {
+        interrupted,
+        interruptedScheduleIds: interruptedIds,
         correlationId,
         traceId,
       });
 
-      const deadline = Date.now() + timeoutMs;
-      await new Promise((resolve) => {
-        const check = setInterval(() => {
-          if (this.executingSchedules.size === 0 || Date.now() >= deadline) {
-            clearInterval(check);
-            resolve();
-          }
-        }, 100);
-      });
+      // Mark interrupted executions for manual review
+      for (const scheduleId of interruptedIds) {
+        try {
+          await Database.run(
+            `INSERT INTO recurring_donation_logs
+               (scheduleId, status, errorMessage, timestamp)
+             VALUES (?, 'interrupted', 'Execution interrupted by server shutdown', ?)`,
+            [scheduleId, new Date().toISOString()]
+          );
+        } catch (dbErr) {
+          log.error('RECURRING_SCHEDULER', 'Failed to mark interrupted execution', {
+            scheduleId,
+            error: dbErr.message,
+          });
+        }
+      }
     }
 
-    log.info('RECURRING_SCHEDULER', 'Scheduler stopped gracefully', { correlationId, traceId });
+    log.info('RECURRING_SCHEDULER', 'Scheduler stopped gracefully', {
+      waited,
+      interrupted,
+      correlationId,
+      traceId,
+    });
+
+    return { waited, interrupted };
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/tests/graceful-shutdown-extended.test.js
+++ b/tests/graceful-shutdown-extended.test.js
@@ -16,49 +16,124 @@ jest.mock('../src/utils/tracing', () => ({
   getCurrentTraceparent: () => null,
 }));
 
-const RecurringDonationScheduler = require('../src/services/RecurringDonationScheduler');
+jest.mock('../src/utils/database', () => ({ run: jest.fn().mockResolvedValue({}) }));
+jest.mock('../src/utils/log', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }));
+jest.mock('../src/utils/correlation', () => ({
+  withBackgroundContext: (_t, fn) => fn(),
+  withAsyncContext: (_t, fn) => fn(),
+  getCorrelationSummary: () => ({ correlationId: 'test-corr', traceId: 'test-trace' }),
+}));
+
+const Database = require('../src/utils/database');
+const RecurringDonationSchedulerModule = require('../src/services/RecurringDonationScheduler');
+const RecurringDonationScheduler = RecurringDonationSchedulerModule.Class || RecurringDonationSchedulerModule;
 const WebhookService = require('../src/services/WebhookService');
 
 describe('RecurringDonationScheduler.stopGracefully', () => {
   let scheduler;
-  beforeEach(() => { scheduler = new RecurringDonationScheduler(null); });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scheduler = new RecurringDonationScheduler({ sendPayment: jest.fn() });
+  });
+
   afterEach(() => { if (scheduler.isRunning) scheduler.stop(); });
 
-  test('stops immediately when no jobs running', async () => {
+  test('stops immediately when no jobs running and returns waited=0, interrupted=0', async () => {
     scheduler.isRunning = true;
     scheduler.intervalId = setInterval(() => {}, 60000);
-    await expect(scheduler.stopGracefully()).resolves.toBeUndefined();
+    const result = await scheduler.stopGracefully();
+    expect(result).toEqual({ waited: 0, interrupted: 0 });
     expect(scheduler.isRunning).toBe(false);
     expect(scheduler.intervalId).toBeNull();
   });
 
   test('no-op when already stopped', async () => {
     scheduler.isRunning = false;
-    await expect(scheduler.stopGracefully()).resolves.toBeUndefined();
+    const result = await scheduler.stopGracefully();
+    expect(result).toEqual({ waited: 0, interrupted: 0 });
   });
 
-  test('waits for executing schedules to finish', async () => {
+  test('waits for executing schedules to finish and reports waited count', async () => {
     scheduler.isRunning = true;
     scheduler.intervalId = setInterval(() => {}, 60000);
     scheduler.executingSchedules.add(42);
+    scheduler.executingSchedules.add(43);
+
     let resolved = false;
-    const p = scheduler.stopGracefully(500).then(() => { resolved = true; });
+    const p = scheduler.stopGracefully(500).then((r) => { resolved = true; return r; });
+
     await new Promise(r => setTimeout(r, 50));
     expect(resolved).toBe(false);
+
     scheduler.executingSchedules.delete(42);
-    await p;
+    scheduler.executingSchedules.delete(43);
+
+    const result = await p;
     expect(resolved).toBe(true);
     expect(scheduler.isRunning).toBe(false);
+    expect(result.waited).toBe(2);
+    expect(result.interrupted).toBe(0);
   });
 
-  test('resolves after timeout even if jobs still running', async () => {
+  test('resolves after timeout and marks interrupted executions in DB', async () => {
     scheduler.isRunning = true;
     scheduler.intervalId = setInterval(() => {}, 60000);
     scheduler.executingSchedules.add(99);
+
     const start = Date.now();
-    await scheduler.stopGracefully(200);
+    const result = await scheduler.stopGracefully(200);
+
     expect(Date.now() - start).toBeGreaterThanOrEqual(190);
     expect(scheduler.isRunning).toBe(false);
+    expect(result.interrupted).toBe(1);
+    expect(result.waited).toBe(0);
+
+    // Should have written an 'interrupted' log entry for schedule 99
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.stringContaining("'interrupted'"),
+      expect.arrayContaining([99])
+    );
+  });
+
+  test('logs interrupted count when timeout is hit with multiple in-progress executions', async () => {
+    scheduler.isRunning = true;
+    scheduler.intervalId = setInterval(() => {}, 60000);
+    scheduler.executingSchedules.add(1);
+    scheduler.executingSchedules.add(2);
+    scheduler.executingSchedules.add(3);
+
+    const result = await scheduler.stopGracefully(150);
+
+    expect(result.interrupted).toBe(3);
+    expect(result.waited).toBe(0);
+    // One DB insert per interrupted schedule
+    expect(Database.run).toHaveBeenCalledTimes(3);
+  });
+
+  test('partial drain: some finish before timeout, rest are interrupted', async () => {
+    scheduler.isRunning = true;
+    scheduler.intervalId = setInterval(() => {}, 60000);
+    scheduler.executingSchedules.add(10);
+    scheduler.executingSchedules.add(11);
+
+    // Schedule 10 finishes quickly, 11 never finishes
+    setTimeout(() => scheduler.executingSchedules.delete(10), 50);
+
+    const result = await scheduler.stopGracefully(200);
+
+    expect(result.waited).toBe(1);
+    expect(result.interrupted).toBe(1);
+    expect(Database.run).toHaveBeenCalledTimes(1);
+    expect(Database.run).toHaveBeenCalledWith(
+      expect.stringContaining("'interrupted'"),
+      expect.arrayContaining([11])
+    );
+  });
+
+  test('default timeout is 30 seconds', async () => {
+    // Verify the default parameter by inspecting the function signature via toString
+    expect(scheduler.stopGracefully.toString()).toMatch(/timeoutMs\s*=\s*30000/);
   });
 });
 


### PR DESCRIPTION
## Problem

During SIGTERM, `recurringDonationScheduler.stop()` returned immediately without waiting for any in-progress donation executions. This could leave a Stellar transaction submitted but not recorded in the DB, causing the same donation to re-execute on the next startup.

## Changes

### `src/services/RecurringDonationScheduler.js`
- `stopGracefully()` default timeout raised from 10 s → **30 s**
- Polls `executingSchedules` until empty or deadline reached
- After timeout, any still-running schedule IDs get an `'interrupted'` row inserted into `recurring_donation_logs` for manual review
- Returns `{ waited, interrupted }` so callers can log the outcome

### `src/routes/app.js`
- Replaced the fragile truthy-check ternary with a direct `await recurringDonationScheduler.stopGracefully(timeoutMs)`
- Passes the global `SHUTDOWN_TIMEOUT_MS` so both limits stay in sync
- Shutdown log now includes `waited` and `interrupted` counts

### `tests/graceful-shutdown-extended.test.js`
- Updated existing tests to assert the new `{ waited, interrupted }` return shape
- Added tests for: full drain, timeout with DB row marking, partial drain, multiple interrupted schedules, and the 30 s default

## Acceptance Criteria

- [x] `scheduler.stop()` (via `stopGracefully`) waits for all in-progress executions before returning
- [x] Maximum wait time of 30 s enforced
- [x] Interrupted executions logged with `status = 'interrupted'` for manual review
- [x] Shutdown log includes the number of waited vs interrupted executions
- [x] Tests verify graceful shutdown behavior
closes #724 