### PR TITLE
fix: filter GET /stream/schedules by requesting user

### DIFF
--- a/src/middleware/rbac.js
+++ b/src/middleware/rbac.js
@@ -19,6 +19,7 @@ const perKeyRateLimit = require('./perKeyRateLimit');
 const { checkRateLimit, buildRateLimitHeaders, DEFAULT_RATE_LIMIT, DEFAULT_WINDOW_SECONDS } = require('./perKeyRateLimit');
 const crypto = require('crypto');
 const { tierMeetsMinimum } = require('../config/permissionMatrix');
+const { verifyAccessToken } = require('../services/JwtService');
 
 /**
  * Role-Based Access Control (RBAC) Configuration

--- a/src/routes/stream.js
+++ b/src/routes/stream.js
@@ -101,6 +101,7 @@ const SseManager = require('../services/SseManager');
 const donationEvents = require('../events/donationEvents');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
 const { requestTimeout, TIMEOUTS } = require('../middleware/requestTimeout');
+const asyncHandler = require('../utils/asyncHandler');
 
 const streamCreateSchema = validateSchema({
   body: {
@@ -309,12 +310,26 @@ router.post('/create', payloadSizeLimiter(ENDPOINT_LIMITS.stream), requestTimeou
 
 /**
  * GET /stream/schedules
- * Get all recurring donation schedules.
+ * Get recurring donation schedules.
+ * Regular users see only their own schedules (where they are the donor).
+ * Admin users can see all schedules by passing ?all=true.
  * Supports optional ?status= filter (e.g. ?status=paused).
  */
 router.get('/schedules', checkPermission(PERMISSIONS.STREAM_READ), asyncHandler(async (req, res, next) => {
   try {
-    const { status } = req.query;
+    const { status, all } = req.query;
+    const isAdmin = req.user?.role === 'admin' || req.apiKey?.role === 'admin';
+    const userPublicKey = req.user?.subject || req.apiKey?.subject;
+
+    // Non-admins must be filtered to their own schedules
+    if (!isAdmin && !userPublicKey) {
+      return res.status(403).json({
+        success: false,
+        error: { code: 'FORBIDDEN', message: 'Cannot identify requesting user' }
+      });
+    }
+
+    const showAll = isAdmin && all === 'true';
 
     let query = `SELECT
         rd.id,
@@ -334,9 +349,18 @@ router.get('/schedules', checkPermission(PERMISSIONS.STREAM_READ), asyncHandler(
        JOIN users recipient ON rd.recipientId = recipient.id`;
 
     const params = [];
+    const conditions = [];
+
+    if (!showAll) {
+      conditions.push('donor.publicKey = ?');
+      params.push(userPublicKey);
+    }
     if (status) {
-      query += ' WHERE rd.status = ?';
+      conditions.push('rd.status = ?');
       params.push(status);
+    }
+    if (conditions.length) {
+      query += ' WHERE ' + conditions.join(' AND ');
     }
     query += ' ORDER BY rd.createdAt DESC';
 

--- a/tests/donations/stream-schedules-bola-754.test.js
+++ b/tests/donations/stream-schedules-bola-754.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * Tests for BOLA fix on GET /stream/schedules (#754)
+ * Users must only see their own schedules; admins can see all with ?all=true.
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-bola-754-key';
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const express = require('express');
+const Database = require('../../src/utils/database');
+const streamRouter = require('../../src/routes/stream');
+const requireApiKey = require('../../src/middleware/apiKey');
+const { attachUserRole } = require('../../src/middleware/rbac');
+const { issueAccessToken } = require('../../src/services/JwtService');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requireApiKey);
+  app.use(attachUserRole());
+  app.use('/stream', streamRouter);
+  app.use((err, req, res, _next) => {
+    res.status(err.status || 500).json({ success: false, error: err.message });
+  });
+  return app;
+}
+
+const DONOR_A = 'GBOLA754DONORA000000000000000000000000000000000000000000001';
+const DONOR_B = 'GBOLA754DONORB000000000000000000000000000000000000000000002';
+const RECIPIENT = 'GBOLA754RECIPIENT0000000000000000000000000000000000000000003';
+
+async function ensureUser(publicKey) {
+  let user = await Database.get('SELECT id FROM users WHERE publicKey = ?', [publicKey]);
+  if (!user) {
+    const r = await Database.run('INSERT INTO users (publicKey) VALUES (?)', [publicKey]);
+    user = { id: r.id };
+  }
+  return user;
+}
+
+async function createSchedule(donorPublicKey, recipientPublicKey) {
+  const donor = await ensureUser(donorPublicKey);
+  const recipient = await ensureUser(recipientPublicKey);
+  const nextDate = new Date(Date.now() + 86400000).toISOString();
+  const result = await Database.run(
+    `INSERT INTO recurring_donations (donorId, recipientId, amount, frequency, nextExecutionDate, status)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [donor.id, recipient.id, 5, 'weekly', nextDate, 'active']
+  );
+  return result.id;
+}
+
+let app;
+let scheduleA; // owned by DONOR_A
+let scheduleB; // owned by DONOR_B
+
+beforeAll(async () => {
+  await Database.initialize();
+  app = createTestApp();
+  scheduleA = await createSchedule(DONOR_A, RECIPIENT);
+  scheduleB = await createSchedule(DONOR_B, RECIPIENT);
+});
+
+afterAll(async () => {
+  await Database.close();
+});
+
+describe('GET /stream/schedules — BOLA fix (#754)', () => {
+  test('user with JWT sees only their own schedules', async () => {
+    const token = issueAccessToken({ sub: DONOR_A, role: 'user' });
+    const res = await request(app)
+      .get('/stream/schedules')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const ids = res.body.data.map(s => s.id);
+    expect(ids).toContain(scheduleA);
+    expect(ids).not.toContain(scheduleB);
+  });
+
+  test('user cannot see another user\'s schedules', async () => {
+    const token = issueAccessToken({ sub: DONOR_B, role: 'user' });
+    const res = await request(app)
+      .get('/stream/schedules')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map(s => s.id);
+    expect(ids).toContain(scheduleB);
+    expect(ids).not.toContain(scheduleA);
+  });
+
+  test('admin without ?all=true sees only their own schedules', async () => {
+    const token = issueAccessToken({ sub: DONOR_A, role: 'admin' });
+    const res = await request(app)
+      .get('/stream/schedules')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map(s => s.id);
+    expect(ids).toContain(scheduleA);
+    expect(ids).not.toContain(scheduleB);
+  });
+
+  test('admin with ?all=true sees all schedules', async () => {
+    const token = issueAccessToken({ sub: DONOR_A, role: 'admin' });
+    const res = await request(app)
+      .get('/stream/schedules?all=true')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map(s => s.id);
+    expect(ids).toContain(scheduleA);
+    expect(ids).toContain(scheduleB);
+  });
+
+  test('non-admin cannot use ?all=true to see all schedules', async () => {
+    const token = issueAccessToken({ sub: DONOR_A, role: 'user' });
+    const res = await request(app)
+      .get('/stream/schedules?all=true')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    // ?all=true is ignored for non-admins; only own schedules returned
+    const ids = res.body.data.map(s => s.id);
+    expect(ids).toContain(scheduleA);
+    expect(ids).not.toContain(scheduleB);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a broken object-level authorization (BOLA) vulnerability where `GET /stream/schedules` returned all recurring donation schedules regardless of who was requesting.

## Changes

- **`src/routes/stream.js`**: `GET /stream/schedules` now filters results to only schedules where the requesting user (identified by JWT `sub`) is the donor. Admin users can bypass this filter with `?all=true`.
- **`src/middleware/rbac.js`**: Added missing `verifyAccessToken` import (pre-existing bug that prevented JWT auth from working in `attachUserRole`).
- **`src/routes/stream.js`**: Added missing `asyncHandler` import (was relying on an implicit global).
- **`tests/donations/stream-schedules-bola-754.test.js`**: 5 new tests verifying the fix.

## Acceptance Criteria

- ✅ `GET /stream/schedules` returns only schedules where the requesting user is the donor
- ✅ Admin users can see all schedules with `?all=true`
- ✅ Tests verify that users only see their own schedules

Closes #754