### PR TITLE
feat: donations total count/envelope + admin db stats endpoint

### DIFF
--- a/src/routes/admin/db.js
+++ b/src/routes/admin/db.js
@@ -6,10 +6,32 @@
  */
 
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 const router = express.Router();
 const { checkPermission } = require('../../middleware/rbac');
 const { PERMISSIONS } = require('../../utils/permissions');
 const Database = require('../../utils/database');
+const { createRateLimiter } = require('../../middleware/rateLimiter');
+
+const dbStatsRateLimiter = createRateLimiter({
+  windowMs: 60 * 1000,
+  max: 10,
+  keyGenerator: (req) => req.apiKey?.id || req.ip,
+});
+
+// Known application tables
+const KNOWN_TABLES = [
+  'users', 'transactions', 'recurring_donations', 'campaigns',
+  'api_keys', 'audit_logs', 'refresh_tokens', 'geo_rules',
+  'donation_velocity', 'student_fees', 'fee_payments',
+  'recovery_guardians', 'recovery_requests', 'recovery_approvals',
+  'recurring_donation_executions', 'recipient_velocity_limits',
+];
+
+// 60-second in-memory cache
+let statsCache = null;
+let statsCacheExpiry = 0;
 
 /**
  * Parse an optional positive integer limit query parameter.
@@ -81,6 +103,90 @@ router.get('/query-stats', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res, ne
       success: true,
       data: stats,
     });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * GET /admin/db/stats
+ * Returns comprehensive database statistics. Cached for 60 seconds.
+ * ?refresh=true bypasses the cache.
+ */
+router.get('/stats', dbStatsRateLimiter, checkPermission(PERMISSIONS.ADMIN_ALL), async (req, res, next) => {
+  try {
+    const now = Date.now();
+    const bypass = req.query.refresh === 'true';
+
+    if (!bypass && statsCache && now < statsCacheExpiry) {
+      res.setHeader('Cache-Control', 'max-age=60');
+      return res.json({ success: true, data: statsCache });
+    }
+
+    const dbPath = process.env.DB_PATH || path.join(__dirname, '../../../data/stellar_donations.db');
+
+    // File sizes
+    let fileSizeBytes = 0;
+    let walFileSizeBytes = 0;
+    try { fileSizeBytes = fs.statSync(dbPath).size; } catch (_) {}
+    try { walFileSizeBytes = fs.statSync(dbPath + '-wal').size; } catch (_) {}
+
+    // PRAGMA info
+    const [pageCountRow, pageSizeRow, journalRow] = await Promise.all([
+      Database.get('PRAGMA page_count'),
+      Database.get('PRAGMA page_size'),
+      Database.get('PRAGMA journal_mode'),
+    ]);
+
+    // Table row counts in parallel
+    const tableCounts = await Promise.all(
+      KNOWN_TABLES.map(async (name) => {
+        try {
+          const row = await Database.get(`SELECT COUNT(*) AS n FROM ${name}`);
+          return { name, rowCount: row ? row.n : 0 };
+        } catch (_) {
+          return null; // table doesn't exist yet
+        }
+      })
+    );
+
+    const perf = Database.getPerformanceMetrics();
+    const pool = Database.getPoolStatus();
+
+    const generatedAt = new Date().toISOString();
+    const cachedUntil = new Date(now + 60000).toISOString();
+
+    const data = {
+      database: {
+        fileSizeBytes,
+        fileSizeMB: Number((fileSizeBytes / 1048576).toFixed(2)),
+        pageSize: pageSizeRow ? pageSizeRow.page_size : null,
+        pageCount: pageCountRow ? pageCountRow.page_count : null,
+        walFileSizeBytes,
+        journalMode: journalRow ? journalRow.journal_mode : null,
+      },
+      tables: tableCounts.filter(Boolean),
+      performance: {
+        slowQueryCount: perf.slowQueryCount,
+        slowQueryThresholdMs: perf.thresholdMs,
+        averageQueryTimeMs: perf.averageQueryTimeMs,
+        totalQueriesExecuted: perf.totalQueries,
+      },
+      pool: {
+        activeConnections: pool.active,
+        idleConnections: pool.idle,
+        maxConnections: pool.poolMax,
+        waitingRequests: pool.waiting,
+      },
+      generatedAt,
+      cachedUntil,
+    };
+
+    statsCache = data;
+    statsCacheExpiry = now + 60000;
+
+    res.setHeader('Cache-Control', 'max-age=60');
+    res.json({ success: true, data });
   } catch (error) {
     next(error);
   }

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -458,6 +458,9 @@ app.get('/suspicious-patterns', require('../middleware/rbac').requireAdmin(), (r
 // Circuit breaker admin endpoints (issue #736)
 app.use('/admin/circuit-breaker', requireApiKey, require('./admin/circuitBreaker'));
 
+// Database monitoring admin endpoints
+app.use('/admin/db', requireApiKey, dbAdminRoutes);
+
 // Transaction inspection (admin only)
 app.use('/admin/inspect/xdr', require('../middleware/rbac').requireAdmin(), adminInspectRoutes);
 

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -465,6 +465,20 @@ router.get('/', checkPermission(PERMISSIONS.DONATIONS_READ), asyncHandler(async 
     const pagination = parseCursorPaginationQuery(req.query);
     const result = donationService.getPaginatedDonations(pagination);
     res.setHeader('X-Total-Count', String(result.totalCount));
+
+    if (req.query.envelope === 'true') {
+      return res.json({
+        data: result.data,
+        pagination: {
+          total: result.totalCount,
+          limit: result.meta.limit,
+          hasMore: result.meta.next_cursor !== null,
+          next_cursor: result.meta.next_cursor,
+          prev_cursor: result.meta.prev_cursor,
+        },
+      });
+    }
+
     res.json({ success: true, data: result.data, count: result.data.length, meta: result.meta });
   } catch (error) {
     next(error);
@@ -483,10 +497,11 @@ router.get('/recent', checkPermission(PERMISSIONS.DONATIONS_READ), asyncHandler(
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 10, 100);
     const Database = require('../utils/database');
-    const rows = await Database.query(
-      `SELECT * FROM transactions ORDER BY timestamp DESC LIMIT ?`,
-      [limit]
-    );
+    const [rows, countRow] = await Promise.all([
+      Database.query(`SELECT * FROM transactions ORDER BY timestamp DESC LIMIT ?`, [limit]),
+      Database.get(`SELECT COUNT(*) AS total FROM transactions`),
+    ]);
+    res.setHeader('X-Total-Count', String(countRow ? countRow.total : rows.length));
     res.json({ success: true, data: rows, count: rows.length });
   } catch (error) {
     next(error);


### PR DESCRIPTION
## Summary

Closes #804
Closes #805

---

## #804 — GET /donations total count and envelope format

**Problem:** Clients cannot implement pagination UI because the response has no total count.

**Changes in `src/routes/donation.js`:**
- `GET /donations?envelope=true` returns `{ data, pagination: { total, limit, hasMore, next_cursor, prev_cursor } }`. Without `envelope=true` the existing response is unchanged — no breaking change.
- `X-Total-Count` header was already set on `GET /donations`; now also set on `GET /donations/recent` (count query runs in parallel with data query).

---

## #805 — GET /admin/db/stats endpoint

**Problem:** No programmatic way to query database health metrics.

**Changes in `src/routes/admin/db.js`:**
- New `GET /admin/db/stats` route: admin-only (`PERMISSIONS.ADMIN_ALL`) + 10 req/min rate limiter
- Returns: file size, WAL size, page info, journal mode, parallel `COUNT(*)` for all 16 known tables, performance metrics, pool metrics
- 60-second in-memory cache; `?refresh=true` bypasses it; `Cache-Control: max-age=60` always set
- File paths not included in response

**Changes in `src/routes/app.js`:**
- Mounted `dbAdminRoutes` at `/admin/db` — it was imported but never mounted

---

## Acceptance Criteria

### #804
- [x] `GET /donations` sets `X-Total-Count` header
- [x] `GET /donations?envelope=true` returns wrapped `{ data, pagination }` format
- [x] Bare array response preserved when `envelope` not set
- [x] `GET /donations/recent` sets `X-Total-Count`
- [x] Count query runs in parallel with data query

### #805
- [x] `GET /admin/db/stats` requires admin authentication (403 for non-admin)
- [x] Response includes file size, WAL size, journal mode
- [x] Response includes row counts for all known tables
- [x] Response includes slow query count and threshold
- [x] Response includes pool metrics (active, idle, max, waiting)
- [x] Response cached 60 seconds (`Cache-Control: max-age=60`)
- [x] `?refresh=true` bypasses cache
- [x] File paths not in response