### PR TITLE
feat(docs): add CHANGELOG.md and npm run changelog script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+- Remove `clientIp` and `protocol` from `GET /health` response to prevent IP enumeration (#758)
+- Add allowlist validation for `category` and `severity` filter parameters in `GET /admin/audit-logs` to prevent SQL injection (#760)
+
+### Added
+- `MockStellarServiceStub`: thin (<200 line) configurable stub implementing `StellarServiceInterface` for unit tests (#756)
+- `npm run changelog` script to generate changelog entries from conventional commits (#761)
+
+---
+
+## [1.0.0] - 2025-04-01
+
+### Added
+- One-time donations via `POST /donations` with Stellar testnet/mainnet support
+- Recurring donation schedules (`POST /stream/create`, `GET /stream/schedules`)
+- Wallet management endpoints (`POST /wallets`, `GET /wallets`, `PATCH /wallets/:id`)
+- Donation analytics and statistics (`GET /stats/daily`, `/stats/weekly`, `/stats/summary`)
+- API key authentication with role-based access control (admin / user / guest)
+- Zero-downtime API key rotation with versioning and graceful deprecation
+- Mock mode (`MOCK_STELLAR=true`) for development without network calls
+- Debug mode (`DEBUG_MODE=true`) for verbose logging
+- Rate limiting on donation endpoints
+- Idempotency key support to prevent duplicate transactions
+- Sensitive data masking in all application logs
+- Automated recurring donation scheduler (runs every 60 s)
+- Audit logging for all security-sensitive operations
+- `GET /health`, `GET /health/live`, `GET /health/ready` health check endpoints
+- `GET /admin/audit-logs` paginated audit log query endpoint
+- Stellar failure simulation for network error testing
+- SQLite database with migration support
+- OpenAPI / Swagger documentation at `/api-docs`
+- GraphQL endpoint at `/graphql`
+- Webhook delivery with retry queue
+- Geo-blocking middleware
+- Circuit breaker for external service calls
+- Transaction reconciliation service
+- PDF tax receipt generation
+- CSV export for donations and audit logs
+- Prometheus metrics at `/metrics`
+
+### Security
+- Helmet middleware for HTTP security headers
+- CORS origin allowlist
+- Request replay detection
+- IP allowlist support
+- Payload size limits on all endpoints
+
+[Unreleased]: https://github.com/Manuel1234477/Stellar-Micro-Donation-API/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/Manuel1234477/Stellar-Micro-Donation-API/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "openapi:check": "node scripts/check-openapi-sync.js",
     "test:load": "node tests/load/run-load-tests.js",
     "test:load:jest": "jest tests/implement-load-testing-suite.test.js --testTimeout=60000 --forceExit",
-    "test:smoke": "jest --config jest.config.smoke.js --forceExit"
+    "test:smoke": "jest --config jest.config.smoke.js --forceExit",
+    "changelog": "node scripts/generate-changelog.js",
+    "changelog:write": "node scripts/generate-changelog.js --write"
   },
   "dependencies": {
     "csv-parse": "^6.2.1",

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * scripts/generate-changelog.js
+ *
+ * Generates a changelog section from conventional commits since the last git tag
+ * (or from the beginning of history if no tags exist).
+ *
+ * Usage:
+ *   npm run changelog              # print unreleased entries to stdout
+ *   npm run changelog -- --write  # prepend entries to CHANGELOG.md
+ *
+ * Conventional commit types recognised:
+ *   feat, fix, perf, refactor, docs, test, chore, ci, build, style, revert
+ *
+ * Breaking changes: commits with "BREAKING CHANGE" in the body or "!" after
+ * the type (e.g. "feat!: ...") are marked as breaking.
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CHANGELOG_PATH = path.join(__dirname, '..', 'CHANGELOG.md');
+const REPO_URL = 'https://github.com/Manuel1234477/Stellar-Micro-Donation-API';
+
+const TYPE_HEADINGS = {
+  feat:     '### Added',
+  fix:      '### Fixed',
+  perf:     '### Performance',
+  refactor: '### Changed',
+  docs:     '### Documentation',
+  test:     '### Tests',
+  chore:    '### Chores',
+  ci:       '### CI',
+  build:    '### Build',
+  style:    '### Style',
+  revert:   '### Reverted',
+};
+
+function run(cmd) {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function getLastTag() {
+  try {
+    return run('git describe --tags --abbrev=0');
+  } catch {
+    return null;
+  }
+}
+
+function getCommitsSince(tag) {
+  const range = tag ? `${tag}..HEAD` : 'HEAD';
+  const log = run(`git log ${range} --pretty=format:"%H|%s|%b|||" --no-merges`);
+  if (!log) return [];
+
+  return log.split('|||').map(raw => raw.trim()).filter(Boolean).map(entry => {
+    const [hash, subject, ...bodyParts] = entry.split('|');
+    return { hash: hash.trim(), subject: subject.trim(), body: bodyParts.join('|').trim() };
+  });
+}
+
+function parseCommit({ hash, subject, body }) {
+  // Match: type(scope)!: description  or  type!: description  or  type: description
+  const match = subject.match(/^(\w+)(\([^)]+\))?(!)?\s*:\s*(.+)$/);
+  if (!match) return null;
+
+  const [, type, scope, bang, description] = match;
+  const isBreaking = Boolean(bang) || /BREAKING CHANGE/i.test(body);
+  const shortHash = hash.slice(0, 7);
+  const scopeStr = scope ? scope.replace(/[()]/g, '') : null;
+
+  return { type, scope: scopeStr, description, isBreaking, hash: shortHash };
+}
+
+function buildSection(commits, fromTag, toRef = 'HEAD') {
+  const today = new Date().toISOString().slice(0, 10);
+  const version = toRef === 'HEAD' ? 'Unreleased' : toRef;
+  const compareUrl = fromTag
+    ? `${REPO_URL}/compare/${fromTag}...${toRef === 'HEAD' ? 'HEAD' : toRef}`
+    : `${REPO_URL}/commits/${toRef === 'HEAD' ? 'HEAD' : toRef}`;
+
+  const breaking = [];
+  const byType = {};
+
+  for (const raw of commits) {
+    const parsed = parseCommit(raw);
+    if (!parsed) continue;
+
+    if (parsed.isBreaking) {
+      breaking.push(`- **BREAKING** ${parsed.description} (\`${parsed.hash}\`)`);
+    }
+
+    const heading = TYPE_HEADINGS[parsed.type];
+    if (!heading) continue;
+
+    byType[heading] = byType[heading] || [];
+    const scopePart = parsed.scope ? `**${parsed.scope}**: ` : '';
+    byType[heading].push(`- ${scopePart}${parsed.description} (\`${parsed.hash}\`)`);
+  }
+
+  const lines = [];
+  lines.push(`## [${version}] - ${today}`);
+  lines.push('');
+
+  if (breaking.length) {
+    lines.push('### ⚠ Breaking Changes');
+    lines.push(...breaking);
+    lines.push('');
+  }
+
+  for (const [heading, entries] of Object.entries(byType)) {
+    lines.push(heading);
+    lines.push(...entries);
+    lines.push('');
+  }
+
+  if (!breaking.length && Object.keys(byType).length === 0) {
+    lines.push('_No conventional commits found in this range._');
+    lines.push('');
+  }
+
+  lines.push(`[${version}]: ${compareUrl}`);
+
+  return lines.join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const shouldWrite = args.includes('--write');
+
+  const lastTag = getLastTag();
+  const commits = getCommitsSince(lastTag);
+
+  if (commits.length === 0) {
+    console.log('No new commits since last tag.');
+    return;
+  }
+
+  const section = buildSection(commits, lastTag);
+
+  if (shouldWrite) {
+    let existing = '';
+    if (fs.existsSync(CHANGELOG_PATH)) {
+      existing = fs.readFileSync(CHANGELOG_PATH, 'utf8');
+    }
+
+    // Insert after the first heading line (# Changelog\n\n...)
+    const insertAfter = '# Changelog\n';
+    const idx = existing.indexOf(insertAfter);
+    let updated;
+    if (idx !== -1) {
+      const after = existing.slice(idx + insertAfter.length).replace(/^\n+/, '');
+      updated = `${insertAfter}\n${section}\n\n${after}`;
+    } else {
+      updated = `${section}\n\n${existing}`;
+    }
+
+    fs.writeFileSync(CHANGELOG_PATH, updated, 'utf8');
+    console.log(`CHANGELOG.md updated with ${commits.length} commit(s).`);
+  } else {
+    console.log(section);
+  }
+}
+
+main();


### PR DESCRIPTION
Closes #761

## Summary
- Created `CHANGELOG.md` following Keep a Changelog standard with entries for all past releases
- Added `npm run changelog` script (`scripts/generate-changelog.js`) that generates changelog entries from conventional commits
- Added `npm run changelog:write` to write entries directly to CHANGELOG.md
- Breaking changes are clearly marked in the changelog

## Changes
- `CHANGELOG.md`: new file with release history
- `scripts/generate-changelog.js`: changelog generator from conventional commits
- `package.json`: added `changelog` and `changelog:write` scripts