### PR TITLE
feat: #802 network route audit + missing endpoints, #803 GET /admin/system/info

### DIFF
--- a/docs/ROUTE_AUDIT.md
+++ b/docs/ROUTE_AUDIT.md
@@ -1,0 +1,51 @@
+# Route Audit — `/network` Router
+
+**File:** `src/routes/network.js`  
+**Mounted at:** `/api/v1/network` (versioned) and `/network` (legacy redirect → 308)  
+**Last audited:** 2026-04-27
+
+---
+
+## Registered Routes
+
+| Method | Path | Handler | Auth | Cache | Description |
+|--------|------|---------|------|-------|-------------|
+| GET | `/network/status` | `router.get('/status')` | None (public) | `public, max-age=30` | Current Stellar network health snapshot (status, baseFee, latency) |
+| GET | `/network/status/history` | `router.get('/status/history')` | None (public) | None | Status snapshots from the last 24 hours |
+| GET | `/network/fees` | `router.get('/fees')` | None (public) | `public, max-age=30` | Current fee statistics (baseFeeStroops, feeLevel, feeSurgeMultiplier) |
+| GET | `/network/ledger` | `router.get('/ledger')` | None (public) | `public, max-age=30` | Latest ledger info (ledgerCloseTimeSeconds, latencyMs, connected) |
+| GET | `/network/metrics` | `router.get('/metrics')` | None (public) | `no-store` | Prometheus-style numeric metrics for monitoring dashboards |
+| ANY | `/network/*` (catch-all) | `router.use(...)` | — | — | Returns 404 with `hint` field listing valid sub-paths |
+
+---
+
+## Data Source
+
+All routes read from `NetworkStatusService` (injected via `setService()`).  
+The service polls Horizon every 30 seconds and caches the latest snapshot in memory.  
+If the service has not been injected, all routes return **503**.
+
+---
+
+## 404 Hint Behaviour
+
+Any request to an unregistered `/network/*` path returns:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ROUTE_NOT_FOUND",
+    "message": "No network route matches GET /network/unknown",
+    "hint": "Valid sub-paths: /status, /status/history, /fees, /ledger, /metrics"
+  }
+}
+```
+
+---
+
+## Audit Notes
+
+- All routes are **publicly accessible** — no API key required.
+- `/network/metrics` sets `Cache-Control: no-store` to ensure monitoring tools always receive fresh data.
+- The legacy unversioned path `/network/*` is redirected (HTTP 308) to `/api/v1/network/*` by the deprecation middleware in `app.js`.

--- a/src/routes/admin/systemInfo.js
+++ b/src/routes/admin/systemInfo.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * GET /admin/system/info
+ * Returns a live snapshot of system state for operations/SRE teams.
+ * Requires admin authentication. Rate-limited to 10 req/min per API key.
+ */
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const router = express.Router();
+const { requireAdmin } = require('../../middleware/rbac');
+const { createRateLimiter } = require('../../middleware/rateLimiter');
+
+const systemInfoRateLimiter = process.env.NODE_ENV === 'test'
+  ? (req, res, next) => next()
+  : createRateLimiter({
+      windowMs: 60 * 1000,
+      max: 10,
+      keyGenerator: (req) => req.apiKey?.id || req.ip,
+    });
+
+/** Patterns for environment variable names that must be redacted. */
+const SENSITIVE_PATTERN = /(_SECRET|_KEY|_TOKEN|_PASSWORD|API_KEYS|ENCRYPTION_KEY|DATABASE_URL)$/i;
+
+/** Format uptime seconds into a human-readable string. */
+function formatUptime(seconds) {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const parts = [];
+  if (d) parts.push(`${d}d`);
+  if (h) parts.push(`${h}h`);
+  parts.push(`${m}m`);
+  return parts.join(' ');
+}
+
+/** Convert bytes to MB rounded to 1 decimal. */
+function toMB(bytes) {
+  return Math.round((bytes / 1024 / 1024) * 10) / 10;
+}
+
+/** Get database file size in MB, or null if unavailable. */
+function getDbFileSizeMB() {
+  try {
+    const dbPath = process.env.DB_PATH || path.join(__dirname, '../../../data/stellar_donations.db');
+    const stat = fs.statSync(dbPath);
+    return toMB(stat.size);
+  } catch {
+    return null;
+  }
+}
+
+/** Check database connectivity. */
+async function getDbStatus() {
+  try {
+    const Database = require('../../utils/database');
+    await Database.query('SELECT 1', []);
+    return 'healthy';
+  } catch {
+    return 'unhealthy';
+  }
+}
+
+router.get('/', requireAdmin(), systemInfoRateLimiter, async (req, res, next) => {
+  try {
+    const uptimeSeconds = Math.floor(process.uptime());
+    const mem = process.memoryUsage();
+    const pkg = require('../../../package.json');
+
+    const [dbStatus, dbFileSizeMB] = await Promise.all([
+      getDbStatus(),
+      Promise.resolve(getDbFileSizeMB()),
+    ]);
+
+    res.json({
+      application: {
+        name: pkg.name || 'stellar-micro-donation-api',
+        version: pkg.version || '1.0.0',
+        environment: process.env.NODE_ENV || 'development',
+        uptime: formatUptime(uptimeSeconds),
+        uptimeSeconds,
+        startedAt: new Date(Date.now() - uptimeSeconds * 1000).toISOString(),
+      },
+      runtime: {
+        nodeVersion: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        pid: process.pid,
+      },
+      memory: {
+        heapUsedMB: toMB(mem.heapUsed),
+        heapTotalMB: toMB(mem.heapTotal),
+        externalMB: toMB(mem.external),
+        rssMB: toMB(mem.rss),
+      },
+      configuration: {
+        stellarNetwork: process.env.STELLAR_NETWORK || 'testnet',
+        mockStellar: process.env.MOCK_STELLAR === 'true',
+        debugMode: process.env.DEBUG_MODE === 'true',
+        rateLimitingEnabled: process.env.DISABLE_RATE_LIMIT !== 'true',
+        port: parseInt(process.env.PORT, 10) || 3000,
+      },
+      database: {
+        type: 'sqlite',
+        status: dbStatus,
+        fileSizeMB: dbFileSizeMB,
+      },
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -34,6 +34,7 @@ const featureFlagsAdminRoutes = require('./admin/featureFlags');
 const createFeeBumpRouter = require('./admin/feeBump');
 const dbAdminRoutes = require('./admin/db');
 const adminTracesRoutes = require('./admin/traces');
+const systemInfoRoutes = require('./admin/systemInfo');
 const retentionAdminRoutes = require('./admin/retention');
 const backupAdminRoutes = require('./admin/backup');
 const encryptionAdminRoutes = require('./admin/encryption');
@@ -457,6 +458,9 @@ app.get('/suspicious-patterns', require('../middleware/rbac').requireAdmin(), (r
 
 // Circuit breaker admin endpoints (issue #736)
 app.use('/admin/circuit-breaker', requireApiKey, require('./admin/circuitBreaker'));
+
+// System info endpoint (issue #803)
+app.use('/admin/system/info', requireApiKey, systemInfoRoutes);
 
 // Database monitoring admin endpoints
 app.use('/admin/db', requireApiKey, dbAdminRoutes);

--- a/src/routes/network.js
+++ b/src/routes/network.js
@@ -2,6 +2,9 @@
  * Network status routes
  * GET /network/status         - current Horizon health snapshot
  * GET /network/status/history - last 24 hours of snapshots
+ * GET /network/fees           - current fee statistics
+ * GET /network/ledger         - latest ledger info
+ * GET /network/metrics        - Prometheus-style metrics
  */
 
 const express = require('express');
@@ -9,9 +12,10 @@ const router = express.Router();
 
 let _service = null;
 
+const VALID_PATHS = ['/status', '/status/history', '/fees', '/ledger', '/metrics'];
+
 /**
  * Inject the NetworkStatusService instance.
- * Called once from app.js after the service is started.
  * @param {import('../services/NetworkStatusService')} service
  */
 function setService(service) {
@@ -48,6 +52,86 @@ router.get('/status', (req, res) => {
 router.get('/status/history', (req, res) => {
   if (!_service) return res.status(503).json({ error: 'NetworkStatusService not initialised' });
   res.json({ history: _service.getHistory() });
+});
+
+/**
+ * GET /network/fees
+ * Returns current fee statistics from NetworkStatusService.
+ */
+router.get('/fees', (req, res) => {
+  if (!_service) return res.status(503).json({ success: false, error: 'NetworkStatusService not initialised' });
+
+  const raw = _service.getStatus();
+
+  res.set('Cache-Control', 'public, max-age=30');
+  res.json({
+    success: true,
+    data: {
+      baseFeeStroops: raw.feeStroops,
+      feeLevel: raw.feeLevel,
+      feeSurgeMultiplier: raw.feeSurgeMultiplier,
+      timestamp: raw.timestamp,
+    },
+  });
+});
+
+/**
+ * GET /network/ledger
+ * Returns latest ledger info derived from NetworkStatusService.
+ */
+router.get('/ledger', (req, res) => {
+  if (!_service) return res.status(503).json({ success: false, error: 'NetworkStatusService not initialised' });
+
+  const raw = _service.getStatus();
+
+  res.set('Cache-Control', 'public, max-age=30');
+  res.json({
+    success: true,
+    data: {
+      connected: raw.connected,
+      ledgerCloseTimeSeconds: raw.ledgerCloseTimeS,
+      latencyMs: raw.latencyMs,
+      timestamp: raw.timestamp,
+    },
+  });
+});
+
+/**
+ * GET /network/metrics
+ * Returns Prometheus-style metrics derived from NetworkStatusService.
+ */
+router.get('/metrics', (req, res) => {
+  if (!_service) return res.status(503).json({ success: false, error: 'NetworkStatusService not initialised' });
+
+  const raw = _service.getStatus();
+
+  res.set('Cache-Control', 'no-store');
+  res.json({
+    success: true,
+    data: {
+      network_connected: raw.connected ? 1 : 0,
+      network_degraded: raw.degraded ? 1 : 0,
+      network_latency_ms: raw.latencyMs,
+      network_fee_stroops: raw.feeStroops,
+      network_fee_surge_multiplier: raw.feeSurgeMultiplier,
+      network_error_rate_percent: raw.errorRatePercent,
+      timestamp: raw.timestamp,
+    },
+  });
+});
+
+/**
+ * Catch-all: unknown /network/* paths return 404 with a hint listing valid sub-paths.
+ */
+router.use((req, res) => {
+  res.status(404).json({
+    success: false,
+    error: {
+      code: 'ROUTE_NOT_FOUND',
+      message: `No network route matches ${req.method} /network${req.path}`,
+      hint: `Valid sub-paths: ${VALID_PATHS.join(', ')}`,
+    },
+  });
 });
 
 module.exports = { router, setService };

--- a/src/services/TOTPService.js
+++ b/src/services/TOTPService.js
@@ -147,7 +147,7 @@ async function ensureTotpColumns() {
     try {
       await db.run(sql);
     } catch (err) {
-      const msg = (err.details && err.details.originalError) || err.message || '';
+      const msg = (err.details && err.details.originalError) || err.originalError?.message || err.message || '';
       if (!msg.includes('duplicate column')) throw err;
     }
   }

--- a/tests/issues-802-803.test.js
+++ b/tests/issues-802-803.test.js
@@ -1,0 +1,399 @@
+'use strict';
+
+/**
+ * Tests for #802 — /network route audit + missing endpoints
+ * Tests for #803 — GET /admin/system/info
+ */
+
+const request = require('supertest');
+const express = require('express');
+const NetworkStatusService = require('../src/services/NetworkStatusService');
+const { router: networkRoutes, setService } = require('../src/routes/network');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNetworkApp(service) {
+  setService(service);
+  const app = express();
+  app.use(express.json());
+  app.use('/network', networkRoutes);
+  return app;
+}
+
+function feeStatsResponse({ lastLedger = 1000, feeMode = '100', capacityUsage = '0.3' } = {}) {
+  return {
+    last_ledger: String(lastLedger),
+    fee_charged: { mode: feeMode, p10: '100', p50: feeMode, p90: feeMode },
+    min_accepted_fee: feeMode,
+    ledger_capacity_usage: capacityUsage,
+  };
+}
+
+function stubFetch(service, data) {
+  service._fetchHorizon = jest.fn().mockResolvedValue(data);
+}
+
+// ---------------------------------------------------------------------------
+// #802 — GET /network/fees
+// ---------------------------------------------------------------------------
+
+describe('#802 GET /network/fees', () => {
+  let svc, app;
+
+  beforeEach(() => {
+    svc = new NetworkStatusService({ pollIntervalMs: 60_000 });
+    app = makeNetworkApp(svc);
+  });
+
+  afterEach(() => svc.stop());
+
+  test('returns 200 with fee data shape', async () => {
+    stubFetch(svc, feeStatsResponse({ feeMode: '100' }));
+    await svc._poll();
+
+    const res = await request(app).get('/network/fees');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('baseFeeStroops');
+    expect(res.body.data).toHaveProperty('feeLevel');
+    expect(res.body.data).toHaveProperty('feeSurgeMultiplier');
+    expect(res.body.data).toHaveProperty('timestamp');
+  });
+
+  test('sets Cache-Control: public, max-age=30', async () => {
+    const res = await request(app).get('/network/fees');
+    expect(res.headers['cache-control']).toBe('public, max-age=30');
+  });
+
+  test('returns 503 when service not initialised', async () => {
+    setService(null);
+    const app2 = express();
+    app2.use('/network', networkRoutes);
+    const res = await request(app2).get('/network/fees');
+    expect(res.status).toBe(503);
+    setService(svc);
+  });
+
+  test('feeLevel is "surge" when fee is high', async () => {
+    stubFetch(svc, feeStatsResponse({ feeMode: '600' }));
+    await svc._poll();
+
+    const res = await request(app).get('/network/fees');
+    expect(res.body.data.feeLevel).toBe('surge');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #802 — GET /network/ledger
+// ---------------------------------------------------------------------------
+
+describe('#802 GET /network/ledger', () => {
+  let svc, app;
+
+  beforeEach(() => {
+    svc = new NetworkStatusService({ pollIntervalMs: 60_000 });
+    app = makeNetworkApp(svc);
+  });
+
+  afterEach(() => svc.stop());
+
+  test('returns 200 with ledger data shape', async () => {
+    stubFetch(svc, feeStatsResponse({ lastLedger: 5000 }));
+    await svc._poll();
+
+    const res = await request(app).get('/network/ledger');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('connected');
+    expect(res.body.data).toHaveProperty('ledgerCloseTimeSeconds');
+    expect(res.body.data).toHaveProperty('latencyMs');
+    expect(res.body.data).toHaveProperty('timestamp');
+  });
+
+  test('sets Cache-Control: public, max-age=30', async () => {
+    const res = await request(app).get('/network/ledger');
+    expect(res.headers['cache-control']).toBe('public, max-age=30');
+  });
+
+  test('returns 503 when service not initialised', async () => {
+    setService(null);
+    const app2 = express();
+    app2.use('/network', networkRoutes);
+    const res = await request(app2).get('/network/ledger');
+    expect(res.status).toBe(503);
+    setService(svc);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #802 — GET /network/metrics
+// ---------------------------------------------------------------------------
+
+describe('#802 GET /network/metrics', () => {
+  let svc, app;
+
+  beforeEach(() => {
+    svc = new NetworkStatusService({ pollIntervalMs: 60_000 });
+    app = makeNetworkApp(svc);
+  });
+
+  afterEach(() => svc.stop());
+
+  test('returns 200 with metrics data shape', async () => {
+    stubFetch(svc, feeStatsResponse());
+    await svc._poll();
+
+    const res = await request(app).get('/network/metrics');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const d = res.body.data;
+    expect(d).toHaveProperty('network_connected');
+    expect(d).toHaveProperty('network_degraded');
+    expect(d).toHaveProperty('network_latency_ms');
+    expect(d).toHaveProperty('network_fee_stroops');
+    expect(d).toHaveProperty('network_fee_surge_multiplier');
+    expect(d).toHaveProperty('network_error_rate_percent');
+    expect(d).toHaveProperty('timestamp');
+  });
+
+  test('network_connected is 1 when connected', async () => {
+    stubFetch(svc, feeStatsResponse({ lastLedger: 2000, feeMode: '100' }));
+    await svc._poll();
+
+    const res = await request(app).get('/network/metrics');
+    expect(res.body.data.network_connected).toBe(1);
+  });
+
+  test('network_connected is 0 when disconnected', async () => {
+    svc._fetchHorizon = jest.fn().mockRejectedValue(new Error('Connection refused'));
+    await svc._poll();
+
+    const res = await request(app).get('/network/metrics');
+    expect(res.body.data.network_connected).toBe(0);
+  });
+
+  test('sets Cache-Control: no-store', async () => {
+    const res = await request(app).get('/network/metrics');
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
+  test('returns 503 when service not initialised', async () => {
+    setService(null);
+    const app2 = express();
+    app2.use('/network', networkRoutes);
+    const res = await request(app2).get('/network/metrics');
+    expect(res.status).toBe(503);
+    setService(svc);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #802 — 404 catch-all with hint
+// ---------------------------------------------------------------------------
+
+describe('#802 /network/* 404 catch-all', () => {
+  let svc, app;
+
+  beforeEach(() => {
+    svc = new NetworkStatusService({ pollIntervalMs: 60_000 });
+    app = makeNetworkApp(svc);
+  });
+
+  afterEach(() => svc.stop());
+
+  test('unknown path returns 404 with hint', async () => {
+    const res = await request(app).get('/network/unknown');
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('ROUTE_NOT_FOUND');
+    expect(res.body.error.hint).toMatch('/status');
+  });
+
+  test('hint lists all valid sub-paths', async () => {
+    const res = await request(app).get('/network/bogus');
+    const hint = res.body.error.hint;
+    expect(hint).toContain('/status');
+    expect(hint).toContain('/fees');
+    expect(hint).toContain('/ledger');
+    expect(hint).toContain('/metrics');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #803 — GET /admin/system/info
+// ---------------------------------------------------------------------------
+
+describe('#803 GET /admin/system/info', () => {
+  const express = require('express');
+  const requireApiKey = require('../src/middleware/apiKey');
+  const { requireAdmin } = require('../src/middleware/rbac');
+  const systemInfoRoutes = require('../src/routes/admin/systemInfo');
+  const { createApiKey } = require('../src/models/apiKeys');
+  const db = require('../src/utils/database');
+
+  let adminKey;
+  let userKey;
+  let app;
+
+  beforeAll(async () => {
+    // Build a minimal app that mirrors how app.js mounts the route
+    app = express();
+    app.use(express.json());
+    // requireApiKey must run before attachUserRole so req.apiKey is set
+    const { attachUserRole } = require('../src/middleware/rbac');
+    app.use('/admin/system/info', requireApiKey, attachUserRole(), systemInfoRoutes);
+    // Error handler so async errors are returned as JSON
+    app.use((err, req, res, next) => {
+      res.status(err.status || err.statusCode || 500).json({ error: err.message, code: err.code });
+    });
+
+    const adminResult = await createApiKey({ name: 'SysInfo Admin', role: 'admin' });
+    adminKey = adminResult.key;
+
+    const userResult = await createApiKey({ name: 'SysInfo User', role: 'user' });
+    userKey = userResult.key;
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  test('returns 200 for admin key', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 403 for non-admin key', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', userKey);
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 401 without API key', async () => {
+    const res = await request(app).get('/admin/system/info');
+    expect(res.status).toBe(401);
+  });
+
+  test('response includes all required sections', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    expect(res.body).toHaveProperty('application');
+    expect(res.body).toHaveProperty('runtime');
+    expect(res.body).toHaveProperty('memory');
+    expect(res.body).toHaveProperty('configuration');
+    expect(res.body).toHaveProperty('database');
+    expect(res.body).toHaveProperty('generatedAt');
+  });
+
+  test('application section has required fields', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    const { application } = res.body;
+    expect(application).toHaveProperty('name');
+    expect(application).toHaveProperty('version');
+    expect(application).toHaveProperty('environment');
+    expect(application).toHaveProperty('uptime');
+    expect(application).toHaveProperty('uptimeSeconds');
+    expect(application).toHaveProperty('startedAt');
+    expect(typeof application.uptimeSeconds).toBe('number');
+    expect(application.uptimeSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  test('runtime section has required fields', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    const { runtime } = res.body;
+    expect(runtime.nodeVersion).toMatch(/^v\d+/);
+    expect(runtime.platform).toBeTruthy();
+    expect(runtime.arch).toBeTruthy();
+    expect(typeof runtime.pid).toBe('number');
+  });
+
+  test('memory section has required fields in MB', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    const { memory } = res.body;
+    expect(typeof memory.heapUsedMB).toBe('number');
+    expect(typeof memory.heapTotalMB).toBe('number');
+    expect(typeof memory.externalMB).toBe('number');
+    expect(typeof memory.rssMB).toBe('number');
+    expect(memory.heapUsedMB).toBeGreaterThan(0);
+  });
+
+  test('configuration section has required fields', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    const { configuration } = res.body;
+    expect(configuration).toHaveProperty('stellarNetwork');
+    expect(configuration).toHaveProperty('mockStellar');
+    expect(configuration).toHaveProperty('debugMode');
+    expect(configuration).toHaveProperty('rateLimitingEnabled');
+    expect(configuration).toHaveProperty('port');
+    expect(typeof configuration.port).toBe('number');
+  });
+
+  test('database section has required fields', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    const { database } = res.body;
+    expect(database.type).toBe('sqlite');
+    expect(['healthy', 'unhealthy']).toContain(database.status);
+  });
+
+  test('response does not contain sensitive env var values', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    const body = JSON.stringify(res.body);
+    // Should not contain raw API key values or encryption key
+    expect(body).not.toContain('ENCRYPTION_KEY');
+    expect(body).not.toContain('API_KEYS');
+    // The actual key value should not appear in the response
+    if (process.env.ENCRYPTION_KEY) {
+      expect(body).not.toContain(process.env.ENCRYPTION_KEY);
+    }
+  });
+
+  test('uptimeSeconds increases between calls', async () => {
+    const res1 = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    await new Promise(r => setTimeout(r, 50));
+
+    const res2 = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    expect(res2.body.application.uptimeSeconds).toBeGreaterThanOrEqual(
+      res1.body.application.uptimeSeconds
+    );
+  });
+
+  test('generatedAt is a valid ISO timestamp', async () => {
+    const res = await request(app)
+      .get('/admin/system/info')
+      .set('x-api-key', adminKey);
+
+    expect(typeof res.body.generatedAt).toBe('string');
+    expect(isNaN(Date.parse(res.body.generatedAt))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #802 
closes #803 

### #802 — Network route audit + missing endpoints

- Added `GET /network/fees` — returns fee stats (baseFeeStroops, feeLevel, feeSurgeMultiplier) from NetworkStatusService
- Added `GET /network/ledger` — returns ledger info (ledgerCloseTimeSeconds, latencyMs, connected)
- Added `GET /network/metrics` — returns Prometheus-style numeric metrics for monitoring dashboards
- Added 404 catch-all for unknown `/network/*` paths; response includes a `hint` field listing all valid sub-paths
- Created `docs/ROUTE_AUDIT.md` documenting every registered route in the `/network` router

### #803 — GET /admin/system/info

- New `src/routes/admin/systemInfo.js` returning `application`, `runtime`, `memory`, `configuration`, and `database` sections
- Admin-only access (`requireAdmin()`); returns 403 for non-admin keys, 401 without a key
- Rate-limited to 10 req/min per API key (bypassed in test environment)
- No sensitive values exposed (API_KEYS, ENCRYPTION_KEY, \*_SECRET, etc.)
- Mounted at `/admin/system/info` in `app.js` with `requireApiKey` + `requireAdmin` guards

### Pre-existing bug fix

- `TOTPService.ensureTotpColumns`: the duplicate-column guard was checking `err.message` (`"Database operation failed"`) instead of the wrapped SQLite error; fixed to also check `err.originalError?.message`

## What was tested

- 26 new tests in `tests/issues-802-803.test.js` — all passing
- Existing 36 `network-status-monitoring` tests — no regressions