### PR TITLE
fix: issues #788 #789 #790 #791

### DIFF
--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -175,9 +175,16 @@ router.get('/stream', checkPermission(PERMISSIONS.STATS_READ), (req, res, next) 
     
     // Register SSE client
     const client = SseManager.addClient(clientId, keyId, filter, res);
+
+    // Keepalive pings
+    const keepaliveMs = parseInt(process.env.LEADERBOARD_KEEPALIVE_MS || '15000', 10);
+    const pingInterval = setInterval(() => {
+      res.write(': ping\n\n');
+    }, keepaliveMs);
     
     // Handle client disconnect
     req.on('close', () => {
+      clearInterval(pingInterval);
       SseManager.removeClient(clientId);
       console.log(`[Leaderboard SSE] Client disconnected: ${clientId}`);
     });
@@ -276,7 +283,16 @@ router.get('/stream', checkPermission(PERMISSIONS.STATS_READ), (req, res, next) 
     const keyId = req.apiKey ? req.apiKey.id : 'anonymous';
     SseManager.addClient(clientId, keyId, { window }, res);
 
-    req.on('close', () => SseManager.removeClient(clientId));
+    // Keepalive pings
+    const keepaliveMs = parseInt(process.env.LEADERBOARD_KEEPALIVE_MS || '15000', 10);
+    const pingInterval = setInterval(() => {
+      res.write(': ping\n\n');
+    }, keepaliveMs);
+
+    req.on('close', () => {
+      clearInterval(pingInterval);
+      SseManager.removeClient(clientId);
+    });
 
     // Send initial snapshot
     const snapshot = LeaderboardSSE.getSnapshot(window);

--- a/src/services/StatsService.js
+++ b/src/services/StatsService.js
@@ -16,15 +16,16 @@ class StatsService {
    * Get daily aggregated stats
    * @param {Date} startDate - Start date for aggregation
    * @param {Date} endDate - End date for aggregation
+   * @param {string} [timezone='UTC'] - IANA timezone string
    * @returns {Array} Array of daily stats with date and total volume
    */
-  static getDailyStats(startDate, endDate) {
+  static getDailyStats(startDate, endDate, timezone = 'UTC') {
     const transactions = Transaction.getByDateRange(startDate, endDate);
     const dailyMap = new Map();
 
     transactions.forEach(tx => {
       const date = new Date(tx.timestamp);
-      const dateKey = this.getDateKey(date);
+      const dateKey = this.getDateKeyInTimezone(date, timezone);
       
       if (!dailyMap.has(dateKey)) {
         dailyMap.set(dateKey, {


### PR DESCRIPTION
- closes  #784  startDate must be in the future (recurring donations)
- closes #785 balance endpoint with 10s cache, all assets, minimum reserve
- closes #786  stats summary optional date range (from/to params)
- closes #787 POST /wallets/:id/fund Friendbot endpoint (testnet only)