### PR TITLE
feat: add GET /stream/schedules/:id/history endpoint

### DIFF
--- a/src/migrations/011_recurring_donation_executions.js
+++ b/src/migrations/011_recurring_donation_executions.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Migration: Add recurring_donation_executions table (#771)
+ *
+ * Stores per-execution history for recurring donation schedules so that
+ * owners and admins can audit past runs (success/failure, tx hash, error).
+ */
+
+exports.name = '011_recurring_donation_executions';
+
+exports.up = async (db) => {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS recurring_donation_executions (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      scheduleId      INTEGER NOT NULL REFERENCES recurring_donations(id) ON DELETE CASCADE,
+      executedAt      TEXT    NOT NULL,
+      status          TEXT    NOT NULL CHECK(status IN ('success', 'failure')),
+      transactionHash TEXT,
+      errorMessage    TEXT,
+      createdAt       TEXT    NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_rde_scheduleId
+    ON recurring_donation_executions(scheduleId, executedAt DESC)
+  `);
+};
+
+exports.down = async (db) => {
+  await db.run('DROP INDEX IF EXISTS idx_rde_scheduleId');
+  await db.run('DROP TABLE IF EXISTS recurring_donation_executions');
+};

--- a/src/routes/stream.js
+++ b/src/routes/stream.js
@@ -558,6 +558,72 @@ router.get('/schedules/:id', checkPermission(PERMISSIONS.STREAM_READ), streamSch
 }));
 
 /**
+ * GET /stream/schedules/:id/history
+ * Paginated execution history for a recurring donation schedule.
+ * Accessible to the schedule owner and admins.
+ *
+ * Query params:
+ *   page  {number} - 1-based page number (default 1)
+ *   limit {number} - records per page (default 20, max 100)
+ */
+router.get('/schedules/:id/history', checkPermission(PERMISSIONS.STREAM_READ), streamScheduleIdSchema, asyncHandler(async (req, res) => {
+  try {
+    // Verify schedule exists and check ownership
+    const schedule = await Database.get(
+      `SELECT rd.id, donor.publicKey as donorPublicKey
+       FROM recurring_donations rd
+       JOIN users donor ON rd.donorId = donor.id
+       WHERE rd.id = ?`,
+      [req.params.id]
+    );
+
+    if (!schedule) {
+      return res.status(404).json({ success: false, error: 'Schedule not found' });
+    }
+
+    const isAdmin = req.user?.role === 'admin' || req.apiKey?.role === 'admin';
+    const userPublicKey = req.user?.subject || req.apiKey?.subject;
+
+    if (!isAdmin && userPublicKey !== schedule.donorPublicKey) {
+      return res.status(403).json({
+        success: false,
+        error: { code: 'FORBIDDEN', message: 'Access denied' }
+      });
+    }
+
+    const page  = Math.max(1, parseInt(req.query.page, 10)  || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 20));
+    const offset = (page - 1) * limit;
+
+    const [executions, countRow] = await Promise.all([
+      Database.query(
+        `SELECT id, executedAt, status, transactionHash, errorMessage
+         FROM recurring_donation_executions
+         WHERE scheduleId = ?
+         ORDER BY executedAt DESC
+         LIMIT ? OFFSET ?`,
+        [req.params.id, limit, offset]
+      ),
+      Database.get(
+        'SELECT COUNT(*) as total FROM recurring_donation_executions WHERE scheduleId = ?',
+        [req.params.id]
+      ),
+    ]);
+
+    const total = countRow ? countRow.total : 0;
+
+    res.json({
+      success: true,
+      data: executions,
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) }
+    });
+  } catch (error) {
+    log.error('STREAM_ROUTE', 'Failed to fetch schedule history', { error: error.message });
+    res.status(500).json({ success: false, error: 'Failed to fetch schedule history' });
+  }
+}));
+
+/**
  * DELETE /stream/schedules/:id
  * Cancel a recurring donation schedule
  * Authorization: Only the donor who created the schedule or an admin can cancel it

--- a/tests/stream/schedule-history.test.js
+++ b/tests/stream/schedule-history.test.js
@@ -1,0 +1,113 @@
+/**
+ * Tests for issue #771: GET /stream/schedules/:id/history
+ */
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../src/middleware/rbac', () => ({
+  checkPermission: () => (req, res, next) => next(),
+  requireAdmin: () => (req, res, next) => next(),
+}));
+jest.mock('../../src/middleware/payloadSizeLimiter', () => ({
+  payloadSizeLimiter: () => (req, res, next) => next(),
+  ENDPOINT_LIMITS: { stream: 1024 },
+}));
+jest.mock('../../src/middleware/requestTimeout', () => ({
+  requestTimeout: () => (req, res, next) => next(),
+  TIMEOUTS: { stream: 30000 },
+}));
+jest.mock('../../src/middleware/schemaValidation', () => ({
+  validateSchema: () => (req, res, next) => next(),
+}));
+jest.mock('../../src/services/SseManager', () => ({
+  broadcast: jest.fn(),
+  addClient: jest.fn(),
+  connectionCount: jest.fn(() => 0),
+  MAX_CONNECTIONS_PER_KEY: 5,
+  getMissedEvents: jest.fn(() => []),
+  matchesFilter: jest.fn(() => true),
+  writeSseEvent: jest.fn(),
+}));
+jest.mock('../../src/events/donationEvents', () => ({
+  on: jest.fn(),
+  constructor: { EVENTS: {} },
+}));
+
+const mockDb = {
+  get: jest.fn(),
+  query: jest.fn(),
+  run: jest.fn(),
+};
+jest.mock('../../src/utils/database', () => mockDb);
+
+const router = require('../../src/routes/stream');
+
+function buildApp(userOverride = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.id = 'test-req-id';
+    req.user = { id: 1, role: 'admin', subject: 'GADMIN', ...userOverride };
+    next();
+  });
+  app.use('/stream', router);
+  return app;
+}
+
+describe('GET /stream/schedules/:id/history (#771)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 404 when schedule does not exist', async () => {
+    mockDb.get.mockResolvedValueOnce(null);
+    const res = await request(buildApp()).get('/stream/schedules/99/history');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Schedule not found');
+  });
+
+  it('returns paginated execution history for admin', async () => {
+    mockDb.get
+      .mockResolvedValueOnce({ id: 1, donorPublicKey: 'GDONOR' }) // schedule lookup
+      .mockResolvedValueOnce({ total: 2 });                        // count
+    mockDb.query.mockResolvedValueOnce([
+      { id: 1, executedAt: '2026-04-01T00:00:00Z', status: 'success', transactionHash: 'abc123', errorMessage: null },
+      { id: 2, executedAt: '2026-04-02T00:00:00Z', status: 'failure', transactionHash: null, errorMessage: 'timeout' },
+    ]);
+
+    const res = await request(buildApp()).get('/stream/schedules/1/history');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta).toMatchObject({ page: 1, limit: 20, total: 2 });
+  });
+
+  it('returns 403 when non-owner non-admin requests history', async () => {
+    mockDb.get.mockResolvedValueOnce({ id: 1, donorPublicKey: 'GDONOR' });
+    const app = buildApp({ role: 'user', subject: 'GSOMEONEELSE' });
+    const res = await request(app).get('/stream/schedules/1/history');
+    expect(res.status).toBe(403);
+  });
+
+  it('allows the schedule owner to access history', async () => {
+    mockDb.get
+      .mockResolvedValueOnce({ id: 1, donorPublicKey: 'GOWNER' })
+      .mockResolvedValueOnce({ total: 0 });
+    mockDb.query.mockResolvedValueOnce([]);
+
+    const app = buildApp({ role: 'user', subject: 'GOWNER' });
+    const res = await request(app).get('/stream/schedules/1/history');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('respects page and limit query params', async () => {
+    mockDb.get
+      .mockResolvedValueOnce({ id: 1, donorPublicKey: 'GDONOR' })
+      .mockResolvedValueOnce({ total: 50 });
+    mockDb.query.mockResolvedValueOnce([]);
+
+    const res = await request(buildApp()).get('/stream/schedules/1/history?page=3&limit=10');
+    expect(res.status).toBe(200);
+    expect(res.body.meta).toMatchObject({ page: 3, limit: 10, total: 50, totalPages: 5 });
+  });
+});


### PR DESCRIPTION
 closes #771

Adds paginated execution history for recurring donation schedules.
Accessible to the schedule owner and admins. Each record includes timestamp, status (success/failure), transaction hash, and error message. 
Adds migration 011_recurring_donation_executions.js to create
the backing table with a scheduleId index. 
Added tests covering 404, 403, owner access, and pagination.
