### PR TITLE
feat: pre-submission balance check with 422 on insufficient funds

### DIFF
--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -184,6 +184,7 @@ const { parseCursorPaginationQuery } = require('../utils/pagination');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
 const { parseAssetInput } = require('../utils/stellarAsset');
 
+const asyncHandler = require('../utils/asyncHandler');
 const { getStellarService } = require('../config/stellar');
 const DonationService = require('../services/DonationService');
 const { calculateCostBreakdown } = require('../utils/costBreakdown');
@@ -193,7 +194,7 @@ const Transaction = require('./models/transaction');
 const donationValidator = require('../utils/donationValidator');
 const { buildErrorResponse } = require('../utils/validationErrorFormatter');
 
-const donationService = new DonationService();
+const donationService = new DonationService(getStellarService());
 
 const donationIdParamSchema = validateSchema({
   params: {

--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -18,7 +18,8 @@ const { calculateAnalyticsFee } = require('../utils/feeCalculator');
 const { sanitizeIdentifier, sanitizeMemo } = require('../utils/sanitizer');
 const { generatePseudonymousId } = require('../utils/anonymization');
 const { TRANSACTION_STATES } = require('../utils/transactionStateMachine');
-const { ValidationError, NotFoundError, ERROR_CODES } = require('../utils/errors');
+const { ValidationError, NotFoundError, BusinessLogicError, ERROR_CODES } = require('../utils/errors');
+const { withTimeout } = require('../utils/timeoutHandler');
 const { PREDEFINED_TAGS } = require('../constants/tags');
 const { paginateCollection } = require('../utils/pagination');
 const { checkConfirmations } = require('../utils/confirmationChecker');
@@ -141,6 +142,28 @@ class DonationService {
 
     // Decrypt sender's secret key
     const secret = encryption.decrypt(sender.encryptedSecret);
+
+    // Check sender balance before submitting (max 2s to avoid slowing donation flow)
+    try {
+      const { balance } = await withTimeout(
+        this.stellarService.getBalance(sender.publicKey),
+        2000,
+        'balanceCheck'
+      );
+      const available = parseFloat(balance);
+      const reserve = parseFloat(process.env.STELLAR_BASE_RESERVE || '1');
+      const required = parseFloat(amount) + reserve;
+      if (available < required) {
+        throw new BusinessLogicError(
+          ERROR_CODES.INSUFFICIENT_BALANCE,
+          `Insufficient balance. Required: ${required.toFixed(7)} XLM, Available: ${available.toFixed(7)} XLM`
+        );
+      }
+    } catch (err) {
+      if (err instanceof BusinessLogicError) throw err;
+      // Balance check timed out or failed — log and proceed optimistically
+      log.warn('DONATION_SERVICE', 'Balance check skipped', { requestId, error: err.message });
+    }
 
     log.debug('DONATION_SERVICE', 'Initiating Stellar transaction', {
       requestId

--- a/tests/donations/insufficient-balance.test.js
+++ b/tests/donations/insufficient-balance.test.js
@@ -1,0 +1,142 @@
+/**
+ * Insufficient Balance Tests
+ * Verifies that a 422 is returned when the sender lacks sufficient funds.
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-key-1';
+
+const request = require('supertest');
+const express = require('express');
+const donationRouter = require('../../src/routes/donation');
+const Database = require('../../src/utils/database');
+const Transaction = require('../../src/routes/models/transaction');
+const { getStellarService } = require('../../src/config/stellar');
+const { attachUserRole } = require('../../src/middleware/rbac');
+const { errorHandler } = require('../../src/middleware/errorHandler');
+const { resetMockStellarService } = require('../helpers/testIsolation');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(attachUserRole());
+  app.use('/donations', donationRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('Insufficient Balance Check', () => {
+  let app;
+  let stellarService;
+  let senderId;
+  let receiverId;
+  let senderPublicKey;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    stellarService = getStellarService();
+
+    // Ensure velocity tables exist (may not be in test DB)
+    await Database.run(`CREATE TABLE IF NOT EXISTS donation_velocity (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      donorId INTEGER NOT NULL,
+      recipientId INTEGER NOT NULL,
+      windowStart DATETIME NOT NULL,
+      totalAmount REAL NOT NULL DEFAULT 0,
+      count INTEGER NOT NULL DEFAULT 0,
+      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+    await Database.run(`CREATE TABLE IF NOT EXISTS recipient_velocity_limits (
+      recipientId INTEGER PRIMARY KEY,
+      maxAmount REAL,
+      maxCount INTEGER,
+      windowType TEXT NOT NULL DEFAULT 'daily',
+      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+
+    // Create Stellar wallets in MockStellarService
+    const senderWallet = await stellarService.createWallet();
+    const receiverWallet = await stellarService.createWallet();
+    await stellarService.fundTestnetWallet(receiverWallet.publicKey);
+
+    senderPublicKey = senderWallet.publicKey;
+
+    // Encrypt secrets for DB storage
+    const encryption = require('../../src/utils/encryption');
+    const encSenderSecret = encryption.encrypt(senderWallet.secretKey);
+    const encReceiverSecret = encryption.encrypt(receiverWallet.secretKey);
+
+    // Insert users into DB
+    const senderRow = await Database.run(
+      'INSERT INTO users (publicKey, encryptedSecret) VALUES (?, ?)',
+      [senderWallet.publicKey, encSenderSecret]
+    );
+    const receiverRow = await Database.run(
+      'INSERT INTO users (publicKey, encryptedSecret) VALUES (?, ?)',
+      [receiverWallet.publicKey, encReceiverSecret]
+    );
+
+    senderId = senderRow.id;
+    receiverId = receiverRow.id;
+
+    // Give sender 5 XLM — not enough for 10 XLM donation + 1 XLM reserve
+    const senderWalletObj = stellarService.wallets.get(senderWallet.publicKey);
+    senderWalletObj.assetBalances.native = '5.0000000';
+    senderWalletObj.balance = '5.0000000';
+  });
+
+  afterEach(() => {
+    Transaction._clearAllData();
+  });
+
+  afterAll(async () => {
+    if (senderId) await Database.run('DELETE FROM users WHERE id = ?', [senderId]);
+    if (receiverId) await Database.run('DELETE FROM users WHERE id = ?', [receiverId]);
+    await Database.run('DELETE FROM transactions WHERE senderId = ?', [senderId]);
+    resetMockStellarService(stellarService);
+  });
+
+  test('returns 422 with INSUFFICIENT_BALANCE when sender cannot cover amount + reserve', async () => {
+    const response = await request(app)
+      .post('/donations')
+      .set('X-API-Key', 'test-key-1')
+      .set('X-Idempotency-Key', 'a1b2c3d4-e5f6-4a7b-8c9d-000000000001')
+      .send({ senderId, receiverId, amount: 10 });
+
+    expect(response.status).toBe(422);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.code).toBe('INSUFFICIENT_BALANCE');
+    expect(response.body.error.message).toMatch(/Insufficient balance/);
+    expect(response.body.error.message).toMatch(/Required:/);
+    expect(response.body.error.message).toMatch(/Available:/);
+  });
+
+  test('error message includes correct XLM amounts', async () => {
+    const response = await request(app)
+      .post('/donations')
+      .set('X-API-Key', 'test-key-1')
+      .set('X-Idempotency-Key', 'a1b2c3d4-e5f6-4a7b-8c9d-000000000002')
+      .send({ senderId, receiverId, amount: 10 });
+
+    expect(response.status).toBe(422);
+    // amount(10) + reserve(1) = 11 required; available = 5
+    expect(response.body.error.message).toContain('11.0000000 XLM');
+    expect(response.body.error.message).toContain('5.0000000 XLM');
+  });
+
+  test('succeeds when sender has sufficient balance', async () => {
+    // Bump sender balance to 20 XLM (covers 10 donation + 1 reserve)
+    const senderWalletObj = stellarService.wallets.get(senderPublicKey);
+    senderWalletObj.assetBalances.native = '20.0000000';
+    senderWalletObj.balance = '20.0000000';
+
+    const response = await request(app)
+      .post('/donations')
+      .set('X-API-Key', 'test-key-1')
+      .set('X-Idempotency-Key', 'a1b2c3d4-e5f6-4a7b-8c9d-000000000003')
+      .send({ senderId, receiverId, amount: 10 });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #752

---

## Summary

Before submitting a Stellar transaction, check the sender's balance and return a clear 422 error if funds are insufficient.

## Changes

- **`src/services/DonationService.js`**: Added balance check before `stellarService.sendDonation()` with a 2s timeout. Throws `BusinessLogicError` (422) with message `Insufficient balance. Required: X XLM, Available: Y XLM` when balance < amount + reserve.
- **`src/routes/donation.js`**: Fixed missing `asyncHandler` import and passed `getStellarService()` to `DonationService` constructor (pre-existing bugs).
- **`tests/donations/insufficient-balance.test.js`**: 3 tests covering the 422 error, correct XLM values in message, and success when balance is sufficient.

## Acceptance Criteria

- ✅ Balance checked before Stellar transaction submission
- ✅ Returns 422 with `Insufficient balance. Required: X XLM, Available: Y XLM`
- ✅ Accounts for Stellar minimum reserve (1 XLM, configurable via `STELLAR_BASE_RESERVE`)
- ✅ Balance check has 2s timeout (fails open to avoid blocking donations)
- ✅ Tests verify the insufficient balance error