### PR TITLE
feat: add backup verification after creation (#735)

### DIFF
--- a/src/routes/admin/backup.js
+++ b/src/routes/admin/backup.js
@@ -29,6 +29,27 @@ router.post('/', checkPermission(PERMISSIONS.ADMIN_ALL), payloadSizeLimiter(ENDP
 }));
 
 /**
+ * GET /admin/backup/status
+ * Show the last backup time and verification result.
+ */
+router.get('/status', checkPermission(PERMISSIONS.ADMIN_ALL), asyncHandler(async (req, res, next) => {
+  try {
+    const backups = await backupService.listBackups();
+    const lastBackup = backups.length > 0 ? backups[0] : null;
+    res.json({
+      success: true,
+      data: {
+        lastBackupTime: lastBackup ? lastBackup.createdAt : null,
+        lastBackupId: lastBackup ? lastBackup.backupId : null,
+        lastVerification: backupService.lastVerification,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}));
+
+/**
  * GET /admin/backups
  * List all available backups.
  */

--- a/src/services/BackupService.js
+++ b/src/services/BackupService.js
@@ -12,6 +12,8 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const os = require('os');
+const sqlite3 = require('sqlite3').verbose();
 const log = require('../utils/log');
 
 const DB_PATH = path.join(__dirname, '../../data/stellar_donations.db');
@@ -73,6 +75,8 @@ class BackupService {
     this.s3 = options.s3 || null;
     this.s3Bucket = options.s3Bucket || process.env.BACKUP_S3_BUCKET || null;
     this.s3Prefix = options.s3Prefix || process.env.BACKUP_S3_PREFIX || 'backups/';
+    /** @type {{backupId: string, passed: boolean, checkedAt: string, details: object}|null} */
+    this.lastVerification = null;
   }
 
   /**
@@ -117,7 +121,116 @@ class BackupService {
     }
 
     log.info('BACKUP', 'Backup completed', { backupId, size: meta.size });
+    await this.verifyBackup(backupId);
     return meta;
+  }
+
+  /**
+   * Verify a backup file is valid and restorable.
+   *
+   * Decrypts the backup to a temp file, opens it with SQLite, runs
+   * PRAGMA integrity_check, and compares row counts for critical tables
+   * against the source database.
+   *
+   * @param {string} backupId
+   * @returns {Promise<{backupId: string, passed: boolean, checkedAt: string, details: object}>}
+   */
+  async verifyBackup(backupId) {
+    const filePath = path.join(this.backupDir, `${backupId}.enc`);
+    const checkedAt = new Date().toISOString();
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Backup not found: ${backupId}`);
+    }
+
+    const encrypted = fs.readFileSync(filePath);
+    const decrypted = decryptBuffer(encrypted);
+
+    const tmpFile = path.join(os.tmpdir(), `verify_${backupId}_${Date.now()}.db`);
+    let passed = false;
+    let details = {};
+
+    try {
+      fs.writeFileSync(tmpFile, decrypted);
+
+      try {
+        const integrityResult = await this._runSqliteQuery(tmpFile, 'PRAGMA integrity_check');
+        const integrityOk = integrityResult.length === 1 && integrityResult[0].integrity_check === 'ok';
+
+        const CRITICAL_TABLES = ['users', 'transactions', 'recurring_donations'];
+        const rowCounts = {};
+        const sourceRowCounts = {};
+        const rowCountMismatches = [];
+
+        for (const table of CRITICAL_TABLES) {
+          const [backupCount, sourceCount] = await Promise.all([
+            this._getRowCount(tmpFile, table),
+            this._getRowCount(this.dbPath, table),
+          ]);
+          rowCounts[table] = backupCount;
+          sourceRowCounts[table] = sourceCount;
+          if (backupCount !== sourceCount) {
+            rowCountMismatches.push({ table, backup: backupCount, source: sourceCount });
+          }
+        }
+
+        passed = integrityOk && rowCountMismatches.length === 0;
+        details = { integrityOk, rowCounts, sourceRowCounts, rowCountMismatches };
+      } catch (sqliteErr) {
+        passed = false;
+        details = { error: sqliteErr.message };
+      }
+    } finally {
+      try { fs.unlinkSync(tmpFile); } catch (_) { /* ignore */ }
+    }
+
+    const verification = { backupId, passed, checkedAt, details };
+    this.lastVerification = verification;
+
+    if (passed) {
+      log.info('BACKUP', 'Backup verification passed', { backupId });
+    } else {
+      log.error('BACKUP', 'Backup verification FAILED', { backupId, details });
+    }
+
+    return verification;
+  }
+
+  /**
+   * Run a SQLite query and return all rows.
+   * @param {string} dbFile
+   * @param {string} sql
+   * @returns {Promise<object[]>}
+   * @private
+   */
+  _runSqliteQuery(dbFile, sql) {
+    return new Promise((resolve, reject) => {
+      const db = new sqlite3.Database(dbFile, sqlite3.OPEN_READONLY, err => {
+        if (err) return reject(err);
+      });
+      db.all(sql, [], (err, rows) => {
+        db.close();
+        if (err) return reject(err);
+        resolve(rows);
+      });
+    });
+  }
+
+  /**
+   * Get row count for a table, returning 0 if the table doesn't exist.
+   * @param {string} dbFile
+   * @param {string} table
+   * @returns {Promise<number>}
+   * @private
+   */
+  async _getRowCount(dbFile, table) {
+    if (!fs.existsSync(dbFile)) return 0;
+    try {
+      const rows = await this._runSqliteQuery(dbFile, `SELECT COUNT(*) as count FROM "${table}"`);
+      return rows[0] ? rows[0].count : 0;
+    } catch (_) {
+      return 0;
+    }
   }
 
   /**

--- a/tests/admin/backup-restore.test.js
+++ b/tests/admin/backup-restore.test.js
@@ -319,3 +319,157 @@ describe('RecurringDonationScheduler backup scheduling', () => {
     expect(backupSpy).not.toHaveBeenCalled();
   });
 });
+
+// ── Backup verification tests ─────────────────────────────────────────────────
+
+describe('BackupService.verifyBackup()', () => {
+  let BackupService;
+  let tmpDir;
+  let fakeDb;
+
+  beforeEach(() => {
+    setEncryptionKey();
+    tmpDir = makeTmpDir();
+    fakeDb = path.join(tmpDir, 'test.db');
+
+    // Write a minimal valid SQLite database (empty, but structurally valid)
+    // SQLite magic header: first 16 bytes are "SQLite format 3\000"
+    const sqlite3 = require('sqlite3').verbose();
+    jest.resetModules();
+    BackupService = require('../../src/services/BackupService');
+
+    // Create a real SQLite DB so integrity_check works
+    return new Promise((resolve, reject) => {
+      const db = new sqlite3.Database(fakeDb, err => {
+        if (err) return reject(err);
+        db.run('CREATE TABLE users (id INTEGER PRIMARY KEY)', err2 => {
+          if (err2) return reject(err2);
+          db.run('CREATE TABLE transactions (id INTEGER PRIMARY KEY)', err3 => {
+            if (err3) return reject(err3);
+            db.run('CREATE TABLE recurring_donations (id INTEGER PRIMARY KEY)', err4 => {
+              db.close();
+              if (err4) return reject(err4);
+              resolve();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('verifyBackup() passes for a valid backup', async () => {
+    const svc = new BackupService({ dbPath: fakeDb, backupDir: tmpDir });
+    const { backupId } = await svc.backup();
+
+    // backup() already calls verifyBackup internally; call it explicitly too
+    const result = await svc.verifyBackup(backupId);
+
+    expect(result.backupId).toBe(backupId);
+    expect(result.passed).toBe(true);
+    expect(result.checkedAt).toBeTruthy();
+    expect(result.details.integrityOk).toBe(true);
+    expect(result.details.rowCountMismatches).toEqual([]);
+  });
+
+  it('verifyBackup() stores result in lastVerification', async () => {
+    const svc = new BackupService({ dbPath: fakeDb, backupDir: tmpDir });
+    const { backupId } = await svc.backup();
+
+    expect(svc.lastVerification).not.toBeNull();
+    expect(svc.lastVerification.backupId).toBe(backupId);
+    expect(typeof svc.lastVerification.passed).toBe('boolean');
+  });
+
+  it('verifyBackup() throws when backup file does not exist', async () => {
+    const svc = new BackupService({ dbPath: fakeDb, backupDir: tmpDir });
+    await expect(svc.verifyBackup('backup_nonexistent_0000')).rejects.toThrow('Backup not found');
+  });
+
+  it('verifyBackup() fails and logs error when backup is corrupted', async () => {
+    const svc = new BackupService({ dbPath: fakeDb, backupDir: tmpDir });
+    const { backupId, filePath } = await svc.backup();
+
+    // Corrupt the ciphertext so decryption fails
+    const buf = fs.readFileSync(filePath);
+    buf[buf.length - 1] ^= 0xff;
+    fs.writeFileSync(filePath, buf);
+
+    await expect(svc.verifyBackup(backupId)).rejects.toThrow();
+  });
+
+  it('backup() automatically calls verifyBackup() and populates lastVerification', async () => {
+    const svc = new BackupService({ dbPath: fakeDb, backupDir: tmpDir });
+    expect(svc.lastVerification).toBeNull();
+
+    await svc.backup();
+
+    expect(svc.lastVerification).not.toBeNull();
+    expect(svc.lastVerification.passed).toBe(true);
+  });
+});
+
+// ── GET /admin/backup/status route tests ─────────────────────────────────────
+
+describe('GET /admin/backup/status', () => {
+  let request;
+  let app;
+  let BackupService;
+
+  beforeEach(() => {
+    setEncryptionKey();
+    jest.resetModules();
+
+    // Mock RBAC before requiring routes
+    jest.mock('../../src/middleware/rbac', () => ({
+      checkPermission: () => (req, res, next) => next(),
+      requireAdmin: () => (req, res, next) => next(),
+      attachUserRole: (req, res, next) => next(),
+    }));
+
+    BackupService = require('../../src/services/BackupService');
+    jest.spyOn(BackupService.prototype, 'listBackups').mockResolvedValue([
+      { backupId: 'backup_999_aabbccdd', filePath: '/data/backups/backup_999_aabbccdd.enc', size: 1024, createdAt: '2026-04-01T12:00:00.000Z' },
+    ]);
+
+    const express = require('express');
+    const backupRoutes = require('../../src/routes/admin/backup');
+    app = express();
+    app.use(express.json());
+    app.use('/', backupRoutes);
+
+    request = require('supertest');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('GET /status returns 200 with lastBackupTime and lastVerification', async () => {
+    const res = await request(app).get('/status');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('lastBackupTime');
+    expect(res.body.data).toHaveProperty('lastBackupId');
+    expect(res.body.data).toHaveProperty('lastVerification');
+  });
+
+  it('GET /status returns null lastBackupTime when no backups exist', async () => {
+    BackupService.prototype.listBackups.mockResolvedValue([]);
+    const res = await request(app).get('/status');
+    expect(res.status).toBe(200);
+    expect(res.body.data.lastBackupTime).toBeNull();
+    expect(res.body.data.lastBackupId).toBeNull();
+  });
+
+  it('GET /status returns lastBackupTime from most recent backup', async () => {
+    const res = await request(app).get('/status');
+    expect(res.status).toBe(200);
+    expect(res.body.data.lastBackupTime).toBe('2026-04-01T12:00:00.000Z');
+    expect(res.body.data.lastBackupId).toBe('backup_999_aabbccdd');
+  });
+});


### PR DESCRIPTION
closes #735


- Add verifyBackup() to BackupService: PRAGMA integrity_check + row count comparison
- Auto-verify after each backup(), store result in lastVerification
- Add GET /admin/backup/status endpoint
- Add 8 tests covering verification and status route