### PR TITLE
feat: add rate limiting to auth endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,14 @@ MAX_DAILY_DONATION_PER_DONOR=0
 # Max requests per IP per time window.
 RATE_LIMIT=100
 
+# Auth token endpoint rate limit (requests per minute per IP)
+# Default: 10 requests per minute
+AUTH_TOKEN_RATE_LIMIT=10
+
+# Auth refresh endpoint rate limit (requests per minute per IP)
+# Default: 20 requests per minute
+AUTH_REFRESH_RATE_LIMIT=20
+
 
 # =====================================
 # Service Account — OPTIONAL

--- a/src/middleware/rateLimiter.js
+++ b/src/middleware/rateLimiter.js
@@ -231,10 +231,114 @@ function createRateLimiter(options = {}) {
   });
 }
 
+/**
+ * Auth Token Limiter
+ * Intent: Prevent brute force attacks on POST /auth/token endpoint
+ * Scope: POST /auth/token
+ * 
+ * Flow & Configuration:
+ * 1. Window: 60-second sliding window
+ * 2. Threshold: Max 10 requests per IP
+ * 3. Headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+ * 4. Exhaustion: Responds with HTTP 429 and Retry-After header
+ */
+const authTokenRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: parseInt(process.env.AUTH_TOKEN_RATE_LIMIT || '10'),
+  keyGenerator: (req) => req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: false,
+  handler: (req, res) => {
+    const retryAfter = req.rateLimit?.resetTime
+      ? Math.ceil((new Date(req.rateLimit.resetTime) - Date.now()) / 1000)
+      : 60;
+
+    AuditLogService.log({
+      category: AuditLogService.CATEGORY.RATE_LIMITING,
+      action: AuditLogService.ACTION.RATE_LIMIT_EXCEEDED,
+      severity: AuditLogService.SEVERITY.HIGH,
+      result: 'FAILURE',
+      requestId: req.id,
+      ipAddress: req.ip,
+      resource: req.path,
+      reason: 'Auth token rate limit exceeded',
+      details: {
+        limit: parseInt(process.env.AUTH_TOKEN_RATE_LIMIT || '10'),
+        window: '60s',
+        resetTime: req.rateLimit.resetTime
+      }
+    }).catch(err => console.error('Audit log failed:', err));
+
+    res.set('Retry-After', String(retryAfter));
+    res.status(429).json({
+      success: false,
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Too many authentication requests from this IP. Please try again later.',
+        retryAfter
+      }
+    });
+  }
+});
+
+/**
+ * Auth Refresh Limiter
+ * Intent: Prevent refresh token exhaustion attacks on POST /auth/refresh
+ * Scope: POST /auth/refresh
+ * 
+ * Flow & Configuration:
+ * 1. Window: 60-second sliding window
+ * 2. Threshold: Max 20 requests per IP (higher than token endpoint)
+ * 3. Headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+ * 4. Exhaustion: Responds with HTTP 429 and Retry-After header
+ */
+const authRefreshRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: parseInt(process.env.AUTH_REFRESH_RATE_LIMIT || '20'),
+  keyGenerator: (req) => req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: false,
+  handler: (req, res) => {
+    const retryAfter = req.rateLimit?.resetTime
+      ? Math.ceil((new Date(req.rateLimit.resetTime) - Date.now()) / 1000)
+      : 60;
+
+    AuditLogService.log({
+      category: AuditLogService.CATEGORY.RATE_LIMITING,
+      action: AuditLogService.ACTION.RATE_LIMIT_EXCEEDED,
+      severity: AuditLogService.SEVERITY.HIGH,
+      result: 'FAILURE',
+      requestId: req.id,
+      ipAddress: req.ip,
+      resource: req.path,
+      reason: 'Auth refresh rate limit exceeded',
+      details: {
+        limit: parseInt(process.env.AUTH_REFRESH_RATE_LIMIT || '20'),
+        window: '60s',
+        resetTime: req.rateLimit.resetTime
+      }
+    }).catch(err => console.error('Audit log failed:', err));
+
+    res.set('Retry-After', String(retryAfter));
+    res.status(429).json({
+      success: false,
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Too many refresh requests from this IP. Please try again later.',
+        retryAfter
+      }
+    });
+  }
+});
+
 module.exports = {
   donationRateLimiter,
   verificationRateLimiter,
   batchRateLimiter,
   bulkImportRateLimiter,
+  authTokenRateLimiter,
+  authRefreshRateLimiter,
   createRateLimiter,
 };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -20,6 +20,7 @@ const { getStellarService } = require('../config/stellar');
 const log = require('../utils/log');
 const asyncHandler = require('../utils/asyncHandler');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
+const { authTokenRateLimiter, authRefreshRateLimiter } = require('../middleware/rateLimiter');
 
 const stellarService = getStellarService();
 const sep10Config = config.sep10 || {};
@@ -70,7 +71,7 @@ router.post('/token/apikey', requireApiKey, payloadSizeLimiter(ENDPOINT_LIMITS.a
  * Rotate a refresh token. Returns a new access token + refresh token.
  * Body: { refreshToken: string }
  */
-router.post('/refresh', payloadSizeLimiter(ENDPOINT_LIMITS.auth), asyncHandler(async (req, res) => {
+router.post('/refresh', authRefreshRateLimiter, payloadSizeLimiter(ENDPOINT_LIMITS.auth), asyncHandler(async (req, res) => {
   const { refreshToken } = req.body || {};
 
   if (!refreshToken || typeof refreshToken !== 'string') {
@@ -146,7 +147,7 @@ router.get('/challenge', asyncHandler(async (req, res) => {
  * Verifies a signed SEP-0010 challenge and returns a JWT access token.
  * Body: { transaction: '<signed_tx_xdr>' }
  */
-router.post('/token', payloadSizeLimiter(ENDPOINT_LIMITS.auth), asyncHandler(async (req, res) => {
+router.post('/token', authTokenRateLimiter, payloadSizeLimiter(ENDPOINT_LIMITS.auth), asyncHandler(async (req, res) => {
   if (!sep10Service) {
     return res.status(501).json({
       success: false,


### PR DESCRIPTION
- Add authTokenRateLimiter: 10 req/min per IP for POST /auth/token
- Add authRefreshRateLimiter: 20 req/min per IP for POST /auth/refresh
- Include rate limit headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
- Return 429 with Retry-After header when limit exceeded
- Configurable via AUTH_TOKEN_RATE_LIMIT and AUTH_REFRESH_RATE_LIMIT env vars
- Audit logging for rate limit violations
- Prevents brute force attacks and token exhaustion

Closes #730
closes #733