### PR TITLE
fix: follow Horizon pagination cursors in transaction sync (#734)

### DIFF
--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -182,6 +182,19 @@ const transactionSyncBodySchema = validateSchema({
         minLength: 1,
         maxLength: 255,
       },
+      cursor: {
+        type: 'string',
+        required: false,
+        trim: true,
+      },
+      maxPages: {
+        type: 'integer',
+        required: false,
+        validate: (value) => {
+          const n = Number(value);
+          return n >= 1 && n <= 500 ? true : 'maxPages must be between 1 and 500';
+        },
+      },
     },
   },
 });
@@ -226,7 +239,7 @@ router.post(
   transactionSyncBodySchema,
   asyncHandler(async (req, res, next) => {
     try {
-      const { publicKey } = req.body;
+      const { publicKey, cursor, maxPages } = req.body;
 
       if (!publicKey) {
         return res.status(400).json(
@@ -235,7 +248,10 @@ router.post(
       }
 
       const syncService = new TransactionSyncService(serviceContainer.getStellarService());
-      const result = await syncService.syncWalletTransactions(publicKey);
+      const result = await syncService.syncWalletTransactions(publicKey, {
+        ...(cursor !== undefined && { cursor }),
+        ...(maxPages !== undefined && { maxPages: Number(maxPages) }),
+      });
 
       return res.status(200).json({
         success: true,

--- a/src/services/TransactionSyncService.js
+++ b/src/services/TransactionSyncService.js
@@ -37,15 +37,24 @@ class TransactionSyncService {
    * Fetches only transactions AFTER the wallet's last_cursor (incremental sync).
    * On success, updates wallet's last_cursor and last_synced_at.
    * @param {string} publicKey - Stellar public key to sync
-   * @param {number} maxTransactions - Limit for unbounded fetching
-   * @returns {Promise<{synced: number, transactions: Array}>} Sync results
+   * @param {Object|number} [options] - Options object or legacy maxTransactions number
+   * @param {number} [options.maxTransactions=500] - Max total transactions to fetch
+   * @param {number} [options.maxPages=50] - Max Horizon pages to follow
+   * @param {string} [options.cursor] - Override cursor (resume from specific point)
+   * @returns {Promise<{synced: number, transactions: Array, lastCursor: string|null}>}
    */
-  async syncWalletTransactions(publicKey, maxTransactions = 500) {
+  async syncWalletTransactions(publicKey, options = {}) {
+    // Support legacy numeric argument
+    if (typeof options === 'number') options = { maxTransactions: options };
+    const { maxTransactions = 500, maxPages = 50, cursor: cursorOverride } = options;
+
     const startTime = Date.now();
     const wallet = Wallet.getByAddress(publicKey);
-    const lastCursor = wallet ? (wallet.last_cursor || wallet.last_synced_cursor) : undefined;
+    const lastCursor = cursorOverride !== undefined
+      ? cursorOverride
+      : (wallet ? (wallet.last_cursor || wallet.last_synced_cursor) : undefined);
 
-    const horizonTxs = await this._fetchHorizonTransactions(publicKey, maxTransactions, lastCursor);
+    const horizonTxs = await this._fetchHorizonTransactions(publicKey, maxTransactions, lastCursor, maxPages);
     const syncedTxs = [];
 
     // Horizon returns asc when fetching forward from cursor
@@ -63,16 +72,16 @@ class TransactionSyncService {
       }
     }
 
+    const newLastCursor = horizonTxs.length > 0
+      ? horizonTxs[horizonTxs.length - 1].paging_token
+      : null;
+
     if (wallet && horizonTxs.length > 0) {
-      // Update the cursor using the latest transaction fetched
-      // Txs are in asc order, so the last one is the newest
-      const latestTx = horizonTxs[horizonTxs.length - 1];
       Wallet.update(wallet.id, {
-        last_cursor: latestTx.paging_token,
+        last_cursor: newLastCursor,
         last_synced_at: new Date().toISOString(),
       });
     } else if (wallet) {
-      // Even if no new txs, update last_synced_at to record the sync attempt
       Wallet.update(wallet.id, { last_synced_at: new Date().toISOString() });
     }
 
@@ -81,35 +90,39 @@ class TransactionSyncService {
       walletAddress: publicKey,
       syncedCount: syncedTxs.length,
       fetchedCount: horizonTxs.length,
-      durationMs: duration
+      durationMs: duration,
+      lastCursor: newLastCursor,
     });
 
-    return { synced: syncedTxs.length, transactions: syncedTxs };
+    return { synced: syncedTxs.length, transactions: syncedTxs, lastCursor: newLastCursor };
   }
 
   /**
-   * Fetch paginated transactions from Horizon
+   * Fetch paginated transactions from Horizon, following next-page cursors.
+   * @param {string} publicKey
+   * @param {number} maxTransactions
+   * @param {string|undefined} cursor - Starting cursor for incremental sync
+   * @param {number} maxPages - Maximum number of pages to fetch
    */
-  async _fetchHorizonTransactions(publicKey, maxTransactions = 500, cursor = undefined) {
+  async _fetchHorizonTransactions(publicKey, maxTransactions = 500, cursor = undefined, maxPages = 50) {
     try {
       let transactions = [];
-      let limit = Math.min(200, maxTransactions); // Max limit allowed by Horizon is 200
+      const pageSize = Math.min(200, maxTransactions);
+      let pagesFetched = 0;
 
       let callBuilder = this.server.transactions()
         .forAccount(publicKey)
-        .limit(limit);
+        .limit(pageSize);
 
       if (cursor) {
-        // Incremental sync logic fetching NEWER transactions since last cursor
         callBuilder = callBuilder.cursor(cursor).order('asc');
       } else {
-        // In full sync, we probably want desc, but we fetch up to maxTransactions.
         callBuilder = callBuilder.order('desc');
       }
 
       let response = await callBuilder.call();
 
-      while (response.records && response.records.length > 0 && transactions.length < maxTransactions) {
+      while (response.records && response.records.length > 0 && transactions.length < maxTransactions && pagesFetched < maxPages) {
         for (const record of response.records) {
           if (transactions.length < maxTransactions) {
             transactions.push(record);
@@ -118,19 +131,22 @@ class TransactionSyncService {
           }
         }
 
-        if (transactions.length >= maxTransactions) {
+        pagesFetched++;
+        log.info('TX_SYNC', `Fetched page ${pagesFetched}`, {
+          publicKey,
+          pageRecords: response.records.length,
+          totalFetched: transactions.length,
+        });
+
+        if (transactions.length >= maxTransactions || pagesFetched >= maxPages) {
           break;
         }
 
-        // Standard way to fetch next page with stellar-sdk
         response = await response.next();
       }
 
-      // If we fetched descending initially, we might want to reverse to get ascending order for processing?
-      // Not strictly necessary since we're just syncing and grabbing the maximum cursor if we flip the logic.
-      // But if we fetched 'desc', the first element is the newest!
       if (!cursor) {
-        transactions.reverse(); // Ensure processing runs from oldest to newest to preserve cursor logic easily
+        transactions.reverse();
       }
 
       return transactions;

--- a/tests/transactions/transaction-sync-pagination.test.js
+++ b/tests/transactions/transaction-sync-pagination.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+/**
+ * Tests for TransactionSyncService multi-page Horizon pagination (#734).
+ */
+
+const TransactionSyncService = require('../../src/services/TransactionSyncService');
+const Transaction = require('../../src/routes/models/transaction');
+const Wallet = require('../../src/routes/models/wallet');
+
+jest.mock('../../src/routes/models/transaction');
+jest.mock('../../src/routes/models/wallet');
+
+const PUBLIC_KEY = 'GTEST1234567890ABCDEF';
+
+function makeTx(id, pagingToken) {
+  return { id, paging_token: pagingToken, created_at: '2024-01-01T00:00:00Z', memo: null };
+}
+
+function makeHorizonPage(records, hasNext = false) {
+  return {
+    records,
+    next: hasNext
+      ? jest.fn().mockResolvedValue(makeHorizonPage([], false))
+      : jest.fn().mockResolvedValue({ records: [], next: jest.fn() }),
+  };
+}
+
+describe('TransactionSyncService – pagination', () => {
+  let svc;
+  let mockServer;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Transaction.getByStellarTxId.mockReturnValue(null);
+    Transaction.create.mockImplementation(data => ({ id: Math.random(), ...data }));
+    Wallet.getByAddress.mockReturnValue(null);
+    Wallet.update.mockReturnValue(null);
+
+    mockServer = {
+      transactions: jest.fn().mockReturnThis(),
+      forAccount: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      cursor: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      call: jest.fn(),
+    };
+
+    svc = new TransactionSyncService('https://horizon-testnet.stellar.org');
+    svc.server = mockServer;
+  });
+
+  it('fetches a single page when there is no next page', async () => {
+    const page1 = makeHorizonPage([makeTx('tx1', 'p1'), makeTx('tx2', 'p2')], false);
+    mockServer.call.mockResolvedValue(page1);
+
+    const txs = await svc._fetchHorizonTransactions(PUBLIC_KEY, 500, 'cursor0', 50);
+    expect(txs).toHaveLength(2);
+    // next() is called once to check for more records; it returns empty so loop stops
+    expect(page1.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows next-page cursor across multiple pages', async () => {
+    const page2 = makeHorizonPage([makeTx('tx3', 'p3'), makeTx('tx4', 'p4')], false);
+    const page1 = { records: [makeTx('tx1', 'p1'), makeTx('tx2', 'p2')], next: jest.fn().mockResolvedValue(page2) };
+    mockServer.call.mockResolvedValue(page1);
+
+    const txs = await svc._fetchHorizonTransactions(PUBLIC_KEY, 500, 'cursor0', 50);
+    expect(txs).toHaveLength(4);
+    expect(page1.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops at maxPages even if more pages exist', async () => {
+    // Each page has 2 records and always has a next page
+    const infinitePage = { records: [makeTx('txA', 'pA'), makeTx('txB', 'pB')] };
+    infinitePage.next = jest.fn().mockResolvedValue(infinitePage);
+    mockServer.call.mockResolvedValue(infinitePage);
+
+    const txs = await svc._fetchHorizonTransactions(PUBLIC_KEY, 10000, 'cursor0', 3);
+    expect(txs).toHaveLength(6); // 3 pages × 2 records
+    expect(infinitePage.next).toHaveBeenCalledTimes(2); // called after page 1 and 2
+  });
+
+  it('stops when maxTransactions is reached mid-page', async () => {
+    const page1 = makeHorizonPage([makeTx('tx1', 'p1'), makeTx('tx2', 'p2'), makeTx('tx3', 'p3')], false);
+    mockServer.call.mockResolvedValue(page1);
+
+    const txs = await svc._fetchHorizonTransactions(PUBLIC_KEY, 2, 'cursor0', 50);
+    expect(txs).toHaveLength(2);
+  });
+
+  it('syncWalletTransactions uses wallet last_cursor for incremental sync', async () => {
+    Wallet.getByAddress.mockReturnValue({ id: 'w1', last_cursor: 'stored_cursor' });
+    const page = makeHorizonPage([makeTx('tx1', 'p1')], false);
+    mockServer.call.mockResolvedValue(page);
+
+    await svc.syncWalletTransactions(PUBLIC_KEY);
+
+    expect(mockServer.cursor).toHaveBeenCalledWith('stored_cursor');
+  });
+
+  it('syncWalletTransactions uses cursor override when provided', async () => {
+    Wallet.getByAddress.mockReturnValue({ id: 'w1', last_cursor: 'stored_cursor' });
+    const page = makeHorizonPage([makeTx('tx1', 'p1')], false);
+    mockServer.call.mockResolvedValue(page);
+
+    await svc.syncWalletTransactions(PUBLIC_KEY, { cursor: 'override_cursor' });
+
+    expect(mockServer.cursor).toHaveBeenCalledWith('override_cursor');
+  });
+
+  it('syncWalletTransactions respects maxPages option', async () => {
+    const infinitePage = { records: [makeTx('txA', 'pA')] };
+    infinitePage.next = jest.fn().mockResolvedValue(infinitePage);
+    mockServer.call.mockResolvedValue(infinitePage);
+
+    const result = await svc.syncWalletTransactions(PUBLIC_KEY, { cursor: 'c0', maxPages: 2 });
+    expect(result.synced).toBe(2);
+  });
+
+  it('syncWalletTransactions updates wallet last_cursor after sync', async () => {
+    Wallet.getByAddress.mockReturnValue({ id: 'w1', last_cursor: null });
+    const page = makeHorizonPage([makeTx('tx1', 'token_abc')], false);
+    mockServer.call.mockResolvedValue(page);
+
+    const result = await svc.syncWalletTransactions(PUBLIC_KEY, { cursor: '' });
+    expect(Wallet.update).toHaveBeenCalledWith('w1', expect.objectContaining({ last_cursor: 'token_abc' }));
+    expect(result.lastCursor).toBe('token_abc');
+  });
+
+  it('syncWalletTransactions returns lastCursor: null when no transactions fetched', async () => {
+    Wallet.getByAddress.mockReturnValue(null);
+    mockServer.call.mockResolvedValue(makeHorizonPage([], false));
+
+    const result = await svc.syncWalletTransactions(PUBLIC_KEY);
+    expect(result.lastCursor).toBeNull();
+    expect(result.synced).toBe(0);
+  });
+
+  it('returns empty array and does not throw on 404 from Horizon', async () => {
+    mockServer.call.mockRejectedValue({ response: { status: 404 } });
+    const txs = await svc._fetchHorizonTransactions(PUBLIC_KEY, 500, undefined, 50);
+    expect(txs).toEqual([]);
+  });
+
+  it('supports legacy numeric argument to syncWalletTransactions', async () => {
+    Wallet.getByAddress.mockReturnValue(null);
+    const page = makeHorizonPage([makeTx('tx1', 'p1')], false);
+    mockServer.call.mockResolvedValue(page);
+
+    // Should not throw
+    const result = await svc.syncWalletTransactions(PUBLIC_KEY, 100);
+    expect(result.synced).toBe(1);
+  });
+});


### PR DESCRIPTION
closes #734

- _fetchHorizonTransactions follows next-page cursors until all pages fetched
- Add maxPages limit (default 50, configurable) to prevent runaway syncs
- Log progress per page for long-running syncs
- syncWalletTransactions accepts options: cursor override, maxPages
- Store lastCursor in result and persist to wallet after sync
- POST /transactions/sync accepts cursor and maxPages in request body
- Add 11 tests covering multi-page, maxPages cap, cursor override, incremental sync