### PR TITLE
Get/admin/feature flags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ const hasSecurityPlugin = (() => {
     return false;
   }
 })();
-
+//minor comment not neccessary
 module.exports = {
   env: {
     node: true,
@@ -35,7 +35,7 @@ module.exports = {
       'security/detect-possible-timing-attacks': 'warn',
       'security/detect-pseudoRandomBytes': 'error',
     } : {}),
-    
+
     // Code quality rules that affect security
     'no-eval': 'error',
     'no-implied-eval': 'error',

--- a/src/routes/admin/auditLogExport.js
+++ b/src/routes/admin/auditLogExport.js
@@ -97,6 +97,8 @@ const router = express.Router();
 const { requireAdmin } = require('../../middleware/rbac');
 const AuditLogExportService = require('../../services/AuditLogExportService');
 const { ValidationError, NotFoundError, ERROR_CODES } = require('../../utils/errors');
+const asyncHandler = require('../../utils/asyncHandler');
+const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../../middleware/payloadSizeLimiter');
 
 /**
  * POST /admin/audit-logs/export

--- a/src/routes/admin/encryption.js
+++ b/src/routes/admin/encryption.js
@@ -13,6 +13,8 @@ const { PERMISSIONS } = require('../../utils/permissions');
 const Wallet = require('../models/wallet');
 const Transaction = require('../models/transaction');
 const log = require('../../utils/log');
+const asyncHandler = require('../../utils/asyncHandler');
+const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../../middleware/payloadSizeLimiter');
 
 /**
  * POST /admin/encryption/rotate
@@ -23,8 +25,6 @@ const log = require('../../utils/log');
 router.post('/rotate', requireAdmin(), payloadSizeLimiter(ENDPOINT_LIMITS.admin), asyncHandler(async (req, res, next) => {
   try {
     const svc = require('../../services/EncryptionService');
-const asyncHandler = require('../../utils/asyncHandler');
-const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../../middleware/payloadSizeLimiter');
     const targetVersion = parseInt(process.env.ENCRYPTION_KEY_VERSION || '1', 10);
 
     const wallets = Wallet.loadWallets();

--- a/src/routes/admin/featureFlags.js
+++ b/src/routes/admin/featureFlags.js
@@ -12,6 +12,7 @@
  * - Bulk operations
  */
 
+const crypto = require('crypto');
 const express = require('express');
 const router = express.Router();
 const featureFlagsUtil = require('../../utils/featureFlags');
@@ -75,27 +76,112 @@ router.get('/', checkPermission(PERMISSIONS.ADMIN_ALL), asyncHandler(async (req,
       }
     }).catch(() => {});
 
+    const flagData = flags.map(f => ({
+      id: f.id,
+      name: f.name,
+      enabled: Boolean(f.enabled),
+      scope: f.scope,
+      scope_value: f.scope_value,
+      description: f.description,
+      created_at: f.created_at,
+      updated_at: f.updated_at,
+      updated_by: f.updated_by
+    }));
+
+    if (req.accepts(['html', 'json']) === 'html') {
+      const rows = flagData.map(f => `
+        <tr>
+          <td>${escHtml(f.name)}</td>
+          <td>${escHtml(f.scope)}${f.scope_value ? ': ' + escHtml(f.scope_value) : ''}</td>
+          <td>${escHtml(f.description || '')}</td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" data-name="${escHtml(f.name)}" data-scope="${escHtml(f.scope)}" data-scope-value="${escHtml(f.scope_value || '')}" ${f.enabled ? 'checked' : ''}>
+              <span>${f.enabled ? 'ON' : 'OFF'}</span>
+            </label>
+          </td>
+        </tr>`).join('');
+
+      const apiKey = req.headers['x-api-key'] || '';
+      const nonce = res.locals.cspNonce || '';
+      const csrfToken = crypto.randomBytes(16).toString('hex');
+      res.cookie('ff_csrf', csrfToken, { httpOnly: false, sameSite: 'strict' });
+
+      const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Feature Flags Admin</title>
+<style>
+  body{font-family:sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem}
+  h1{font-size:1.4rem}
+  table{width:100%;border-collapse:collapse}
+  th,td{text-align:left;padding:.5rem .75rem;border-bottom:1px solid #ddd}
+  th{background:#f5f5f5}
+  .toggle input{display:none}
+  .toggle span{cursor:pointer;padding:.25rem .6rem;border-radius:3px;background:#ccc;color:#fff;font-size:.85rem;user-select:none}
+  .toggle input:checked+span{background:#2a9d2a}
+  #toast{position:fixed;bottom:1rem;right:1rem;padding:.6rem 1rem;border-radius:4px;display:none;color:#fff;font-size:.9rem}
+  #toast.ok{background:#2a9d2a} #toast.err{background:#c0392b}
+</style>
+</head>
+<body>
+<h1>Feature Flags Admin</h1>
+<table>
+  <thead><tr><th>Name</th><th>Scope</th><th>Description</th><th>State</th></tr></thead>
+  <tbody>${rows}</tbody>
+</table>
+<div id="toast"></div>
+<script nonce="${nonce}">
+const API_KEY = ${JSON.stringify(apiKey)};
+const CSRF_TOKEN = ${JSON.stringify(csrfToken)};
+function showToast(msg, ok) {
+  const t = document.getElementById('toast');
+  t.textContent = msg; t.className = ok ? 'ok' : 'err'; t.style.display = 'block';
+  setTimeout(() => { t.style.display = 'none'; }, 3000);
+}
+document.querySelectorAll('.toggle input').forEach(cb => {
+  cb.addEventListener('change', async function() {
+    const name = this.dataset.name, scope = this.dataset.scope, sv = this.dataset.scopeValue;
+    const enabled = this.checked;
+    const span = this.nextElementSibling;
+    const prev = !enabled;
+    try {
+      const url = '/admin/feature-flags/' + encodeURIComponent(name) + '?scope=' + encodeURIComponent(scope) + (sv ? '&scope_value=' + encodeURIComponent(sv) : '');
+      const r = await fetch(url, {
+        method: 'PATCH',
+        headers: {'Content-Type':'application/json','x-api-key': API_KEY,'x-csrf-token': CSRF_TOKEN},
+        body: JSON.stringify({enabled})
+      });
+      if (!r.ok) throw new Error((await r.json()).error?.message || r.statusText);
+      span.textContent = enabled ? 'ON' : 'OFF';
+      showToast(name + ' ' + (enabled ? 'enabled' : 'disabled'), true);
+    } catch(e) {
+      this.checked = prev;
+      span.textContent = prev ? 'ON' : 'OFF';
+      showToast('Error: ' + e.message, false);
+    }
+  });
+});
+</script>
+</body>
+</html>`;
+      return res.set('Content-Type', 'text/html').send(html);
+    }
+
     res.json({
       success: true,
-      data: {
-        flags: flags.map(f => ({
-          id: f.id,
-          name: f.name,
-          enabled: Boolean(f.enabled),
-          scope: f.scope,
-          scope_value: f.scope_value,
-          description: f.description,
-          created_at: f.created_at,
-          updated_at: f.updated_at,
-          updated_by: f.updated_by
-        })),
-        total: flags.length
-      }
+      data: { flags: flagData, total: flags.length }
     });
   } catch (error) {
     next(error);
   }
 }));
+
+function escHtml(str) {
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
 
 /**
  * GET /admin/feature-flags/:name
@@ -267,6 +353,18 @@ const updateFlagSchema = validateSchema({
 
 router.patch('/:name', checkPermission(PERMISSIONS.ADMIN_ALL), updateFlagSchema, payloadSizeLimiter(ENDPOINT_LIMITS.admin), asyncHandler(async (req, res, next) => {
   try {
+    // CSRF double-submit cookie validation (applies when request originates from the HTML UI)
+    const rawCookie = req.headers.cookie || '';
+    const csrfCookie = rawCookie.split(';').reduce((acc, part) => {
+      const [k, v] = part.trim().split('=');
+      if (k === 'ff_csrf') acc = decodeURIComponent(v || '');
+      return acc;
+    }, '');
+    const csrfHeader = req.headers['x-csrf-token'];
+    if (csrfCookie && (!csrfHeader || csrfHeader !== csrfCookie)) {
+      return res.status(403).json({ success: false, error: { code: 'CSRF_INVALID', message: 'CSRF token mismatch' } });
+    }
+
     const { name } = req.params;
     const { scope, scope_value } = req.query;
     const { enabled, description } = req.body;

--- a/src/routes/admin/impactMetrics.js
+++ b/src/routes/admin/impactMetrics.js
@@ -13,6 +13,8 @@ const requireApiKey = require('../../middleware/apiKey');
 const { requireAdmin } = require('../../middleware/rbac');
 const { validateSchema } = require('../../middleware/schemaValidation');
 const log = require('../../utils/log');
+const asyncHandler = require('../../utils/asyncHandler');
+const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../../middleware/payloadSizeLimiter');
 
 const createImpactMetricSchema = validateSchema({
   body: {
@@ -60,8 +62,6 @@ router.get('/', requireApiKey, requireAdmin(), asyncHandler(async (req, res, nex
       metrics = await ImpactMetricService.getByCampaign(parseInt(campaign_id, 10));
     } else {
       const Database = require('../../utils/database');
-const asyncHandler = require('../../utils/asyncHandler');
-const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../../middleware/payloadSizeLimiter');
       metrics = await Database.query('SELECT * FROM impact_metrics ORDER BY campaign_id, amount_per_unit ASC');
     }
 

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -94,6 +94,7 @@ const { metricsMiddleware, registry } = require('../utils/metrics');
 const { attachSubscriptionServer } = require('../graphql');
 const sseManager = require('../services/SseManager');
 const claimableBalancesRoutes = require('./claimableBalances');
+const { requestTimeout, TIMEOUTS } = require('../middleware/requestTimeout');
 
 const app = express();
 
@@ -454,6 +455,9 @@ app.get('/suspicious-patterns', require('../middleware/rbac').requireAdmin(), (r
   });
 });
 
+// Feature flags admin UI + API (issue #807)
+app.use('/admin/feature-flags', requireApiKey, featureFlagsAdminRoutes);
+
 // Circuit breaker admin endpoints (issue #736)
 app.use('/admin/circuit-breaker', requireApiKey, require('./admin/circuitBreaker'));
 
@@ -475,21 +479,6 @@ const AUDIT_LOG_MAX_LIMIT = 500;
 
 app.get('/admin/audit-logs', require('../middleware/rbac').requireAdmin(), asyncHandler(async (req, res, next) => {
   try {
-<<<<<<< fix/760-audit-logs-input-validation
-    const pagination = parseCursorPaginationQuery(req.query);
-
-    // Allowlist validation — reject unknown enum values before they reach the DB layer
-    const VALID_CATEGORIES = new Set(Object.values(AuditLogService.CATEGORY));
-    const VALID_SEVERITIES = new Set(Object.values(AuditLogService.SEVERITY));
-
-    if (req.query.category && !VALID_CATEGORIES.has(req.query.category)) {
-      return res.status(400).json({ success: false, error: 'Invalid category value' });
-    }
-    if (req.query.severity && !VALID_SEVERITIES.has(req.query.severity)) {
-      return res.status(400).json({ success: false, error: 'Invalid severity value' });
-    }
-
-=======
     // Parse and enforce limit bounds (default 50, max 500)
     let limit = AUDIT_LOG_DEFAULT_LIMIT;
     if (req.query.limit !== undefined) {
@@ -503,11 +492,21 @@ app.get('/admin/audit-logs', require('../middleware/rbac').requireAdmin(), async
       limit = parsed;
     }
 
+    // Allowlist validation — reject unknown enum values before they reach the DB layer
+    const VALID_CATEGORIES = new Set(Object.values(AuditLogService.CATEGORY));
+    const VALID_SEVERITIES = new Set(Object.values(AuditLogService.SEVERITY));
+
+    if (req.query.category && !VALID_CATEGORIES.has(req.query.category)) {
+      return res.status(400).json({ success: false, error: 'Invalid category value' });
+    }
+    if (req.query.severity && !VALID_SEVERITIES.has(req.query.severity)) {
+      return res.status(400).json({ success: false, error: 'Invalid severity value' });
+    }
+
     // Parse cursor using existing utility but override limit
     const pagination = parseCursorPaginationQuery({ ...req.query, limit: String(limit) });
     pagination.limit = limit; // ensure our validated limit is used
 
->>>>>>> main
     const filters = {
       category: req.query.category,
       action: req.query.action,

--- a/src/routes/claimableBalances.js
+++ b/src/routes/claimableBalances.js
@@ -9,8 +9,12 @@
 const express = require('express');
 const asyncHandler = require('../utils/asyncHandler');
 const router = express.Router();
-const { requireAuth, requirePermission } = require('../middleware/auth');
-const { getStellarService } = require('../utils/serviceLocator');
+const { checkPermission } = require('../middleware/rbac');
+const requireApiKey = require('../middleware/apiKey');
+
+const requireAuth = requireApiKey;
+const requirePermission = (perm) => checkPermission(perm);
+const { getStellarService } = require('../config/stellar');
 
 /**
  * @openapi

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -221,6 +221,18 @@ const updateDonationStatusSchema = validateSchema({
   }
 });
 
+const sendDonationSchema = validateSchema({
+  body: {
+    fields: {
+      senderId: { type: 'string', required: true, trim: true, minLength: 1 },
+      receiverId: { type: 'string', required: true, trim: true, minLength: 1 },
+      amount: { type: 'number', required: true },
+      memo: { type: 'string', required: false, maxLength: 28, nullable: true },
+      campaign_id: { type: 'string', required: false, nullable: true }
+    }
+  }
+});
+
 /**
  * POST /donations/send
  * Send XLM from one wallet to another and record it
@@ -359,7 +371,7 @@ router.post('/send', payloadSizeLimiter(ENDPOINT_LIMITS.singleDonation), donatio
  * Donations with the same donor are grouped into multi-operation Stellar transactions.
  * Rate limited: 10 batch requests per minute per IP.
  */
-router.post('/batch', payloadSizeLimiter(ENDPOINT_LIMITS.batchDonation), safeBatchRateLimiter, requireApiKey, async (req, res, next) => {
+router.post('/batch', payloadSizeLimiter(ENDPOINT_LIMITS.batchDonation), batchRateLimiter, requireApiKey, async (req, res, next) => {
   try {
     const { donations } = req.body;
 
@@ -400,6 +412,23 @@ router.post('/batch', payloadSizeLimiter(ENDPOINT_LIMITS.batchDonation), safeBat
     });
   } catch (error) {
     next(error);
+  }
+});
+
+const createDonationSchema = validateSchema({
+  body: {
+    fields: {
+      amount: { type: 'number', required: true },
+      recipient: { type: 'string', required: true, trim: true, minLength: 1 },
+      currency: { type: 'string', required: false, nullable: true },
+      donor: { type: 'string', required: false, nullable: true },
+      memo: { type: 'string', required: false, maxLength: 28, nullable: true },
+      memoType: { type: 'string', required: false, nullable: true },
+      notes: { type: 'string', required: false, nullable: true },
+      tags: { type: 'array', required: false, nullable: true },
+      sourceAsset: { type: 'string', required: false, nullable: true },
+      sourceAmount: { type: 'number', required: false, nullable: true }
+    }
   }
 });
 

--- a/src/routes/liquidity-pools.js
+++ b/src/routes/liquidity-pools.js
@@ -125,6 +125,8 @@ const requireApiKey = require('../middleware/apiKey');
 const { checkPermission } = require('../middleware/rbac');
 const { PERMISSIONS } = require('../utils/permissions');
 const { getStellarService } = require('../config/stellar');
+const asyncHandler = require('../utils/asyncHandler');
+const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
 
 /**
  * POST /liquidity-pools/deposit

--- a/src/routes/receipt.js
+++ b/src/routes/receipt.js
@@ -16,6 +16,7 @@ const AuditLogService = require('../services/AuditLogService');
 const ReceiptService = require('../services/ReceiptService');
 const Transaction = require('./models/transaction');
 const asyncHandler = require('../utils/asyncHandler');
+const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
 
 // In-memory receipt generation log (keyed by donation ID)
 // Stores { generatedAt: ISO string, emailedTo: string|null }

--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -133,7 +133,7 @@
 
 const express = require('express');
 const router = express.Router();
-const Transaction = require('../models/transaction');
+const Transaction = require('./models/transaction');
 const TransactionSyncService = require('../services/TransactionSyncService');
 const MultiSigService = require('../services/MultiSigService');
 const { buildErrorResponse } = require('../utils/validationErrorFormatter');
@@ -141,8 +141,7 @@ const sseManager = require('../services/SseManager');
 const serviceContainer = require('../config/serviceContainer');
 const { checkPermission } = require('../middleware/rbac');
 const { PERMISSIONS } = require('../utils/permissions');
-const { payloadSizeLimiter } = require('../middleware/payloadSizeLimiter');
-const { ENDPOINT_LIMITS } = require('../constants');
+const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
 const { validateSchema } = require('../middleware/schemaValidation');
 const asyncHandler = require('../utils/asyncHandler');
 
@@ -326,7 +325,7 @@ router.post(
     } catch (error) {
       next(error);
     }
-  },
+  })
 );
 
 
@@ -681,7 +680,7 @@ router.get('/stream', (req, res) => {
 
   // Send initial connection event
   res.write(`data: ${JSON.stringify({ type: 'connected' })}\n\n`);
-}));
+});
 
 /**
  * GET /transactions/:id

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -18,6 +18,39 @@ const Database = require('../utils/database');
 const asyncHandler = require('../utils/asyncHandler');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
 const { buildErrorResponse } = require('../utils/validationErrorFormatter');
+const { validateSchema } = require('../middleware/schemaValidation');
+const { cacheMiddleware } = require('../middleware/caching');
+const { validateDataEntry } = require('../middleware/validateDataEntry');
+
+const requireAuth = requireAdmin;
+const requirePermission = (perm) => checkPermission(perm);
+
+const walletIdSchema = validateSchema({
+  params: {
+    fields: {
+      id: { type: 'string', required: true, trim: true, minLength: 1 }
+    }
+  }
+});
+
+const walletPublicKeySchema = validateSchema({
+  params: {
+    fields: {
+      publicKey: { type: 'string', required: true, trim: true, minLength: 1 }
+    }
+  }
+});
+
+const walletCreateSchema = validateSchema({
+  body: {
+    fields: {
+      address: { type: 'string', required: true, trim: true, minLength: 1 },
+      label: { type: 'string', required: false, nullable: true },
+      ownerName: { type: 'string', required: false, nullable: true },
+      sponsored: { type: 'boolean', required: false, nullable: true }
+    }
+  }
+});
 
 // Inflation destination schema for PATCH
 const inflationDestinationSchema = {

--- a/src/services/RecurringDonationScheduler.js
+++ b/src/services/RecurringDonationScheduler.js
@@ -338,8 +338,13 @@ class RecurringDonationScheduler {
         this.lastTickDurationMs = Date.now() - _tickStart;
         this.lastTickFailedSchedules = _tickFailedSchedules;
       }
-      }); // end runWithTrace
-    });
+    } catch (outerError) {
+      log.error('RECURRING_SCHEDULER', 'Unexpected error in processSchedules', {
+        error: outerError.message,
+        correlationId: correlation.correlationId,
+        traceId: correlation.traceId,
+      });
+    }
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/src/services/WebhookService.js
+++ b/src/services/WebhookService.js
@@ -25,10 +25,6 @@ const {
 } = require('../utils/correlation');
 const { withSpan, injectTraceHeaders } = require('../utils/tracing');
 
-const MAX_RETRIES = 3;
-const BASE_BACKOFF_MS = 1000;
-const MAX_CONSECUTIVE_FAILURES = 5;
-
 /** Retry queue constants */
 const RETRY_DELAYS_MS = [
   60 * 1000,        // 1 minute

--- a/tests/admin/feature-flags-system.test.js
+++ b/tests/admin/feature-flags-system.test.js
@@ -1,0 +1,115 @@
+/**
+ * Tests: GET /admin/feature-flags — content negotiation (HTML + JSON)
+ * Issue #807
+ */
+
+const request = require('supertest');
+const app = require('../../src/routes/app');
+const apiKeysModel = require('../../src/models/apiKeys');
+const featureFlagsUtil = require('../../src/utils/featureFlags');
+const db = require('../../src/utils/database');
+
+let adminKey;
+
+beforeAll(async () => {
+  await apiKeysModel.initializeApiKeysTable();
+  await featureFlagsUtil.initializeFeatureFlagsTable();
+
+  const info = await apiKeysModel.createApiKey({
+    name: 'ff-test-admin',
+    role: 'admin',
+    createdBy: 'ff-test-suite',
+  });
+  adminKey = info.key;
+
+  // Seed a couple of flags
+  await featureFlagsUtil.setFlag('test-flag-on', true, 'global', null, { description: 'On flag' });
+  await featureFlagsUtil.setFlag('test-flag-off', false, 'global', null, { description: 'Off flag' });
+});
+
+afterAll(async () => {
+  await db.run("DELETE FROM api_keys WHERE created_by = 'ff-test-suite'");
+  await db.run("DELETE FROM feature_flags WHERE name LIKE 'test-flag-%'");
+});
+
+describe('GET /admin/feature-flags — JSON (default / explicit)', () => {
+  test('returns JSON with success + data when Accept: application/json', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('x-api-key', adminKey)
+      .set('Accept', 'application/json');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/json/);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data.flags)).toBe(true);
+    expect(typeof res.body.data.total).toBe('number');
+  });
+
+  test('returns 401 without API key', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('Accept', 'application/json');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /admin/feature-flags — HTML (Accept: text/html)', () => {
+  test('returns HTML page with 200', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('x-api-key', adminKey)
+      .set('Accept', 'text/html');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+  });
+
+  test('HTML page lists seeded flags', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('x-api-key', adminKey)
+      .set('Accept', 'text/html');
+
+    expect(res.text).toContain('test-flag-on');
+    expect(res.text).toContain('test-flag-off');
+  });
+
+  test('HTML page contains toggle inputs', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('x-api-key', adminKey)
+      .set('Accept', 'text/html');
+
+    expect(res.text).toContain('<input type="checkbox"');
+    expect(res.text).toContain('data-name=');
+  });
+
+  test('HTML page includes PATCH fetch call in script', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('x-api-key', adminKey)
+      .set('Accept', 'text/html');
+
+    expect(res.text).toContain("method: 'PATCH'");
+  });
+
+  test('HTML response includes Content-Security-Policy header', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('x-api-key', adminKey)
+      .set('Accept', 'text/html');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-security-policy']).toBeDefined();
+  });
+
+  test('returns 401 without API key', async () => {
+    const res = await request(app)
+      .get('/admin/feature-flags')
+      .set('Accept', 'text/html');
+
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Feature flags are stored in the feature_flags database table and can be toggled via the admin REST API. However, toggling a feature flag currently requires constructing a raw HTTP request (e.g., with curl or Postman), which is error-prone and inaccessible to non-technical operations staff.

A lightweight server-rendered HTML UI at GET /admin/feature-flags would allow operations teams to view and toggle feature flags directly in a browser without writing API calls. This is a common pattern for internal admin tooling (e.g., LaunchDarkly, Unleash) and significantly reduces the operational overhead of managing feature rollouts.

Current Behavior
Feature flags can only be managed via:

GET /admin/feature-flags — returns JSON list (requires API client)
PATCH /admin/feature-flags/:name — toggles a flag (requires API client)
There is no browser-accessible UI. Operations staff must use curl or Postman, which requires knowing the API key and endpoint structure. 
closes #807