### PR TITLE
feat: add campaign progress caching, schedule cancellation handling, and Stellar tx hash mapping

### DIFF
--- a/src/middleware/caching.js
+++ b/src/middleware/caching.js
@@ -22,6 +22,7 @@ const crypto = require('crypto');
 const MAX_AGE = {
   wallet: 30,
   campaign: 60,
+  'campaign-progress': 30,
   stats: 120,
   'exchange-rate': 300,
   default: 60,

--- a/src/routes/campaigns.js
+++ b/src/routes/campaigns.js
@@ -542,9 +542,10 @@ router.post('/admin/:id/milestones/:milestoneId/verify', requireApiKey, checkPer
 
 /**
  * GET /campaigns/:id/progress
- * Returns total raised, milestone completion, and remaining amount.
+ * Returns real-time funding progress for a campaign (#779).
+ * Response is cached for 30 seconds.
  */
-router.get('/:id/progress', requireApiKey, asyncHandler(async (req, res, next) => {
+router.get('/:id/progress', requireApiKey, cacheMiddleware('campaign-progress', 'public'), asyncHandler(async (req, res, next) => {
   try {
     const campaignId = parseInt(req.params.id, 10);
 
@@ -568,15 +569,33 @@ router.get('/:id/progress', requireApiKey, asyncHandler(async (req, res, next) =
       ? Math.min(100, Math.round((campaign.current_amount / campaign.goal_amount) * 100))
       : 0;
 
+    // Count unique donors for this campaign
+    const donorCountRow = await Database.get(
+      `SELECT COUNT(DISTINCT senderId) AS donorCount
+       FROM transactions
+       WHERE campaign_id = ? AND deleted_at IS NULL`,
+      [campaignId]
+    );
+    const donorCount = donorCountRow ? donorCountRow.donorCount : 0;
+
+    // Calculate days remaining (null if no end_date or already ended)
+    let daysRemaining = null;
+    if (campaign.end_date) {
+      const msRemaining = new Date(campaign.end_date).getTime() - Date.now();
+      daysRemaining = msRemaining > 0 ? Math.ceil(msRemaining / (1000 * 60 * 60 * 24)) : 0;
+    }
+
     res.json({
       success: true,
       data: {
         campaignId,
         name: campaign.name,
         goalAmount: campaign.goal_amount,
-        currentAmount: campaign.current_amount,
+        raisedAmount: campaign.current_amount,
         remaining: Math.max(0, campaign.goal_amount - campaign.current_amount),
-        progressPercent: progressPct,
+        percentage: progressPct,
+        donorCount,
+        daysRemaining,
         status: campaign.status,
         milestones: {
           total: totalMilestones,

--- a/src/routes/stream.js
+++ b/src/routes/stream.js
@@ -669,12 +669,37 @@ router.delete('/schedules/:id', checkPermission(PERMISSIONS.STREAM_DELETE), stre
       });
     }
 
+    // Check if the schedule is currently being executed (#778)
+    const scheduler = require('../services/RecurringDonationScheduler');
+    const scheduleIdNum = parseInt(req.params.id, 10);
+    const isInProgress = scheduler.executingSchedules && scheduler.executingSchedules.has(scheduleIdNum);
+
+    if (isInProgress) {
+      // Mark as pending_cancellation — the scheduler will set it to cancelled after execution completes
+      await Database.run(
+        'UPDATE recurring_donations SET status = ? WHERE id = ?',
+        ['pending_cancellation', req.params.id]
+      );
+
+      log.info('STREAM_ROUTE', 'Schedule cancellation deferred — execution in progress', {
+        scheduleId: req.params.id,
+        cancelledBy: userPublicKey || req.user?.id,
+        isAdmin
+      });
+
+      return res.json({
+        success: true,
+        cancellationStatus: 'deferred',
+        message: 'Schedule is currently executing. Cancellation will take effect after the current execution completes.'
+      });
+    }
+
     await Database.run(
       'UPDATE recurring_donations SET status = ? WHERE id = ?',
       ['cancelled', req.params.id]
     );
 
-    log.info('STREAM_ROUTE', 'Schedule cancelled', {
+    log.info('STREAM_ROUTE', 'Schedule cancelled immediately', {
       scheduleId: req.params.id,
       cancelledBy: userPublicKey || req.user?.id,
       isAdmin
@@ -682,6 +707,7 @@ router.delete('/schedules/:id', checkPermission(PERMISSIONS.STREAM_DELETE), stre
 
     res.json({
       success: true,
+      cancellationStatus: 'immediate',
       message: 'Recurring donation schedule cancelled successfully'
     });
   } catch (error) {

--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -213,6 +213,17 @@ const transactionSyncBodySchema = validateSchema({
   },
 });
 
+/**
+ * Map a transaction record to include stellarTxHash for blockchain verification (#776).
+ * stellarTxHash is a 64-char hex string when present, or null for pending transactions.
+ */
+function withStellarTxHash(tx) {
+  return {
+    ...tx,
+    stellarTxHash: tx.stellarTxId || null,
+  };
+}
+
 router.get('/', checkPermission(PERMISSIONS.TRANSACTIONS_READ), transactionListQuerySchema, asyncHandler(async (req, res, next) => {
   try {
     const { limit = 20, offset, cursor } = req.query;
@@ -226,7 +237,7 @@ router.get('/', checkPermission(PERMISSIONS.TRANSACTIONS_READ), transactionListQ
 
       return res.status(200).json({
         success: true,
-        data: result.data,
+        data: result.data.map(withStellarTxHash),
         pagination: {
           limit: parseInt(limit),
           nextCursor: result.nextCursor,
@@ -262,7 +273,7 @@ router.get('/', checkPermission(PERMISSIONS.TRANSACTIONS_READ), transactionListQ
 
       return res.status(200).json({
         success: true,
-        data: result.data,
+        data: result.data.map(withStellarTxHash),
         pagination: result.pagination
       });
     }
@@ -274,7 +285,7 @@ router.get('/', checkPermission(PERMISSIONS.TRANSACTIONS_READ), transactionListQ
 
     return res.status(200).json({
       success: true,
-      data: result.data,
+      data: result.data.map(withStellarTxHash),
       pagination: {
         limit: parseInt(limit),
         nextCursor: result.nextCursor,
@@ -671,6 +682,30 @@ router.get('/stream', (req, res) => {
   // Send initial connection event
   res.write(`data: ${JSON.stringify({ type: 'connected' })}\n\n`);
 }));
+
+/**
+ * GET /transactions/:id
+ * Get a single transaction by ID, including stellarTxHash for blockchain verification (#776).
+ * Must be declared after all specific named routes to avoid shadowing them.
+ */
+router.get(
+  '/:id',
+  checkPermission(PERMISSIONS.TRANSACTIONS_READ),
+  asyncHandler(async (req, res, next) => {
+    try {
+      const tx = Transaction.getById(req.params.id);
+      if (!tx) {
+        return res.status(404).json({
+          success: false,
+          error: { code: 'TRANSACTION_NOT_FOUND', message: `Transaction ${req.params.id} not found` },
+        });
+      }
+      return res.status(200).json({ success: true, data: withStellarTxHash(tx) });
+    } catch (error) {
+      next(error);
+    }
+  })
+);
 
 module.exports = router;
 module.exports.sseManager = sseManager;

--- a/src/services/RecurringDonationScheduler.js
+++ b/src/services/RecurringDonationScheduler.js
@@ -416,6 +416,29 @@ class RecurringDonationScheduler {
           await this.handlePersistentFailure(schedule, lastError);
         } finally {
           this.executingSchedules.delete(schedule.id);
+
+          // Apply deferred cancellation (#778): if the schedule was cancelled while in-flight,
+          // finalize the cancellation now that execution has completed.
+          try {
+            const current = await Database.get(
+              'SELECT status FROM recurring_donations WHERE id = ?',
+              [schedule.id]
+            );
+            if (current && current.status === 'pending_cancellation') {
+              await Database.run(
+                'UPDATE recurring_donations SET status = ? WHERE id = ?',
+                ['cancelled', schedule.id]
+              );
+              log.info('RECURRING_SCHEDULER', 'Deferred cancellation applied after execution', {
+                scheduleId: schedule.id,
+              });
+            }
+          } catch (cancelErr) {
+            log.error('RECURRING_SCHEDULER', 'Failed to apply deferred cancellation', {
+              scheduleId: schedule.id,
+              error: cancelErr.message,
+            });
+          }
         }
       },
       { scheduleId: schedule.id }

--- a/tests/donations/campaign-progress-779.test.js
+++ b/tests/donations/campaign-progress-779.test.js
@@ -1,0 +1,135 @@
+'use strict';
+/**
+ * Tests for #779: GET /campaigns/:id/progress — real-time campaign funding progress
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-779-key';
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const express = require('express');
+const Database = require('../../src/utils/database');
+const campaignsRouter = require('../../src/routes/campaigns');
+const requireApiKey = require('../../src/middleware/apiKey');
+const { attachUserRole } = require('../../src/middleware/rbac');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requireApiKey);
+  app.use(attachUserRole());
+  app.use('/campaigns', campaignsRouter);
+  app.use((err, req, res, _next) => {
+    res.status(err.status || 500).json({ success: false, error: err.message });
+  });
+  return app;
+}
+
+let app;
+let campaignId;
+let campaignWithEndDate;
+
+beforeAll(async () => {
+  await Database.initialize();
+  app = createApp();
+
+  // Create a test campaign
+  const result = await Database.run(
+    `INSERT INTO campaigns (name, description, goal_amount, current_amount, status)
+     VALUES (?, ?, ?, ?, ?)`,
+    ['Test Campaign 779', 'Progress test', 1000, 250, 'active']
+  );
+  campaignId = result.id;
+
+  // Create a campaign with an end date
+  const endDate = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(); // 10 days from now
+  const result2 = await Database.run(
+    `INSERT INTO campaigns (name, description, goal_amount, current_amount, status, end_date)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ['Timed Campaign 779', 'With end date', 500, 100, 'active', endDate]
+  );
+  campaignWithEndDate = result2.id;
+});
+
+afterAll(async () => {
+  await Database.close();
+});
+
+describe('#779 — GET /campaigns/:id/progress', () => {
+  test('returns goal amount, raised amount, and percentage', async () => {
+    const res = await request(app)
+      .get(`/campaigns/${campaignId}/progress`)
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const { data } = res.body;
+    expect(data).toHaveProperty('goalAmount', 1000);
+    expect(data).toHaveProperty('raisedAmount', 250);
+    expect(data).toHaveProperty('percentage', 25);
+  });
+
+  test('returns donor count', async () => {
+    const res = await request(app)
+      .get(`/campaigns/${campaignId}/progress`)
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('donorCount');
+    expect(typeof res.body.data.donorCount).toBe('number');
+  });
+
+  test('returns daysRemaining for campaign with end date', async () => {
+    const res = await request(app)
+      .get(`/campaigns/${campaignWithEndDate}/progress`)
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(200);
+    const { daysRemaining } = res.body.data;
+    expect(daysRemaining).not.toBeNull();
+    expect(daysRemaining).toBeGreaterThan(0);
+    expect(daysRemaining).toBeLessThanOrEqual(10);
+  });
+
+  test('returns daysRemaining as null when no end date', async () => {
+    const res = await request(app)
+      .get(`/campaigns/${campaignId}/progress`)
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.daysRemaining).toBeNull();
+  });
+
+  test('returns remaining amount', async () => {
+    const res = await request(app)
+      .get(`/campaigns/${campaignId}/progress`)
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.remaining).toBe(750);
+  });
+
+  test('returns 404 for non-existent campaign', async () => {
+    const res = await request(app)
+      .get('/campaigns/999999/progress')
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(404);
+  });
+
+  test('percentage is capped at 100 when over-funded', async () => {
+    const result = await Database.run(
+      `INSERT INTO campaigns (name, goal_amount, current_amount, status)
+       VALUES (?, ?, ?, ?)`,
+      ['Overfunded 779', 100, 150, 'active']
+    );
+
+    const res = await request(app)
+      .get(`/campaigns/${result.id}/progress`)
+      .set('x-api-key', 'test-779-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.percentage).toBe(100);
+  });
+});

--- a/tests/donations/receipt-endpoint-777.test.js
+++ b/tests/donations/receipt-endpoint-777.test.js
@@ -1,0 +1,110 @@
+'use strict';
+/**
+ * Tests for #777: GET /donations/:id/receipt — downloadable donation receipts
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-777-key';
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const Transaction = require('../../src/routes/models/transaction');
+const donationRouter = require('../../src/routes/donation');
+const requireApiKey = require('../../src/middleware/apiKey');
+const { attachUserRole } = require('../../src/middleware/rbac');
+
+const TEST_DB = path.join(__dirname, '../data/test-777-transactions.json');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requireApiKey);
+  app.use(attachUserRole());
+  app.use('/donations', donationRouter);
+  app.use((err, req, res, _next) => {
+    res.status(err.status || 500).json({ success: false, error: err.message });
+  });
+  return app;
+}
+
+let app;
+
+beforeAll(() => {
+  Transaction.getDbPath = () => TEST_DB;
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  app = createApp();
+});
+
+afterAll(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+describe('#777 — GET /donations/:id/receipt', () => {
+  test('returns a PDF for a confirmed donation', async () => {
+    const tx = Transaction.create({
+      id: 'receipt-777-confirmed',
+      amount: 10,
+      donor: 'GDONOR777A',
+      recipient: 'GRECIPIENT777A',
+      status: 'confirmed',
+      stellarTxId: 'd'.repeat(64),
+    });
+
+    const res = await request(app)
+      .get(`/donations/${tx.id}/receipt`)
+      .set('x-api-key', 'test-777-key');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/pdf/);
+    expect(res.headers['content-disposition']).toMatch(/attachment/);
+    expect(res.body).toBeDefined();
+  });
+
+  test('receipt is accessible with a valid API key (donor/admin)', async () => {
+    const tx = Transaction.create({
+      id: 'receipt-777-access',
+      amount: 5,
+      donor: 'GDONOR777B',
+      recipient: 'GRECIPIENT777B',
+      status: 'confirmed',
+      stellarTxId: 'e'.repeat(64),
+    });
+
+    const res = await request(app)
+      .get(`/donations/${tx.id}/receipt`)
+      .set('x-api-key', 'test-777-key');
+
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 404 for a non-existent donation', async () => {
+    const res = await request(app)
+      .get('/donations/nonexistent-777/receipt')
+      .set('x-api-key', 'test-777-key');
+
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 401 without API key', async () => {
+    const tx = Transaction.create({
+      id: 'receipt-777-noauth',
+      amount: 2,
+      donor: 'GDONOR777C',
+      recipient: 'GRECIPIENT777C',
+      status: 'confirmed',
+      stellarTxId: 'f'.repeat(64),
+    });
+
+    const res = await request(app)
+      .get(`/donations/${tx.id}/receipt`);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/stream/schedule-cancel-778.test.js
+++ b/tests/stream/schedule-cancel-778.test.js
@@ -1,0 +1,127 @@
+'use strict';
+/**
+ * Tests for #778: DELETE /stream/schedules/:id — deferred cancellation during in-progress execution
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-778-key';
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const express = require('express');
+const Database = require('../../src/utils/database');
+const streamRouter = require('../../src/routes/stream');
+const requireApiKey = require('../../src/middleware/apiKey');
+const { attachUserRole } = require('../../src/middleware/rbac');
+const { issueAccessToken } = require('../../src/services/JwtService');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requireApiKey);
+  app.use(attachUserRole());
+  app.use('/stream', streamRouter);
+  app.use((err, req, res, _next) => {
+    res.status(err.status || 500).json({ success: false, error: err.message });
+  });
+  return app;
+}
+
+const DONOR = 'GCANCEL778DONOR0000000000000000000000000000000000000000001';
+const RECIPIENT = 'GCANCEL778RECIP0000000000000000000000000000000000000000002';
+
+async function ensureUser(publicKey) {
+  let user = await Database.get('SELECT id FROM users WHERE publicKey = ?', [publicKey]);
+  if (!user) {
+    const r = await Database.run('INSERT INTO users (publicKey) VALUES (?)', [publicKey]);
+    user = { id: r.id };
+  }
+  return user;
+}
+
+async function createSchedule(donorPublicKey, recipientPublicKey) {
+  const donor = await ensureUser(donorPublicKey);
+  const recipient = await ensureUser(recipientPublicKey);
+  const nextDate = new Date(Date.now() + 86400000).toISOString();
+  const result = await Database.run(
+    `INSERT INTO recurring_donations (donorId, recipientId, amount, frequency, nextExecutionDate, status)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [donor.id, recipient.id, 5, 'weekly', nextDate, 'active']
+  );
+  return result.id;
+}
+
+let app;
+
+beforeAll(async () => {
+  await Database.initialize();
+  app = createApp();
+});
+
+afterAll(async () => {
+  await Database.close();
+});
+
+describe('#778 — DELETE /stream/schedules/:id deferred cancellation', () => {
+  test('immediate cancellation when schedule is not in-progress', async () => {
+    const scheduleId = await createSchedule(DONOR, RECIPIENT);
+    const token = issueAccessToken({ sub: DONOR, role: 'user' });
+
+    const res = await request(app)
+      .delete(`/stream/schedules/${scheduleId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.cancellationStatus).toBe('immediate');
+
+    const row = await Database.get('SELECT status FROM recurring_donations WHERE id = ?', [scheduleId]);
+    expect(row.status).toBe('cancelled');
+  });
+
+  test('deferred cancellation when schedule is currently executing', async () => {
+    const scheduleId = await createSchedule(DONOR, RECIPIENT);
+    const token = issueAccessToken({ sub: DONOR, role: 'user' });
+
+    // Simulate in-progress execution by adding to the scheduler's executingSchedules set
+    const scheduler = require('../../src/services/RecurringDonationScheduler');
+    scheduler.executingSchedules.add(scheduleId);
+
+    try {
+      const res = await request(app)
+        .delete(`/stream/schedules/${scheduleId}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.cancellationStatus).toBe('deferred');
+
+      const row = await Database.get('SELECT status FROM recurring_donations WHERE id = ?', [scheduleId]);
+      expect(row.status).toBe('pending_cancellation');
+    } finally {
+      scheduler.executingSchedules.delete(scheduleId);
+    }
+  });
+
+  test('response indicates whether cancellation was immediate or deferred', async () => {
+    const scheduleId = await createSchedule(DONOR, RECIPIENT);
+    const token = issueAccessToken({ sub: DONOR, role: 'user' });
+
+    const res = await request(app)
+      .delete(`/stream/schedules/${scheduleId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.body).toHaveProperty('cancellationStatus');
+    expect(['immediate', 'deferred']).toContain(res.body.cancellationStatus);
+  });
+
+  test('returns 404 for non-existent schedule', async () => {
+    const token = issueAccessToken({ sub: DONOR, role: 'user' });
+
+    const res = await request(app)
+      .delete('/stream/schedules/999999')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/transactions/stellar-tx-hash-776.test.js
+++ b/tests/transactions/stellar-tx-hash-776.test.js
@@ -1,0 +1,141 @@
+'use strict';
+/**
+ * Tests for #776: GET /transactions and GET /transactions/:id must include stellarTxHash
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-776-key';
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const Transaction = require('../../src/routes/models/transaction');
+const transactionRouter = require('../../src/routes/transaction');
+const requireApiKey = require('../../src/middleware/apiKey');
+const { attachUserRole } = require('../../src/middleware/rbac');
+
+const TEST_DB = path.join(__dirname, '../data/test-776-transactions.json');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requireApiKey);
+  app.use(attachUserRole());
+  app.use('/transactions', transactionRouter);
+  app.use((err, req, res, _next) => {
+    res.status(err.status || 500).json({ success: false, error: err.message });
+  });
+  return app;
+}
+
+let app;
+
+beforeAll(() => {
+  Transaction.getDbPath = () => TEST_DB;
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+  app = createApp();
+});
+
+afterAll(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DB)) fs.unlinkSync(TEST_DB);
+});
+
+describe('#776 — stellarTxHash in transaction responses', () => {
+  test('GET /transactions includes stellarTxHash for confirmed transaction', async () => {
+    Transaction.create({
+      id: 'tx-776-confirmed',
+      amount: 5,
+      donor: 'GDONOR1',
+      recipient: 'GRECIPIENT1',
+      status: 'confirmed',
+      stellarTxId: 'a'.repeat(64),
+    });
+
+    const res = await request(app)
+      .get('/transactions')
+      .set('x-api-key', 'test-776-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const tx = res.body.data.find(t => t.id === 'tx-776-confirmed');
+    expect(tx).toBeDefined();
+    expect(tx).toHaveProperty('stellarTxHash');
+    expect(tx.stellarTxHash).toBe('a'.repeat(64));
+  });
+
+  test('GET /transactions includes stellarTxHash as null for pending transaction', async () => {
+    Transaction.create({
+      id: 'tx-776-pending',
+      amount: 3,
+      donor: 'GDONOR2',
+      recipient: 'GRECIPIENT2',
+      status: 'pending',
+      stellarTxId: null,
+    });
+
+    const res = await request(app)
+      .get('/transactions')
+      .set('x-api-key', 'test-776-key');
+
+    expect(res.status).toBe(200);
+    const tx = res.body.data.find(t => t.id === 'tx-776-pending');
+    expect(tx).toBeDefined();
+    expect(tx.stellarTxHash).toBeNull();
+  });
+
+  test('GET /transactions/:id returns stellarTxHash for a known transaction', async () => {
+    const created = Transaction.create({
+      id: 'tx-776-byid',
+      amount: 7,
+      donor: 'GDONOR3',
+      recipient: 'GRECIPIENT3',
+      status: 'confirmed',
+      stellarTxId: 'b'.repeat(64),
+    });
+
+    const res = await request(app)
+      .get(`/transactions/${created.id}`)
+      .set('x-api-key', 'test-776-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('stellarTxHash', 'b'.repeat(64));
+  });
+
+  test('GET /transactions/:id returns 404 for unknown id', async () => {
+    const res = await request(app)
+      .get('/transactions/nonexistent-id-776')
+      .set('x-api-key', 'test-776-key');
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('stellarTxHash is a 64-char hex string when present', async () => {
+    const hash = 'c'.repeat(64);
+    Transaction.create({
+      id: 'tx-776-hexcheck',
+      amount: 1,
+      donor: 'GDONOR4',
+      recipient: 'GRECIPIENT4',
+      status: 'confirmed',
+      stellarTxId: hash,
+    });
+
+    const res = await request(app)
+      .get('/transactions/tx-776-hexcheck')
+      .set('x-api-key', 'test-776-key');
+
+    expect(res.status).toBe(200);
+    const { stellarTxHash } = res.body.data;
+    expect(typeof stellarTxHash).toBe('string');
+    expect(stellarTxHash).toHaveLength(64);
+    expect(/^[0-9a-f]+$/i.test(stellarTxHash)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves four issues across the transaction, donation, stream, and campaign APIs.

---

### #776 — Add `stellarTxHash` to transaction responses

`GET /transactions` and the new `GET /transactions/:id` endpoint now include a
`stellarTxHash` field on every transaction object. The field is a 64-character
hex string when the transaction has been submitted to Stellar, or `null` for
pending transactions. A `withStellarTxHash` mapper is applied to all list and
single-item responses.

---

### #777 — `GET /donations/:id/receipt` — downloadable donation receipts

The endpoint was already wired up in `src/routes/donation.js` and delegates to
`ReceiptService.generatePDF`, which produces a PDF containing the donation
amount, date, donor, recipient, Stellar transaction hash, and a QR code linking
to the Stellar explorer. The endpoint requires `donations:read` permission,
making it accessible to both donors and admins. Tests verify the PDF response,
auth enforcement, and 404 handling.

---

### #778 — Deferred cancellation for in-progress schedule executions

`DELETE /stream/schedules/:id` now checks `RecurringDonationScheduler.executingSchedules`
before writing to the database. If the schedule is currently executing a Stellar
transaction, the status is set to `pending_cancellation` and the response
includes `cancellationStatus: "deferred"`. Once the execution finishes,
`executeScheduleWithRetry` detects the `pending_cancellation` status and
finalises it to `cancelled`. Immediate cancellations return
`cancellationStatus: "immediate"`.

---

### #779 — `GET /campaigns/:id/progress` — real-time funding progress

The existing progress endpoint has been enhanced with:
- `raisedAmount` (renamed from `currentAmount` for clarity)
- `percentage` (renamed from `progressPercent`)
- `donorCount` — unique donor count via `COUNT(DISTINCT senderId)`
- `daysRemaining` — days until `end_date`, or `null` if no end date is set
- 30-second cache via `cacheMiddleware('campaign-progress', 'public')`

---

### Tests

Four new test files cover all acceptance criteria:
- `tests/transactions/stellar-tx-hash-776.test.js`
- `tests/donations/receipt-endpoint-777.test.js`
- `tests/stream/schedule-cancel-778.test.js`
- `tests/donations/campaign-progress-779.test.js`

---

Closes #776
Closes #777
Closes #778
Closes #779
