### PR TITLE
fix/feat: Frequency validation, idempotency enforcement, multi-asset fee analytics, and HTTP caching headers                                                                                                                                                                                                       

### DIFF
--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -493,6 +493,23 @@ router.get('/:id', checkPermission(PERMISSIONS.DONATIONS_READ), donationIdParamS
       req.markLifecycleStage(LIFECYCLE_STAGES.PROCESSED);
     }
 
+    // ETag and conditional request support (#751)
+    const lastModifiedDate = new Date(transaction.statusUpdatedAt || transaction.timestamp);
+    const etag = `"${transaction.id}-${lastModifiedDate.getTime()}"`;
+    res.setHeader('ETag', etag);
+    res.setHeader('Last-Modified', lastModifiedDate.toUTCString());
+    res.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
+
+    if (req.headers['if-none-match'] === etag) {
+      return res.status(304).end();
+    }
+    if (req.headers['if-modified-since']) {
+      const ifModifiedSince = new Date(req.headers['if-modified-since']);
+      if (!isNaN(ifModifiedSince.getTime()) && lastModifiedDate <= ifModifiedSince) {
+        return res.status(304).end();
+      }
+    }
+
     // HTTP/2 server push + Link header for related resources
     const { pushDonationRelated } = require('../utils/pushHelper');
     pushDonationRelated(req, res, transaction);

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -405,6 +405,60 @@ router.get('/:id/certificate', checkPermission(PERMISSIONS.DONATIONS_READ), dona
 });
 
 /**
+ * POST /donations
+ * Create a new donation.
+ * Requires Idempotency-Key header (UUID v4) to prevent duplicate donations from network retries.
+ */
+router.post('/', donationRateLimiter, checkPermission(PERMISSIONS.DONATIONS_CREATE), requireIdempotency, payloadSizeLimiter(ENDPOINT_LIMITS.singleDonation), asyncHandler(async (req, res, next) => {
+  try {
+    const { senderId, receiverId, amount, memo } = req.body;
+
+    if (!senderId || !receiverId || !amount) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required fields: senderId, receiverId, amount'
+      });
+    }
+
+    const amountValidation = validateFloat(amount);
+    if (!amountValidation.valid) {
+      return res.status(400).json({ success: false, error: `Invalid amount: ${amountValidation.error}` });
+    }
+
+    const result = await donationService.sendCustodialDonation({
+      senderId,
+      receiverId,
+      amount: amountValidation.value,
+      memo: memo || null,
+      idempotencyKey: req.idempotency && req.idempotency.key,
+      requestId: req.id,
+    });
+
+    const response = { success: true, data: result };
+    await storeIdempotencyResponse(req, response);
+
+    return res.status(201).json(response);
+  } catch (error) {
+    next(error);
+  }
+}));
+
+/**
+ * GET /donations
+ * List all donations with optional pagination.
+ */
+router.get('/', checkPermission(PERMISSIONS.DONATIONS_READ), asyncHandler(async (req, res, next) => {
+  try {
+    const pagination = parseCursorPaginationQuery(req.query);
+    const result = donationService.getPaginatedDonations(pagination);
+    res.setHeader('X-Total-Count', String(result.totalCount));
+    res.json({ success: true, data: result.data, count: result.data.length, meta: result.meta });
+  } catch (error) {
+    next(error);
+  }
+}));
+
+/**
  * GET /donations/recent
  * Get recent donations, ordered by creation date descending.
  * Must be registered before /:id to prevent Express matching "recent" as an id.

--- a/src/routes/stream.js
+++ b/src/routes/stream.js
@@ -132,6 +132,19 @@ const streamCreateSchema = validateSchema({
             : `frequency must be one of: ${VALID_FREQUENCIES.join(', ')}`;
         },
       },
+      customIntervalDays: {
+        type: 'number',
+        required: false,
+        min: 1,
+      },
+    },
+    validate: (body) => {
+      if (body.frequency && body.frequency.toLowerCase() === 'custom') {
+        if (!body.customIntervalDays || !Number.isInteger(Number(body.customIntervalDays)) || Number(body.customIntervalDays) < 1) {
+          return 'customIntervalDays is required and must be a positive integer when frequency is "custom"';
+        }
+      }
+      return null;
     },
   },
 });
@@ -150,7 +163,7 @@ const streamScheduleIdSchema = validateSchema({
  */
 router.post('/create', payloadSizeLimiter(ENDPOINT_LIMITS.stream), requestTimeout(TIMEOUTS.stream), checkPermission(PERMISSIONS.STREAM_CREATE), streamCreateSchema, asyncHandler(async (req, res, next) => {
   try {
-    const { donorPublicKey, recipientPublicKey, amount, frequency } = req.body;
+    const { donorPublicKey, recipientPublicKey, amount, frequency, customIntervalDays } = req.body;
 
     // Validate required fields
     const requiredValidation = validateRequiredFields(
@@ -181,6 +194,17 @@ router.post('/create', payloadSizeLimiter(ENDPOINT_LIMITS.stream), requestTimeou
         success: false,
         error: frequencyValidation.error
       });
+    }
+
+    // Validate customIntervalDays when frequency is 'custom'
+    const normalizedFrequency = frequency.toLowerCase();
+    if (normalizedFrequency === 'custom') {
+      if (!customIntervalDays || !Number.isInteger(Number(customIntervalDays)) || Number(customIntervalDays) < 1) {
+        return res.status(400).json({
+          success: false,
+          error: 'customIntervalDays is required and must be a positive integer when frequency is "custom"'
+        });
+      }
     }
 
     // Check if donor exists
@@ -231,6 +255,9 @@ router.post('/create', payloadSizeLimiter(ENDPOINT_LIMITS.stream), requestTimeou
       case 'monthly':
         nextExecutionDate.setMonth(nextExecutionDate.getMonth() + 1);
         break;
+      case 'custom':
+        nextExecutionDate.setDate(nextExecutionDate.getDate() + parseInt(customIntervalDays, 10));
+        break;
     }
 
     // Insert recurring donation schedule
@@ -269,6 +296,7 @@ router.post('/create', payloadSizeLimiter(ENDPOINT_LIMITS.stream), requestTimeou
         recipient: schedule.recipientPublicKey,
         amount: schedule.amount,
         frequency: schedule.frequency,
+        ...(schedule.frequency === 'custom' && { customIntervalDays: parseInt(customIntervalDays, 10) }),
         nextExecution: schedule.nextExecutionDate,
         status: schedule.status,
         executionCount: schedule.executionCount

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -332,6 +332,24 @@ router.get('/:id', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, ca
     if (!wallet) {
       return res.status(404).json({ success: false, error: 'Wallet not found' });
     }
+
+    // ETag and conditional request support (#751)
+    const lastModifiedDate = new Date(wallet.updatedAt || wallet.createdAt);
+    const etag = `"${wallet.id}-${lastModifiedDate.getTime()}"`;
+    res.setHeader('ETag', etag);
+    res.setHeader('Last-Modified', lastModifiedDate.toUTCString());
+    res.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
+
+    if (req.headers['if-none-match'] === etag) {
+      return res.status(304).end();
+    }
+    if (req.headers['if-modified-since']) {
+      const ifModifiedSince = new Date(req.headers['if-modified-since']);
+      if (!isNaN(ifModifiedSince.getTime()) && lastModifiedDate <= ifModifiedSince) {
+        return res.status(304).end();
+      }
+    }
+
     const stellarSvc = getStellarService();
     const homeDomain = await stellarSvc.getHomeDomain(wallet.address || wallet.publicKey).catch(() => null);
     res.json({ success: true, data: { ...wallet, homeDomain: homeDomain || null } });

--- a/src/services/IdempotencyService.js
+++ b/src/services/IdempotencyService.js
@@ -115,25 +115,12 @@ class IdempotencyService {
       };
     }
 
-    if (key.length < 16) {
+    // Validate UUID v4 format
+    const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!uuidV4Regex.test(key)) {
       return {
         valid: false,
-        error: 'Idempotency key must be at least 16 characters long'
-      };
-    }
-
-    if (key.length > 255) {
-      return {
-        valid: false,
-        error: 'Idempotency key must not exceed 255 characters'
-      };
-    }
-
-    // Check for valid characters (alphanumeric, hyphens, underscores)
-    if (!/^[a-zA-Z0-9_-]+$/.test(key)) {
-      return {
-        valid: false,
-        error: 'Idempotency key must contain only alphanumeric characters, hyphens, and underscores'
+        error: 'Idempotency-Key must be a valid UUID v4 (e.g. 550e8400-e29b-41d4-a716-446655440000)'
       };
     }
 

--- a/src/services/StatsService.js
+++ b/src/services/StatsService.js
@@ -277,55 +277,67 @@ class StatsService {
   }
 
   /**
-   * Get analytics fee summary
+   * Get analytics fee summary broken down by asset type.
+   * Fees are grouped per asset so mixed-currency totals are not meaninglessly summed.
+   * A `totalInXLM` field provides a unified view using stored exchange rates.
    * @param {Date} startDate - Start date for aggregation
    * @param {Date} endDate - End date for aggregation
-   * @returns {Object} Analytics fee summary
+   * @returns {Object} Analytics fee summary with per-asset breakdown
    */
   static getAnalyticsFeeStats(startDate, endDate) {
     const transactions = Transaction.getByDateRange(startDate, endDate);
-    
-    const feeStats = {
-      totalFeesCalculated: 0,
-      totalDonationVolume: 0,
-      transactionCount: transactions.length,
-      averageFeePerTransaction: 0,
-      feesByRecipient: {},
-      dateRange: {
-        start: startDate.toISOString(),
-        end: endDate.toISOString()
-      }
-    };
 
-    if (transactions.length === 0) {
-      return feeStats;
-    }
+    const byAsset = {};
 
     transactions.forEach(tx => {
+      const asset = tx.asset || tx.assetCode || 'XLM';
       const amount = parseFloat(tx.amount) || 0;
       const fee = parseFloat(tx.analyticsFee) || 0;
-      
-      feeStats.totalFeesCalculated += fee;
-      feeStats.totalDonationVolume += amount;
+      const xlmRate = parseFloat(tx.xlmRate) || (asset === 'XLM' ? 1 : 0);
 
-      const recipient = tx.recipient || 'Unknown';
-      if (!feeStats.feesByRecipient[recipient]) {
-        feeStats.feesByRecipient[recipient] = {
+      if (!byAsset[asset]) {
+        byAsset[asset] = {
+          asset,
           totalFees: 0,
-          donationCount: 0,
-          totalVolume: 0
+          totalVolume: 0,
+          transactionCount: 0,
+          totalFeesInXLM: 0,
         };
       }
-      
-      feeStats.feesByRecipient[recipient].totalFees += fee;
-      feeStats.feesByRecipient[recipient].donationCount += 1;
-      feeStats.feesByRecipient[recipient].totalVolume += amount;
+
+      byAsset[asset].totalFees += fee;
+      byAsset[asset].totalVolume += amount;
+      byAsset[asset].transactionCount += 1;
+      byAsset[asset].totalFeesInXLM += asset === 'XLM' ? fee : fee * xlmRate;
     });
 
-    feeStats.averageFeePerTransaction = feeStats.totalFeesCalculated / transactions.length;
-    feeStats.effectiveFeePercentage = (feeStats.totalFeesCalculated / feeStats.totalDonationVolume) * 100;
+    const feesByAsset = Object.values(byAsset).map(a => ({
+      ...a,
+      totalFees: +a.totalFees.toFixed(7),
+      totalVolume: +a.totalVolume.toFixed(7),
+      totalFeesInXLM: +a.totalFeesInXLM.toFixed(7),
+      effectiveFeePercentage: a.totalVolume > 0
+        ? +((a.totalFees / a.totalVolume) * 100).toFixed(4)
+        : 0,
+    }));
 
-    return feeStats;
+    const totalInXLM = +feesByAsset.reduce((s, a) => s + a.totalFeesInXLM, 0).toFixed(7);
+    const totalTransactions = transactions.length;
+    const totalFeesXLM = feesByAsset.find(a => a.asset === 'XLM');
+
+    return {
+      feesByAsset,
+      totalInXLM,
+      transactionCount: totalTransactions,
+      averageFeePerTransactionXLM: totalTransactions > 0
+        ? +(totalInXLM / totalTransactions).toFixed(7)
+        : 0,
+      dateRange: {
+        start: startDate.toISOString(),
+        end: endDate.toISOString(),
+      },
+      note: 'totalInXLM uses exchange rates stored at transaction time; non-XLM assets with no rate are excluded from totalInXLM',
+    };
   }
   /**
    * Get wallet donation analytics


### PR DESCRIPTION

  Closes #748                                                                                                                                             
  Closes #749                                                                                                                                             
  Closes #750                                                                                                                                             
  Closes #751                                                                                                                                             
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Summary                                                                                                                                              
                                                                                                                                                          
  This PR addresses four issues across validation, reliability, analytics correctness, and HTTP caching performance.                                      
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  ### #748 — [BUG] `POST /stream/create` does not validate `frequency` against supported values                                                           
                                                                                                                                                          
  **File:** `src/routes/stream.js`                                                                                                                        
                                                                                                                                                          
  - Added `customIntervalDays` field to the `streamCreateSchema` with a cross-field validation rule: when `frequency` is `"custom"`, `customIntervalDays` 
  is required and must be a positive integer.                                                                                                             
  - Added an explicit `case 'custom'` branch to the `nextExecutionDate` switch statement, advancing the date by `customIntervalDays` days.                
  - The response payload now includes `customIntervalDays` when the frequency is `custom`.                                                                
  - Invalid frequency values (e.g. `"hourly"`, `"yearly"`) continue to return `400` with a clear error listing valid options: `daily`, `weekly`,          
  `monthly`, `custom`.                                                                                                                                    
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### #749 — [IMPROVEMENT] Add request deduplication for `POST /donations`                                                                                
                                                                                                                                                          
  **Files:** `src/routes/donation.js`, `src/services/IdempotencyService.js`                                                                               
                                                                                                                                                          
  - Added `POST /donations` route (previously missing) with the `requireIdempotency` middleware applied, making the `Idempotency-Key` header mandatory for
  all donation creation requests.                                                                                                                         
  - Added `GET /donations` route for listing all donations with cursor-based pagination.                                                                  
  - Updated `IdempotencyService.validateKey` to enforce strict **UUID v4** format (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`). Requests with a missing or    
  malformed key return `400` with instructions. Duplicate requests with the same valid key return the original cached response (stored for 24 hours via   
  the existing `IdempotencyService`).                                                                                                                     
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### #750 — [BUG] `GET /stats/analytics-fees` returns incorrect fee calculations for multiple asset types                                                
                                                                                                                                                          
  **File:** `src/services/StatsService.js`                                                                                                                
                                                                                                                                                          
  - Rewrote `getAnalyticsFeeStats` to group fees by asset type instead of summing across all currencies into a single meaningless total.                  
  - Response now includes a `feesByAsset` array where each entry contains: `asset`, `totalFees`, `totalVolume`, `transactionCount`, `totalFeesInXLM`, and 
  `effectiveFeePercentage`.                                                                                                                               
  - Added a top-level `totalInXLM` field that sums all asset fees converted to XLM using the exchange rate stored at transaction time. Assets with no     
  stored rate are excluded from this total and a `note` field explains this.                                                                              
  - Added `averageFeePerTransactionXLM` for a unified cross-asset average.                                                                                
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### #751 — [IMPROVEMENT] Add `ETag` and `Last-Modified` headers to GET endpoints                                                                        
                                                                                                                                                          
  **Files:** `src/routes/donation.js`, `src/routes/wallet.js`                                                                                             
                                                                                                                                                          
  - `GET /donations/:id`: Sets `ETag` (derived from `statusUpdatedAt` or `timestamp`), `Last-Modified`, and `Cache-Control: private, max-age=0,           
  must-revalidate`. Returns `304 Not Modified` when the client sends a matching `If-None-Match` or a valid `If-Modified-Since` header.                    
  - `GET /wallets/:id`: Same pattern, using the wallet's `updatedAt` or `createdAt` timestamp for the ETag and Last-Modified values.                      
  - No changes to response body or existing middleware — purely additive headers.                                                                         
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Files Changed                                                                                                                                        
                                                                                                                                                          
  | File | Issue |                                                                                                                                        
  |---|---|                                                                                                                                               
  | `src/routes/stream.js` | #748 |                                                                                                                       
  | `src/routes/donation.js` | #749, #751 |                                                                                                               
  | `src/services/IdempotencyService.js` | #749 |                                                                                                         
  | `src/services/StatsService.js` | #750 |                                                                                                               
  | `src/routes/wallet.js` | #751 |                                                                                                                       
                                   