### PR TITLE
fix: webhook signature verification, health probes, trustlines, audit log flush (#926 #927 #928 #929)

### DIFF
--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -162,7 +162,14 @@ class Logger {
    * 6. Output: Dispatches the aggregated data to the console and file system.
    */
   middleware() {
+    const PROBE_PATHS = ['/health/live', '/health/ready'];
     return (req, res, next) => {
+      // Exclude Kubernetes liveness/readiness probes from request logging
+      const path = req.path || req.url;
+      if (PROBE_PATHS.some(p => path === p || path.startsWith(p + '/'))) {
+        return next();
+      }
+
       const startTime = Date.now();
       const timestamp = new Date().toISOString();
       const requestId = req.id;

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -403,24 +403,30 @@ app.get('/api/v1/health', healthCheckRateLimiter, healthHandler);
 
 app.get('/health', healthCheckRateLimiter, healthHandler);
 
-// Liveness probe — returns 200 as long as the process is running
-app.get('/health/live', healthCheckRateLimiter, (req, res) => {
+// Liveness probe — returns 200 as long as the process is running.
+// Excluded from rate limiting: Kubernetes calls this every few seconds per pod.
+app.get('/health/live', (req, res) => {
   return res.status(200).json(HealthCheckService.getLiveness());
 });
 
-// Readiness probe — returns 200 only when all dependencies are healthy
-app.get('/health/ready', healthCheckRateLimiter, asyncHandler(async (req, res) => {
+// Readiness probe — returns 200 only when all dependencies are healthy.
+// Excluded from rate limiting: Kubernetes calls this every few seconds per pod.
+app.get('/health/ready', asyncHandler(async (req, res) => {
+  if (isShuttingDown) {
+    return res.status(503).json({ status: 'not_ready', reason: 'server is shutting down' });
+  }
   try {
     const readiness = await HealthCheckService.getReadiness(stellarService, networkStatusService, recurringDonationScheduler);
-    const httpStatus = readiness.ready ? 200 : 503;
-    return res.status(httpStatus).json(readiness);
+    if (readiness.ready) {
+      return res.status(200).json({ status: 'ready', timestamp: readiness.timestamp });
+    }
+    const reason = readiness.status === 'unhealthy'
+      ? 'one or more critical dependencies are unavailable'
+      : `service is ${readiness.status}`;
+    return res.status(503).json({ status: 'not_ready', reason, timestamp: readiness.timestamp });
   } catch (err) {
     log.error('HEALTH', 'Readiness check failed', { error: err.message });
-    return res.status(503).json({
-      success: false,
-      ready: false,
-      error: { code: 'READINESS_CHECK_ERROR', message: 'Readiness check failed' }
-    });
+    return res.status(503).json({ status: 'not_ready', reason: 'readiness check failed' });
   }
 }));
 
@@ -722,6 +728,9 @@ async function startServer() {
         await WebhookService.WebhookService.initTable();
         await validateRBAC();
 
+        // Start audit log auto-flush timer
+        AuditLogService.startAutoFlush();
+
         // Only start background workers and jobs if not in test environment
         if (process.env.NODE_ENV !== 'test') {
           const stopQuotaResetJob = startQuotaResetJob();
@@ -869,6 +878,15 @@ async function startServer() {
           log.info("SHUTDOWN", "SQLite WAL checkpoint completed");
         } catch (err) {
           log.warn("SHUTDOWN", "Error checkpointing WAL", { error: err.message });
+        }
+
+        // Flush pending audit log entries before closing the database
+        try {
+          await AuditLogService.flush();
+          AuditLogService.stopAutoFlush();
+          log.info("SHUTDOWN", "Audit log buffer flushed");
+        } catch (err) {
+          log.error("SHUTDOWN", "Error flushing audit log buffer", { error: err.message });
         }
 
         await Database.close();

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -1581,19 +1581,57 @@ router.delete('/:id/trustlines/:asset', checkPermission(PERMISSIONS.WALLETS_UPDA
 
 /**
  * GET /wallets/:id/trustlines
- * List all trustlines for the wallet's Stellar account with their balances.
- *
- * Returns an array of trustlines containing asset details, current balance, and limits.
+ * List all trustlines (and native XLM balance) for the wallet's Stellar account.
+ * Response is cached for 30 seconds per wallet.
  */
 router.get('/:id/trustlines', checkPermission(PERMISSIONS.WALLETS_READ), trustlineListSchema, asyncHandler(async (req, res, next) => {
   try {
     const walletId = parseInt(req.params.id, 10);
 
-    const wallet = await Database.get('SELECT * FROM users WHERE id = ?', [walletId]);
-    if (!wallet) throw new NotFoundError(`Wallet ${walletId} not found`);
+    const wallet = await Database.get('SELECT id, publicKey, address FROM users WHERE id = ?', [walletId]);
+    if (!wallet) {
+      return res.status(404).json({
+        success: false,
+        error: { code: 'WALLET_NOT_FOUND', message: `Wallet ${walletId} not found` },
+      });
+    }
 
+    const publicKey = wallet.publicKey || wallet.address;
     const stellar = getStellarService();
-    const trustlines = await stellar.getTrustlines(wallet.publicKey);
+
+    let balances;
+    try {
+      balances = await stellar.getAccountBalances(publicKey);
+    } catch (err) {
+      // Horizon returns 404 when the account has never been funded
+      const notFound =
+        err?.status === 404 ||
+        err?.response?.status === 404 ||
+        err?.message?.toLowerCase().includes('not found') ||
+        err?.message?.toLowerCase().includes('does not exist');
+      if (notFound) {
+        return res.status(422).json({
+          success: false,
+          error: { code: 'STELLAR_ACCOUNT_NOT_FOUND', message: 'Stellar account does not exist on the network' },
+        });
+      }
+      throw err;
+    }
+
+    const trustlines = balances.map(b => {
+      if (b.asset_type === 'native') {
+        return { assetCode: 'XLM', assetType: 'native', balance: b.balance };
+      }
+      return {
+        assetCode: b.asset_code,
+        assetIssuer: b.asset_issuer,
+        balance: b.balance,
+        limit: b.limit,
+        authorized: Boolean(b.is_authorized),
+      };
+    });
+
+    res.setHeader('Cache-Control', 'private, max-age=30');
 
     await AuditLogService.log({
       category: AuditLogService.CATEGORY.WALLET_OPERATION,
@@ -1607,7 +1645,7 @@ router.get('/:id/trustlines', checkPermission(PERMISSIONS.WALLETS_READ), trustli
       details: { walletId, count: trustlines.length },
     });
 
-    return res.json({ success: true, data: { trustlines, count: trustlines.length } });
+    return res.json({ success: true, data: trustlines, count: trustlines.length });
   } catch (error) {
     next(error);
   }

--- a/src/routes/webhooks.js
+++ b/src/routes/webhooks.js
@@ -1,16 +1,67 @@
 /**
  * Webhook Routes
- * POST /webhooks   - Register a webhook
- * GET  /webhooks   - List webhooks
- * DELETE /webhooks/:id - Remove a webhook
+ * POST /webhooks                    - Register a webhook
+ * GET  /webhooks                    - List webhooks
+ * DELETE /webhooks/:id              - Remove a webhook
+ * POST /webhooks/:id/rotate-secret  - Rotate the HMAC secret for a webhook
  */
 
 const express = require('express');
 const router = express.Router();
+const crypto = require('crypto');
 const requireApiKey = require('../middleware/apiKey');
 const WebhookService = require('../services/WebhookService');
+const EncryptionService = require('../services/EncryptionService');
 const asyncHandler = require('../utils/asyncHandler');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
+
+/**
+ * Middleware that verifies the X-Webhook-Signature header on incoming webhook payloads.
+ * The signature must be `sha256=<HMAC-SHA256(secret, rawBody)>`.
+ * Requires `express.json({ verify: (req, _res, buf) => { req.rawBody = buf } })` upstream.
+ *
+ * @param {Function} getSecret - Async function that receives req and returns the plaintext secret
+ * @returns {import('express').RequestHandler}
+ */
+function verifyWebhookSignature(getSecret) {
+  return asyncHandler(async (req, res, next) => {
+    const header = req.headers['x-webhook-signature'];
+    if (!header) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_WEBHOOK_SIGNATURE', message: 'Missing X-Webhook-Signature header' },
+      });
+    }
+
+    const rawBody = req.rawBody || '';
+    let secret;
+    try {
+      secret = await getSecret(req);
+    } catch {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_WEBHOOK_SIGNATURE', message: 'Could not resolve webhook secret' },
+      });
+    }
+
+    const expected = Buffer.from(`sha256=${crypto.createHmac('sha256', secret).update(rawBody).digest('hex')}`);
+    const received = Buffer.from(header);
+
+    // Constant-time comparison to prevent timing attacks
+    const valid =
+      expected.length === received.length &&
+      crypto.timingSafeEqual(expected, received);
+
+    if (!valid) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_WEBHOOK_SIGNATURE', message: 'Invalid webhook signature' },
+      });
+    }
+
+    next();
+  });
+}
 
 /**
  * POST /webhooks
@@ -19,11 +70,11 @@ const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSi
  */
 router.post('/', requireApiKey, payloadSizeLimiter(ENDPOINT_LIMITS.webhook), asyncHandler(async (req, res, next) => {
   try {
-    const { url, events, secret, tlsSkipVerify } = req.body;
+    const { url, events, tlsSkipVerify } = req.body;
+    // secret is always generated server-side; caller-supplied secrets are ignored
     const webhook = await WebhookService.register({
       url,
       events,
-      secret,
       tlsSkipVerify: !!tlsSkipVerify,
       apiKeyId: req.apiKeyId || null,
     });
@@ -92,6 +143,25 @@ router.get('/:id/deliveries', requireApiKey, asyncHandler(async (req, res, next)
 }));
 
 /**
+ * POST /webhooks/:id/rotate-secret
+ * Generate a new HMAC-SHA256 signing secret for the webhook.
+ * The new secret is returned once and cannot be retrieved again.
+ */
+router.post('/:id/rotate-secret', requireApiKey, asyncHandler(async (req, res, next) => {
+  try {
+    const webhookId = parseInt(req.params.id, 10);
+    if (isNaN(webhookId)) {
+      return res.status(400).json({ success: false, error: { message: 'Invalid webhook ID' } });
+    }
+    const result = await WebhookService.WebhookService.rotateSecret(webhookId);
+    res.json({ success: true, data: result });
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ success: false, error: { message: err.message } });
+    next(err);
+  }
+}));
+
+/**
  * POST /webhooks/dead-letters/:id/replay
  * Manually trigger a retry for a dead-letter webhook.
  */
@@ -118,3 +188,4 @@ router.post('/dead-letters/:id/replay', requireApiKey, asyncHandler(async (req, 
 }));
 
 module.exports = router;
+module.exports.verifyWebhookSignature = verifyWebhookSignature;

--- a/src/services/AuditLogService.js
+++ b/src/services/AuditLogService.js
@@ -120,6 +120,12 @@ const auditLogMetrics = {
   totalFailures: 0,
 };
 
+/** In-memory buffer for pending audit log entries */
+const _pendingBuffer = [];
+const BUFFER_FLUSH_THRESHOLD = 20;
+const BUFFER_FLUSH_INTERVAL_MS = 2000;
+let _autoFlushTimer = null;
+
 class AuditLogService {
   /**
    * Return a snapshot of audit log failure metrics.
@@ -316,7 +322,7 @@ class AuditLogService {
     reason = null
   }) {
     if (process.env.NODE_ENV === 'test') {
-      return { id: 'test-log-id', ...params };
+      return { id: 'test-log-id', category, action, severity, result };
     }
 
     try {
@@ -347,50 +353,20 @@ class AuditLogService {
       const hash = this.generateHash(auditEntry);
       auditEntry.integrityHash = hash;
 
-      // Integrity hash is already checked, proceed to insert
-      // Insert into database (immutable)
-      const dbResult = await db.run(
-        `INSERT INTO audit_logs (
-          timestamp, category, action, severity, result,
-          userId, requestId, ipAddress, resource, reason,
-          details, integrityHash
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [
-          auditEntry.timestamp,
-          auditEntry.category,
-          auditEntry.action,
-          auditEntry.severity,
-          auditEntry.result,
-          auditEntry.userId,
-          auditEntry.requestId,
-          auditEntry.ipAddress,
-          auditEntry.resource,
-          auditEntry.reason,
-          auditEntry.details,
-          auditEntry.integrityHash
-        ]
-      );
+      // Buffer entry; flush when threshold is reached
+      _pendingBuffer.push(auditEntry);
 
-      // Also log to application logs for real-time monitoring
-      if (process.env.NODE_ENV !== 'test') {
-        const logLevel = severity === AUDIT_SEVERITY.HIGH ? 'warn' : 'info';
-        log[logLevel]('AUDIT', `${action}: ${result}`, {
-          category,
-          action,
-          severity,
-          result,
-          userId,
-          requestId,
-          ipAddress,
-          resource,
-          reason
-        });
+      // Log to application logs for real-time monitoring
+      const logLevel = severity === AUDIT_SEVERITY.HIGH ? 'warn' : 'info';
+      log[logLevel]('AUDIT', `${action}: ${result}`, {
+        category, action, severity, result, userId, requestId, ipAddress, resource, reason
+      });
+
+      if (_pendingBuffer.length >= BUFFER_FLUSH_THRESHOLD) {
+        AuditLogService.flush().catch(() => {});
       }
 
-      return {
-        id: dbResult.id,
-        ...auditEntry
-      };
+      return { buffered: true, ...auditEntry };
     } catch (error) {
       this.logWriteFailure(error, category, action);
       // Re-throw validation errors, swallow DB errors
@@ -398,6 +374,82 @@ class AuditLogService {
         throw error;
       }
       // Don't re-throw DB errors — audit log failures should never block operations
+    }
+  }
+
+  /**
+   * Write all buffered entries to the database in a single transaction.
+   * Has a 5-second timeout; on timeout the buffered entries are written to stderr and the
+   * buffer is cleared so that shutdown can proceed.
+   * Safe to call multiple times (idempotent).
+   * @returns {Promise<void>}
+   */
+  static async flush() {
+    if (_pendingBuffer.length === 0) return;
+
+    const entries = _pendingBuffer.splice(0, _pendingBuffer.length);
+
+    const writeEntries = async () => {
+      await db.run('BEGIN TRANSACTION');
+      try {
+        for (const entry of entries) {
+          await db.run(
+            `INSERT INTO audit_logs (
+              timestamp, category, action, severity, result,
+              userId, requestId, ipAddress, resource, reason,
+              details, integrityHash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              entry.timestamp, entry.category, entry.action, entry.severity, entry.result,
+              entry.userId, entry.requestId, entry.ipAddress, entry.resource, entry.reason,
+              entry.details, entry.integrityHash
+            ]
+          );
+        }
+        await db.run('COMMIT');
+      } catch (err) {
+        await db.run('ROLLBACK').catch(() => {});
+        throw err;
+      }
+    };
+
+    const FLUSH_TIMEOUT_MS = 5000;
+    try {
+      await Promise.race([
+        writeEntries(),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('flush timeout')), FLUSH_TIMEOUT_MS)
+        ),
+      ]);
+    } catch (err) {
+      process.stderr.write(
+        JSON.stringify({ event: 'audit_flush_failed', error: err.message, entries }) + '\n'
+      );
+    }
+  }
+
+  /**
+   * Start the periodic auto-flush timer.
+   * @returns {void}
+   */
+  static startAutoFlush() {
+    if (_autoFlushTimer) return;
+    _autoFlushTimer = setInterval(() => {
+      if (_pendingBuffer.length > 0) {
+        AuditLogService.flush().catch(() => {});
+      }
+    }, BUFFER_FLUSH_INTERVAL_MS);
+    if (_autoFlushTimer.unref) _autoFlushTimer.unref();
+  }
+
+  /**
+   * Stop the periodic auto-flush timer.
+   * @returns {void}
+   */
+  static stopAutoFlush() {
+    if (_autoFlushTimer) {
+      clearInterval(_autoFlushTimer);
+      _autoFlushTimer = null;
     }
   }
 

--- a/src/services/WebhookService.js
+++ b/src/services/WebhookService.js
@@ -14,6 +14,7 @@ const http = require('http');
 const crypto = require('crypto');
 const { URL } = require('url');
 const log = require('../utils/log');
+const EncryptionService = require('./EncryptionService');
 
 const MAX_RETRIES = 3;
 const MAX_CONSECUTIVE_FAILURES = 5;
@@ -103,7 +104,7 @@ class WebhookService {
    * @param {string} [params.ownerEmail]
    * @returns {Promise<Object>}
    */
-  async register({ url, events, secret, apiKeyId = null, ownerEmail = null, tlsSkipVerify = false }) {
+  async register({ url, events, apiKeyId = null, ownerEmail = null, tlsSkipVerify = false }) {
     if (!url) { const e = new Error('url is required'); e.status = 400; throw e; }
     if (!events || events.length === 0) { const e = new Error('events must be a non-empty array'); e.status = 400; throw e; }
 
@@ -124,15 +125,36 @@ class WebhookService {
       const e = new Error('tlsSkipVerify is not allowed in production'); e.status = 400; throw e;
     }
 
-    const resolvedSecret = secret || crypto.randomBytes(20).toString('hex');
+    // Always generate a 32-byte random secret server-side; never accept caller-supplied secrets
+    const plaintextSecret = crypto.randomBytes(32).toString('hex');
+    const encryptedSecret = EncryptionService.encryptField(plaintextSecret);
     const eventsStr = JSON.stringify(events);
 
     const Database = require('../utils/database');
     const result = await Database.run(
       `INSERT INTO webhooks (url, events, secret, api_key_id, owner_email, tls_skip_verify) VALUES (?, ?, ?, ?, ?, ?)`,
-      [url, eventsStr, resolvedSecret, apiKeyId, ownerEmail, tlsSkipVerify ? 1 : 0]
+      [url, eventsStr, encryptedSecret, apiKeyId, ownerEmail, tlsSkipVerify ? 1 : 0]
     );
-    return { id: result.id, url, events, secret: resolvedSecret, isActive: true, ownerEmail, tlsSkipVerify: !!tlsSkipVerify };
+    // Return plaintext secret once — it cannot be retrieved again, only rotated
+    return { id: result.id, url, events, secret: plaintextSecret, isActive: true, ownerEmail, tlsSkipVerify: !!tlsSkipVerify };
+  }
+
+  /**
+   * Rotate the secret for an existing webhook. Generates a new 32-byte random secret,
+   * encrypts it for storage, and returns the plaintext secret once.
+   * @param {number} id - Webhook ID
+   * @returns {Promise<{id: number, secret: string}>}
+   */
+  static async rotateSecret(id) {
+    const Database = require('../utils/database');
+    const webhook = await Database.get(`SELECT id FROM webhooks WHERE id = ?`, [id]);
+    if (!webhook) {
+      const e = new Error(`Webhook ${id} not found`); e.status = 404; throw e;
+    }
+    const plaintextSecret = crypto.randomBytes(32).toString('hex');
+    const encryptedSecret = EncryptionService.encryptField(plaintextSecret);
+    await Database.run(`UPDATE webhooks SET secret = ? WHERE id = ?`, [encryptedSecret, id]);
+    return { id, secret: plaintextSecret };
   }
 
   /**
@@ -459,7 +481,10 @@ class WebhookService {
         operationId: correlationHeaders['X-Operation-ID'],
       },
     });
-    const signature = WebhookService._sign(body, webhook.secret || '');
+    const plaintextSecret = webhook.secret
+      ? EncryptionService.decryptField(webhook.secret)
+      : '';
+    const signature = WebhookService._sign(body, plaintextSecret);
 
     try {
       const result = await WebhookService._httpPost(webhook.url, body, signature, correlationHeaders, !!webhook.tls_skip_verify);
@@ -511,7 +536,7 @@ class WebhookService {
    * @param {string} secret
    * @returns {string}
    */
-  _sign(body, secret) {
+  static _sign(body, secret) {
     return crypto.createHmac('sha256', secret).update(body).digest('hex');
   }
 
@@ -519,7 +544,7 @@ class WebhookService {
    * POST a JSON body to a URL with a timeout.
    * @private
    */
-  _httpPost(url, body, signature, correlationHeaders = {}, tlsSkipVerify = false) {
+  static _httpPost(url, body, signature, correlationHeaders = {}, tlsSkipVerify = false) {
     return new Promise((resolve, reject) => {
       const parsed = new URL(url);
       const lib = parsed.protocol === 'https:' ? https : http;


### PR DESCRIPTION
## Summary

### #926 — Webhook signature verification (`WebhookService.js`, `webhooks.js`)

- `WebhookService.register()` now **always generates a 32-byte server-side secret** (caller-supplied secrets are ignored). The secret is encrypted at rest via `EncryptionService.encryptField()` and returned in plaintext exactly once.
- Added `WebhookService.rotateSecret(id)` — generates a new secret, encrypts it, and returns the plaintext once.
- Added `POST /webhooks/:id/rotate-secret` route.
- Added `verifyWebhookSignature(getSecret)` middleware — verifies `X-Webhook-Signature: sha256=<hmac>` using HMAC-SHA256 and `crypto.timingSafeEqual()`. Returns `401 INVALID_WEBHOOK_SIGNATURE` on failure.
- `_deliverWithRetry` now decrypts the stored secret before computing the outbound HMAC signature.

closes #926 

### #927 — Kubernetes health probes (`app.js`, `logger.js`)

- `GET /health/live` and `GET /health/ready` no longer pass through `healthCheckRateLimiter` — Kubernetes probes fire every few seconds and must not be rate-limited.
- `GET /health/ready` now returns `{ status: "ready" }` on HTTP 200 and `{ status: "not_ready", reason: "..." }` on HTTP 503. Also returns 503 immediately while `isShuttingDown` is true.
- `logger.js` middleware skips `/health/live` and `/health/ready` to prevent log noise from frequent probe calls (`accessLog` already excluded these paths).

closes #927 

### #928 — `GET /wallets/:id/trustlines` (`wallet.js`)

- Replaced the missing `stellar.getTrustlines()` call with the existing `stellar.getAccountBalances()`.
- Response maps the native balance to `{ assetCode: "XLM", assetType: "native", balance }` and custom assets to `{ assetCode, assetIssuer, balance, limit, authorized }`.
- Returns **404** when the wallet record is absent from the database.
- Returns **422 `STELLAR_ACCOUNT_NOT_FOUND`** when the Stellar account has never been funded on the network.
- Sets `Cache-Control: private, max-age=30` (30-second TTL per wallet).

closes #928 

### #929 — `AuditLogService` flush on shutdown (`AuditLogService.js`, `app.js`)

- Added `_pendingBuffer` — `_log()` now buffers entries and writes them in batches (flush triggers when buffer ≥ 20 entries or every 2 s via auto-flush timer).
- Added `AuditLogService.flush()` with a 5-second timeout. On timeout the pending entries are written to `stderr` as JSON so no security-relevant events are silently lost.
- Added `startAutoFlush()` / `stopAutoFlush()` to manage the background timer.
- Graceful shutdown in `app.js` calls `AuditLogService.flush()` + `stopAutoFlush()` **before** `Database.close()`. Server startup calls `startAutoFlush()` after migrations complete.

closes #929 
