### PR TITLE
fix(#713): derive HORIZON_URL default from resolved network, warn on …

### DIFF
--- a/src/config/stellarEnvironments.js
+++ b/src/config/stellarEnvironments.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Stellar environment presets providing auto-configuration defaults 
- * for testnet and mainnet deployments dynamically.
+ * for testnet, mainnet, and futurenet deployments dynamically.
  */
 
 const environments = {
@@ -17,7 +17,14 @@ const environments = {
     networkPassphrase: 'Public Global Stellar Network ; September 2015',
     baseReserve: '0.5',
     feeMultiplier: 100,
-  }
+  },
+  futurenet: {
+    network: 'futurenet',
+    horizonUrl: 'https://horizon-futurenet.stellar.org',
+    networkPassphrase: 'Test SDF Future Network ; October 2022',
+    baseReserve: '0.5',
+    feeMultiplier: 100,
+  },
 };
 
 /**
@@ -29,21 +36,39 @@ const environments = {
 function getActiveEnvironment() {
   const rawEnv = process.env.STELLAR_ENVIRONMENT || 'testnet';
   const envName = rawEnv.toLowerCase();
-  
-  if (!['testnet', 'mainnet'].includes(envName)) {
-    throw new Error(`Invalid STELLAR_ENVIRONMENT provided: '${envName}'. Must be strictly 'testnet' or 'mainnet'.`);
+
+  if (!Object.keys(environments).includes(envName)) {
+    throw new Error(`Invalid STELLAR_ENVIRONMENT provided: '${envName}'. Must be one of: ${Object.keys(environments).join(', ')}.`);
   }
 
   if (envName === 'mainnet' && process.env.NODE_ENV === 'test') {
     throw new Error('SECURITY BLOCK: Mainnet operations are explicitly prevented when NODE_ENV is set to "test".');
   }
 
+  // Resolve the active network — STELLAR_NETWORK overrides STELLAR_ENVIRONMENT
+  const resolvedNetwork = (process.env.STELLAR_NETWORK || envName).toLowerCase();
+
+  // Derive the expected Horizon URL from the resolved network
+  const expectedHorizonUrl = (environments[resolvedNetwork] || environments[envName]).horizonUrl;
+
+  // Use HORIZON_URL override if provided, otherwise default to the expected URL for the network
+  const horizonUrl = process.env.HORIZON_URL || expectedHorizonUrl;
+
+  // Warn if an explicit HORIZON_URL override doesn't match the expected URL for the network
+  if (process.env.HORIZON_URL && process.env.HORIZON_URL !== expectedHorizonUrl) {
+    console.warn(
+      `[STELLAR_CONFIG] WARNING: HORIZON_URL "${process.env.HORIZON_URL}" does not match ` +
+      `the expected URL for network "${resolvedNetwork}" ("${expectedHorizonUrl}"). ` +
+      `Ensure this is intentional.`
+    );
+  }
+
   const preset = environments[envName];
 
   return {
     environment: envName,
-    network: process.env.STELLAR_NETWORK || preset.network,
-    horizonUrl: process.env.HORIZON_URL || preset.horizonUrl,
+    network: resolvedNetwork,
+    horizonUrl,
     networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || preset.networkPassphrase,
     baseReserve: process.env.STELLAR_BASE_RESERVE || preset.baseReserve,
     feeMultiplier: parseInt(process.env.STELLAR_FEE_MULTIPLIER || preset.feeMultiplier.toString(), 10)

--- a/tests/config/stellar-environments.test.js
+++ b/tests/config/stellar-environments.test.js
@@ -1,0 +1,133 @@
+/**
+ * Tests: stellarEnvironments — Issue #713
+ *
+ * Verifies:
+ *  - Correct default HORIZON_URL for each network (testnet/mainnet/futurenet)
+ *  - STELLAR_NETWORK overrides STELLAR_ENVIRONMENT for URL selection
+ *  - Warning emitted when HORIZON_URL override doesn't match expected URL
+ *  - No warning when HORIZON_URL matches expected URL
+ *  - Invalid STELLAR_ENVIRONMENT throws
+ */
+
+'use strict';
+
+describe('stellarEnvironments — getActiveEnvironment()', () => {
+  let getActiveEnvironment;
+
+  // Save and restore env vars around each test
+  const saved = {};
+  const VARS = ['STELLAR_ENVIRONMENT', 'STELLAR_NETWORK', 'HORIZON_URL', 'NODE_ENV'];
+
+  beforeEach(() => {
+    VARS.forEach(k => { saved[k] = process.env[k]; delete process.env[k]; });
+    jest.resetModules();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    ({ getActiveEnvironment } = require('../../src/config/stellarEnvironments'));
+  });
+
+  afterEach(() => {
+    VARS.forEach(k => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+    jest.restoreAllMocks();
+  });
+
+  // ── Default URL per network ──────────────────────────────────────────────
+
+  it('testnet: defaults horizonUrl to https://horizon-testnet.stellar.org', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    const env = getActiveEnvironment();
+    expect(env.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(env.network).toBe('testnet');
+  });
+
+  it('mainnet: defaults horizonUrl to https://horizon.stellar.org', () => {
+    process.env.STELLAR_ENVIRONMENT = 'mainnet';
+    process.env.NODE_ENV = 'production';
+    const env = getActiveEnvironment();
+    expect(env.horizonUrl).toBe('https://horizon.stellar.org');
+    expect(env.network).toBe('mainnet');
+  });
+
+  it('futurenet: defaults horizonUrl to https://horizon-futurenet.stellar.org', () => {
+    process.env.STELLAR_ENVIRONMENT = 'futurenet';
+    const env = getActiveEnvironment();
+    expect(env.horizonUrl).toBe('https://horizon-futurenet.stellar.org');
+    expect(env.network).toBe('futurenet');
+  });
+
+  // ── STELLAR_NETWORK overrides URL selection ──────────────────────────────
+
+  it('STELLAR_NETWORK=futurenet overrides STELLAR_ENVIRONMENT=testnet for horizonUrl', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    process.env.STELLAR_NETWORK = 'futurenet';
+    const env = getActiveEnvironment();
+    expect(env.horizonUrl).toBe('https://horizon-futurenet.stellar.org');
+    expect(env.network).toBe('futurenet');
+  });
+
+  it('STELLAR_NETWORK=mainnet overrides STELLAR_ENVIRONMENT=testnet for horizonUrl', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    process.env.STELLAR_NETWORK = 'mainnet';
+    process.env.NODE_ENV = 'production';
+    const env = getActiveEnvironment();
+    expect(env.horizonUrl).toBe('https://horizon.stellar.org');
+    expect(env.network).toBe('mainnet');
+  });
+
+  // ── Mismatch warning ─────────────────────────────────────────────────────
+
+  it('emits a warning when HORIZON_URL does not match the expected URL for the network', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    process.env.HORIZON_URL = 'https://horizon.stellar.org'; // mainnet URL on testnet
+    getActiveEnvironment();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('does not match')
+    );
+  });
+
+  it('emits no warning when HORIZON_URL matches the expected URL for the network', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+    getActiveEnvironment();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits no warning when HORIZON_URL is not set', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    getActiveEnvironment();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('warning message includes the override URL, network name, and expected URL', () => {
+    process.env.STELLAR_ENVIRONMENT = 'futurenet';
+    process.env.HORIZON_URL = 'https://custom.horizon.example.com';
+    getActiveEnvironment();
+    const msg = console.warn.mock.calls[0][0];
+    expect(msg).toContain('https://custom.horizon.example.com');
+    expect(msg).toContain('futurenet');
+    expect(msg).toContain('https://horizon-futurenet.stellar.org');
+  });
+
+  // ── HORIZON_URL override is respected ────────────────────────────────────
+
+  it('uses the explicit HORIZON_URL override even when it mismatches', () => {
+    process.env.STELLAR_ENVIRONMENT = 'testnet';
+    process.env.HORIZON_URL = 'https://my-custom-horizon.example.com';
+    const env = getActiveEnvironment();
+    expect(env.horizonUrl).toBe('https://my-custom-horizon.example.com');
+  });
+
+  // ── Invalid STELLAR_ENVIRONMENT ──────────────────────────────────────────
+
+  it('throws for an unknown STELLAR_ENVIRONMENT value', () => {
+    process.env.STELLAR_ENVIRONMENT = 'devnet';
+    expect(() => getActiveEnvironment()).toThrow(/Invalid STELLAR_ENVIRONMENT/);
+  });
+
+  it('error message lists all valid options', () => {
+    process.env.STELLAR_ENVIRONMENT = 'devnet';
+    expect(() => getActiveEnvironment()).toThrow(/testnet.*mainnet.*futurenet/);
+  });
+});


### PR DESCRIPTION
…mismatch

## Problem
STELLAR_NETWORK=futurenet caused getActiveEnvironment() to throw because futurenet was not in the environments map. Even when using STELLAR_NETWORK to override the network name, horizonUrl always defaulted to the STELLAR_ENVIRONMENT preset (testnet or mainnet), creating a silent network/URL mismatch.

## Root cause (src/config/stellarEnvironments.js)
1. futurenet missing from environments map → throws on STELLAR_ENVIRONMENT=futurenet
2. STELLAR_NETWORK env var changed the network name but not the horizonUrl default
3. No warning when HORIZON_URL override didn't match the active network

## Fix

### environments map
- Added futurenet preset: horizonUrl: https://horizon-futurenet.stellar.org networkPassphrase: Test SDF Future Network ; October 2022

### getActiveEnvironment()
- Resolves network as: STELLAR_NETWORK || STELLAR_ENVIRONMENT (STELLAR_NETWORK wins)
- Derives expectedHorizonUrl from the resolved network's preset
- horizonUrl = HORIZON_URL override ?? expectedHorizonUrl (correct default)
- Emits console.warn when HORIZON_URL is set but doesn't match expectedHorizonUrl
- Updated invalid-env error message to list all three valid values

### Network-to-URL mapping (now correct)
  testnet   → https://horizon-testnet.stellar.org
  mainnet   → https://horizon.stellar.org
  futurenet → https://horizon-futurenet.stellar.org

## Tests (tests/config/stellar-environments.test.js — 12 passing)
- Default URL correct for testnet, mainnet, futurenet
- STELLAR_NETWORK=futurenet overrides STELLAR_ENVIRONMENT=testnet for URL
- Warning emitted when HORIZON_URL mismatches expected URL
- No warning when HORIZON_URL matches or is absent
- Warning message contains override URL, network name, and expected URL
- Explicit HORIZON_URL override is still respected (with warning)
- Invalid STELLAR_ENVIRONMENT throws with message listing valid options

Closes #713