### PR TITLE
feat: X-Request-ID response header — validation, docs, and tests

### DIFF
--- a/src/config/openapi.js
+++ b/src/config/openapi.js
@@ -34,6 +34,15 @@ const options = {
           description: 'API key passed in the x-api-key header. Obtain via `npm run keys:create`.',
         },
       },
+      headers: {
+        XRequestID: {
+          description:
+            'Unique identifier for the request. Include this in support requests to correlate client activity with server logs. ' +
+            'If you supply a valid UUID v4 in the `X-Request-ID` request header the server echoes it back; ' +
+            'otherwise the server generates one automatically.',
+          schema: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+        },
+      },
       schemas: {
         Error: {
           type: 'object',

--- a/src/middleware/requestId.js
+++ b/src/middleware/requestId.js
@@ -13,8 +13,11 @@ try {
 const log = require('../utils/log');
 const correlationUtils = require("../utils/correlation");
 
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 const requestIdMiddleware = (req, res, next) => {
-  const requestId = req.get('X-Request-ID') || uuidv4();
+  const clientId = req.get('X-Request-ID');
+  const requestId = (clientId && UUID_V4_RE.test(clientId)) ? clientId : uuidv4();
 
   req.id = requestId;
   res.setHeader('X-Request-ID', requestId);

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -44,6 +44,9 @@
  *     responses:
  *       201:
  *         description: Donation created successfully
+ *         headers:
+ *           X-Request-ID:
+ *             $ref: '#/components/headers/XRequestID'
  *       400:
  *         description: Validation error
  *         content:

--- a/tests/middleware/requestId-correlation.test.js
+++ b/tests/middleware/requestId-correlation.test.js
@@ -32,6 +32,32 @@ describe('Request ID Middleware with Correlation Support', () => {
     jest.clearAllMocks();
   });
 
+  describe('X-Request-ID Response Header', () => {
+    test('should include X-Request-ID in response when not provided by client', async () => {
+      const response = await request(app).get('/test').expect(200);
+      expect(response.headers['x-request-id']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+
+    test('should echo valid UUID v4 X-Request-ID from client', async () => {
+      const clientId = '550e8400-e29b-41d4-a716-446655440000';
+      const response = await request(app).get('/test').set('X-Request-ID', clientId).expect(200);
+      expect(response.headers['x-request-id']).toBe(clientId);
+    });
+
+    test('should ignore invalid X-Request-ID and generate a new UUID v4', async () => {
+      const response = await request(app).get('/test').set('X-Request-ID', 'not-a-uuid').expect(200);
+      expect(response.headers['x-request-id']).not.toBe('not-a-uuid');
+      expect(response.headers['x-request-id']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+
+    test('should include X-Request-ID on error responses', async () => {
+      app.get('/error-test', (req, res, next) => next(new Error('boom')));
+      app.use((err, req, res, next) => { void next; res.status(500).json({ error: err.message }); });
+      const response = await request(app).get('/error-test');
+      expect(response.headers['x-request-id']).toBeDefined();
+    });
+  });
+
   describe('Basic Request ID Functionality', () => {
     test('should generate request ID when not provided in headers', async () => {
       const response = await request(app)
@@ -43,7 +69,7 @@ describe('Request ID Middleware with Correlation Support', () => {
     });
 
     test('should use existing request ID from headers', async () => {
-      const existingRequestId = 'existing-request-123';
+      const existingRequestId = '550e8400-e29b-41d4-a716-446655440001';
       
       const response = await request(app)
         .get('/test')
@@ -103,7 +129,7 @@ describe('Request ID Middleware with Correlation Support', () => {
 
     test('should maintain trace ID when correlation ID is provided', async () => {
       const headers = {
-        'X-Request-ID': 'req-123',
+        'X-Request-ID': '550e8400-e29b-41d4-a716-446655440002',
         'X-Correlation-ID': 'corr-456',
         'X-Trace-ID': 'trace-789'
       };
@@ -115,7 +141,7 @@ describe('Request ID Middleware with Correlation Support', () => {
       
       const { correlationContext } = response.body;
       
-      expect(correlationContext.requestId).toBe('req-123');
+      expect(correlationContext.requestId).toBe('550e8400-e29b-41d4-a716-446655440002');
       expect(correlationContext.correlationId).toBe('corr-456');
       expect(correlationContext.traceId).toBe('trace-789');
       expect(response.body.headers['X-Trace-ID']).toBe('trace-789');


### PR DESCRIPTION
Closes #753

---

## Summary

Completes the X-Request-ID acceptance criteria. The middleware already set the header and used the client value; this PR adds the missing pieces.

## Changes

- **`src/middleware/requestId.js`**: Validate client-provided `X-Request-ID` as UUID v4. Invalid values are silently replaced with a server-generated UUID (fail-open — never blocks a request).
- **`src/config/openapi.js`**: Added `XRequestID` header component to OpenAPI spec with description explaining how to use it for support correlation.
- **`src/routes/donation.js`**: Referenced `XRequestID` header on `POST /donations` 201 response in JSDoc.
- **`tests/middleware/requestId-correlation.test.js`**: Added 4 new tests; updated 2 existing tests that used non-UUID request IDs (now correctly rejected by validation).

## Acceptance Criteria

- ✅ All responses include `X-Request-ID` header (already implemented, verified by tests)
- ✅ Client-provided `X-Request-ID` is used **and validated** (UUID v4 only)
- ✅ Request ID appears in all log entries (already implemented via `log.setContext`)
- ✅ API documentation explains how to use `X-Request-ID` for support requests
- ✅ Tests verify the header is present in all responses (including error responses)