### PR TITLE
feat: implement issues #914 and #915

### DIFF
--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -36,6 +36,7 @@ const dbAdminRoutes = require('./admin/db');
 const adminTracesRoutes = require('./admin/traces');
 const systemInfoRoutes = require('./admin/systemInfo');
 const retentionAdminRoutes = require('./admin/retention');
+const retentionService = require('../services/RetentionService');
 const backupAdminRoutes = require('./admin/backup');
 const geoRulesAdminRoutes = require('./admin/geoRules');
 const encryptionAdminRoutes = require('./admin/encryption');
@@ -491,6 +492,9 @@ app.get('/suspicious-patterns', require('../middleware/rbac').requireAdmin(), (r
   });
 });
 
+// Data retention admin endpoints (admin only)
+app.use('/admin/retention', retentionAdminRoutes);
+
 // Geo-rules management (admin only)
 app.use('/admin/geo-rules', geoRulesAdminRoutes);
 
@@ -747,6 +751,7 @@ async function startServer() {
           recurringDonationScheduler.start();
           reconciliationService.start();
           auditLogRetentionService.start();
+          retentionService.start();
           transactionSyncScheduler.start();
           sseManager.start();
 
@@ -859,6 +864,7 @@ async function startServer() {
 
         reconciliationService.stop();
         auditLogRetentionService.stop();
+        retentionService.stop();
         transactionSyncScheduler.stop();
         require('../workers/expiryWorker').stop();
         

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -26,6 +26,16 @@ const { toWalletResponse } = require('../utils/responseSanitizer');
 const BulkWalletImportService = require('../services/BulkWalletImportService');
 const Wallet = require('./models/wallet');
 const { STROOPS_PER_XLM } = require('../constants');
+const WalletService = require('../services/WalletService');
+const AuditLogService = require('../services/AuditLogService');
+const log = require('../utils/log');
+const { parseCursorPaginationQuery } = require('../utils/pagination');
+
+const walletService = new WalletService();
+
+function getStellarService() {
+  return require('../config/serviceContainer').getStellarService();
+}
 
 const requireAuth = requireAdmin;
 const requirePermission = (perm) => checkPermission(perm);
@@ -372,59 +382,38 @@ router.get('/', checkPermission(PERMISSIONS.WALLETS_READ), cacheMiddleware('wall
 
 /**
  * GET /wallets/:id/balance
- * Get wallet balance natively bypassing horizon load via TTL
+ * Returns XLM balance with TTL caching. Use ?refresh=true to force a live query.
+ * Requires wallets:read permission.
  */
 router.get('/:id/balance', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, asyncHandler(async (req, res, next) => {
   try {
     const forceRefresh = req.query.refresh === 'true';
-    const wallet = await walletService.getWalletById(req.params.id);
-    
-    if (!wallet) {
-      throw new NotFoundError('Wallet not found', ERROR_CODES.WALLET_NOT_FOUND);
-    }
-    
-    const address = wallet.address || wallet.publicKey;
-    const stellarSvc = getStellarService();
 
-    res.setHeader('Cache-Control', 'max-age=10');
-
-    // Try to get all asset balances if available
-    if (stellarSvc && typeof stellarSvc.getAccountBalances === 'function') {
-      try {
-        const balances = await stellarSvc.getAccountBalances(address);
-        const nativeBalance = balances.find(b => b.asset_type === 'native');
-        const xlmBalance = nativeBalance ? parseFloat(nativeBalance.balance) : 0;
-        const subentryCount = balances.filter(b => b.asset_type !== 'native').length;
-        const minimumReserve = 1.0 + subentryCount * 0.5;
-
-        return res.json({
-          success: true,
-          data: {
-            balances: balances.map(b => ({
-              asset: b.asset_type === 'native' ? 'XLM' : `${b.asset_code}:${b.asset_issuer}`,
-              balance: b.balance,
-              assetType: b.asset_type,
-            })),
-            xlmBalance: nativeBalance ? nativeBalance.balance : '0',
-            minimumReserve: minimumReserve.toFixed(7),
-          }
+    let result;
+    try {
+      result = await walletService.getBalance(req.params.id, forceRefresh);
+    } catch (err) {
+      // StellarErrorHandler throws plain objects: { status, code, message }
+      // A 404 from Horizon means the account exists locally but not on-chain
+      if (err && (err.status === 404 || err.response?.status === 404)) {
+        return res.status(422).json({
+          success: false,
+          error: {
+            code: 'STELLAR_ACCOUNT_NOT_FOUND',
+            message: 'Stellar account not found. The account exists in the local database but has not been funded on the Stellar network.',
+          },
         });
-      } catch (_) {
-        // fall through to getBalance
       }
+      throw err;
     }
-
-    const result = await walletService.getBalance(req.params.id, forceRefresh);
 
     res.setHeader('X-Cache', result.cached ? 'HIT' : 'MISS');
 
-    res.json({
-      success: true,
-      data: {
-        balance: result.balance,
-        asset: result.asset,
-        minimumReserve: '1.0000000',
-      }
+    return res.json({
+      balance: result.balance,
+      asset: result.asset || 'XLM',
+      lastUpdated: result.lastUpdated || new Date().toISOString(),
+      cached: result.cached,
     });
   } catch (error) {
     next(error);

--- a/src/services/RetentionService.js
+++ b/src/services/RetentionService.js
@@ -6,9 +6,13 @@
  * DEPENDENCIES: Database
  *
  * Supports three independent retention windows via environment variables:
- *   RETENTION_TRANSACTIONS_DAYS  (default: 365)
- *   RETENTION_AUDIT_LOGS_DAYS    (default: 90)
- *   RETENTION_USER_DATA_DAYS     (default: 730)
+ *   RETENTION_DONATIONS_DAYS    (default: 2555, ~7 years) — anonymise donation records
+ *   RETENTION_AUDIT_LOGS_DAYS   (default: 365)            — delete audit log entries
+ *   RETENTION_IDEMPOTENCY_DAYS  (default: 30)             — delete idempotency keys
+ *
+ * Set any period to 0 to disable purging for that data type.
+ * Set RETENTION_DRY_RUN=true to log what would be deleted without deleting.
+ * Scheduling: defaults to 02:00 UTC daily, override with RETENTION_SCHEDULE_CRON="HH:MM".
  *
  * Anonymization replaces PII with SHA-256 hashes so aggregate analytics remain valid.
  */
@@ -17,10 +21,13 @@ const crypto = require('crypto');
 const Database = require('../utils/database');
 const log = require('../utils/log');
 
-/** @returns {number} */
+/** Returns days from env var; 0 means disabled; negative/invalid falls back to default. */
 function parseDays(envVar, defaultDays) {
-  const v = parseInt(process.env[envVar], 10);
-  return Number.isFinite(v) && v > 0 ? v : defaultDays;
+  const raw = process.env[envVar];
+  if (raw === undefined || raw === '') return defaultDays;
+  const v = parseInt(raw, 10);
+  if (!Number.isFinite(v) || v < 0) return defaultDays;
+  return v;
 }
 
 /**
@@ -42,15 +49,45 @@ function cutoffDate(days) {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
+/** Parse RETENTION_SCHEDULE_CRON="HH:MM" into [hour, minute]; default [2, 0]. */
+function parseScheduleTime() {
+  const raw = process.env.RETENTION_SCHEDULE_CRON || '';
+  const match = raw.match(/^(\d{1,2}):(\d{2})$/);
+  if (match) {
+    const h = parseInt(match[1], 10);
+    const m = parseInt(match[2], 10);
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) return [h, m];
+  }
+  // Also accept cron syntax "MM HH * * *"
+  const cronMatch = raw.match(/^(\d+)\s+(\d+)\s/);
+  if (cronMatch) {
+    const m = parseInt(cronMatch[1], 10);
+    const h = parseInt(cronMatch[2], 10);
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) return [h, m];
+  }
+  return [2, 0];
+}
+
 class RetentionService {
+  constructor() {
+    this._timer = null;
+  }
+
+  get dryRun() {
+    return process.env.RETENTION_DRY_RUN === 'true';
+  }
+
   /**
-   * Anonymize transactions older than RETENTION_TRANSACTIONS_DAYS.
-   * Replaces memo with a hash; sender/receiver IDs are preserved for FK integrity.
-   * @param {number} [days] - Override retention period
-   * @returns {Promise<number>} Number of records anonymized
+   * Anonymise donation (transaction) records older than RETENTION_DONATIONS_DAYS.
+   * Replaces memo with a pseudonymous hash. Returns 0 immediately if period is 0.
+   * @param {number} [days]
+   * @returns {Promise<{purged: number, remaining: number, durationMs: number}>}
    */
-  async runTransactionRetention(days) {
-    const retentionDays = days !== undefined ? days : parseDays('RETENTION_TRANSACTIONS_DAYS', 365);
+  async runDonationRetention(days) {
+    const retentionDays = days !== undefined ? days : parseDays('RETENTION_DONATIONS_DAYS', 2555);
+    if (retentionDays === 0) return { purged: 0, remaining: 0, durationMs: 0 };
+
+    const start = Date.now();
     const cutoff = cutoffDate(retentionDays);
 
     const rows = await Database.query(
@@ -58,79 +95,101 @@ class RetentionService {
       [cutoff]
     );
 
-    for (const row of rows) {
-      await Database.run(
-        `UPDATE transactions SET memo = ? WHERE id = ?`,
-        [anonymize(row.memo), row.id]
-      );
+    if (!this.dryRun) {
+      for (const row of rows) {
+        await Database.run(
+          `UPDATE transactions SET memo = ? WHERE id = ?`,
+          [anonymize(row.memo), row.id]
+        );
+      }
     }
 
-    if (rows.length > 0) {
-      log.info('RETENTION_SERVICE', 'Anonymized transactions', { count: rows.length, retentionDays, cutoff });
-    }
-    return rows.length;
+    const remaining = await Database.get(
+      `SELECT COUNT(*) as n FROM transactions WHERE memo NOT LIKE 'anon:%' OR memo IS NULL`
+    ).catch(() => ({ n: 0 }));
+
+    const durationMs = Date.now() - start;
+    log.info('RETENTION_SERVICE', this.dryRun ? '[DRY RUN] Would anonymise donations' : 'Anonymised donations', {
+      dataType: 'donations', purged: rows.length, remaining: remaining.n, retentionDays, cutoff, durationMs,
+    });
+    return { purged: rows.length, remaining: remaining.n, durationMs };
   }
 
   /**
    * Delete audit log entries older than RETENTION_AUDIT_LOGS_DAYS.
-   * @param {number} [days] - Override retention period
-   * @returns {Promise<number>} Number of records deleted
+   * @param {number} [days]
+   * @returns {Promise<{purged: number, remaining: number, durationMs: number}>}
    */
   async runAuditLogRetention(days) {
-    const retentionDays = days !== undefined ? days : parseDays('RETENTION_AUDIT_LOGS_DAYS', 90);
+    const retentionDays = days !== undefined ? days : parseDays('RETENTION_AUDIT_LOGS_DAYS', 365);
+    if (retentionDays === 0) return { purged: 0, remaining: 0, durationMs: 0 };
+
+    const start = Date.now();
     const cutoff = cutoffDate(retentionDays);
 
-    const result = await Database.run(
-      `DELETE FROM audit_logs WHERE timestamp < ?`,
-      [cutoff]
-    );
-
-    const count = result && result.changes != null ? result.changes : 0;
-    if (count > 0) {
-      log.info('RETENTION_SERVICE', 'Deleted audit logs', { count, retentionDays, cutoff });
+    let purged = 0;
+    if (!this.dryRun) {
+      const result = await Database.run(`DELETE FROM audit_logs WHERE timestamp < ?`, [cutoff]);
+      purged = result && result.changes != null ? result.changes : 0;
+    } else {
+      const preview = await Database.get(`SELECT COUNT(*) as n FROM audit_logs WHERE timestamp < ?`, [cutoff]).catch(() => ({ n: 0 }));
+      purged = preview.n;
     }
-    return count;
+
+    const remaining = await Database.get('SELECT COUNT(*) as n FROM audit_logs').catch(() => ({ n: 0 }));
+    const durationMs = Date.now() - start;
+    log.info('RETENTION_SERVICE', this.dryRun ? '[DRY RUN] Would delete audit logs' : 'Deleted audit logs', {
+      dataType: 'auditLogs', purged, remaining: remaining.n, retentionDays, cutoff, durationMs,
+    });
+    return { purged, remaining: remaining.n, durationMs };
   }
 
   /**
-   * Anonymize user PII (publicKey) for accounts older than RETENTION_USER_DATA_DAYS.
-   * @param {number} [days] - Override retention period
-   * @returns {Promise<number>} Number of records anonymized
+   * Delete expired idempotency keys older than RETENTION_IDEMPOTENCY_DAYS.
+   * @param {number} [days]
+   * @returns {Promise<{purged: number, remaining: number, durationMs: number}>}
    */
-  async runUserDataRetention(days) {
-    const retentionDays = days !== undefined ? days : parseDays('RETENTION_USER_DATA_DAYS', 730);
+  async runIdempotencyRetention(days) {
+    const retentionDays = days !== undefined ? days : parseDays('RETENTION_IDEMPOTENCY_DAYS', 30);
+    if (retentionDays === 0) return { purged: 0, remaining: 0, durationMs: 0 };
+
+    const start = Date.now();
     const cutoff = cutoffDate(retentionDays);
 
-    const rows = await Database.query(
-      `SELECT id, publicKey FROM users WHERE createdAt < ? AND publicKey NOT LIKE 'anon:%'`,
-      [cutoff]
-    );
-
-    for (const row of rows) {
-      await Database.run(
-        `UPDATE users SET publicKey = ? WHERE id = ?`,
-        [anonymize(row.publicKey), row.id]
-      );
+    let purged = 0;
+    if (!this.dryRun) {
+      const result = await Database.run(`DELETE FROM idempotency_keys WHERE createdAt < ?`, [cutoff]);
+      purged = result && result.changes != null ? result.changes : 0;
+    } else {
+      const preview = await Database.get(`SELECT COUNT(*) as n FROM idempotency_keys WHERE createdAt < ?`, [cutoff]).catch(() => ({ n: 0 }));
+      purged = preview.n;
     }
 
-    if (rows.length > 0) {
-      log.info('RETENTION_SERVICE', 'Anonymized user records', { count: rows.length, retentionDays, cutoff });
-    }
-    return rows.length;
+    const remaining = await Database.get('SELECT COUNT(*) as n FROM idempotency_keys').catch(() => ({ n: 0 }));
+    const durationMs = Date.now() - start;
+    log.info('RETENTION_SERVICE', this.dryRun ? '[DRY RUN] Would delete idempotency keys' : 'Deleted idempotency keys', {
+      dataType: 'idempotencyKeys', purged, remaining: remaining.n, retentionDays, cutoff, durationMs,
+    });
+    return { purged, remaining: remaining.n, durationMs };
   }
 
   /**
    * Run all three retention jobs and return a combined summary.
-   * @returns {Promise<{transactions: number, auditLogs: number, userData: number}>}
+   * @returns {Promise<{donations: Object, auditLogs: Object, idempotencyKeys: Object}>}
    */
   async runAll() {
-    const [transactions, auditLogs, userData] = await Promise.all([
-      this.runTransactionRetention(),
+    const runStart = Date.now();
+    const [donations, auditLogs, idempotencyKeys] = await Promise.all([
+      this.runDonationRetention(),
       this.runAuditLogRetention(),
-      this.runUserDataRetention(),
+      this.runIdempotencyRetention(),
     ]);
-    log.info('RETENTION_SERVICE', 'Full retention run complete', { transactions, auditLogs, userData });
-    return { transactions, auditLogs, userData };
+    log.info('RETENTION_SERVICE', 'Full retention run complete', {
+      donations: donations.purged, auditLogs: auditLogs.purged,
+      idempotencyKeys: idempotencyKeys.purged, totalDurationMs: Date.now() - runStart,
+      dryRun: this.dryRun,
+    });
+    return { donations, auditLogs, idempotencyKeys };
   }
 
   /**
@@ -139,27 +198,66 @@ class RetentionService {
    */
   async getStatus() {
     const config = {
-      transactionRetentionDays: parseDays('RETENTION_TRANSACTIONS_DAYS', 365),
-      auditLogRetentionDays: parseDays('RETENTION_AUDIT_LOGS_DAYS', 90),
-      userDataRetentionDays: parseDays('RETENTION_USER_DATA_DAYS', 730),
+      donationRetentionDays: parseDays('RETENTION_DONATIONS_DAYS', 2555),
+      auditLogRetentionDays: parseDays('RETENTION_AUDIT_LOGS_DAYS', 365),
+      idempotencyRetentionDays: parseDays('RETENTION_IDEMPOTENCY_DAYS', 30),
+      dryRun: this.dryRun,
+      scheduleCron: process.env.RETENTION_SCHEDULE_CRON || '02:00',
     };
 
-    const [txTotal, txAnon, auditTotal, userTotal, userAnon] = await Promise.all([
+    const [txTotal, txAnon, auditTotal, idempotencyTotal] = await Promise.all([
       Database.get('SELECT COUNT(*) as n FROM transactions').catch(() => ({ n: 0 })),
       Database.get(`SELECT COUNT(*) as n FROM transactions WHERE memo LIKE 'anon:%'`).catch(() => ({ n: 0 })),
       Database.get('SELECT COUNT(*) as n FROM audit_logs').catch(() => ({ n: 0 })),
-      Database.get('SELECT COUNT(*) as n FROM users').catch(() => ({ n: 0 })),
-      Database.get(`SELECT COUNT(*) as n FROM users WHERE publicKey LIKE 'anon:%'`).catch(() => ({ n: 0 })),
+      Database.get('SELECT COUNT(*) as n FROM idempotency_keys').catch(() => ({ n: 0 })),
     ]);
 
     return {
       config,
       stats: {
-        transactions: { total: txTotal.n, anonymized: txAnon.n },
+        donations: { total: txTotal.n, anonymized: txAnon.n },
         auditLogs: { total: auditTotal.n },
-        users: { total: userTotal.n, anonymized: userAnon.n },
+        idempotencyKeys: { total: idempotencyTotal.n },
       },
     };
+  }
+
+  /** Schedule a daily retention run at the configured UTC time. */
+  start() {
+    if (this._timer) return;
+    const [h, m] = parseScheduleTime();
+    const scheduleTime = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')} UTC`;
+    log.info('RETENTION_SERVICE', 'Scheduled daily retention run', {
+      scheduledAt: scheduleTime,
+      donationDays: parseDays('RETENTION_DONATIONS_DAYS', 2555),
+      auditLogDays: parseDays('RETENTION_AUDIT_LOGS_DAYS', 365),
+      idempotencyDays: parseDays('RETENTION_IDEMPOTENCY_DAYS', 30),
+      dryRun: this.dryRun,
+    });
+    this._scheduleNext();
+  }
+
+  _scheduleNext() {
+    const [h, m] = parseScheduleTime();
+    const now = new Date();
+    const next = new Date();
+    next.setUTCHours(h, m, 0, 0);
+    if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+    const delay = next.getTime() - now.getTime();
+    this._timer = setTimeout(() => {
+      this.runAll().catch(err =>
+        log.error('RETENTION_SERVICE', 'Scheduled run failed', { error: err.message })
+      );
+      this._timer = null;
+      this._scheduleNext();
+    }, delay);
+  }
+
+  stop() {
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
   }
 }
 

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -288,8 +288,9 @@ class WalletService {
   async getBalance(id, forceRefresh = false) {
     const wallet = this.getWalletById(id);
     const cacheKey = `wallet_balance_${wallet.address}`;
-    const cacheTtl = parseInt(process.env.WALLET_BALANCE_CACHE_TTL, 10) || 10000;
-    
+    const ttlSeconds = parseInt(process.env.WALLET_BALANCE_CACHE_TTL_SECONDS, 10);
+    const cacheTtl = (Number.isFinite(ttlSeconds) && ttlSeconds > 0 ? ttlSeconds : 30) * 1000;
+
     const Cache = require('../utils/cache');
     const serviceContainer = require('../config/serviceContainer');
     const stellarService = serviceContainer.getStellarService();
@@ -297,14 +298,15 @@ class WalletService {
     if (!forceRefresh) {
       const cached = Cache.get(cacheKey);
       if (cached !== null) {
-         return { ...cached, cached: true };
+        return { ...cached, cached: true };
       }
     }
 
     const liveBalance = await stellarService.getBalance(wallet.address);
-    Cache.set(cacheKey, liveBalance, cacheTtl);
+    const result = { ...liveBalance, lastUpdated: new Date().toISOString() };
+    Cache.set(cacheKey, result, cacheTtl);
 
-    return { ...liveBalance, cached: false };
+    return { ...result, cached: false };
   }
   /**
    * Revoke platform sponsorship for a wallet.

--- a/tests/issues/issue-915-wallet-balance-endpoint.test.js
+++ b/tests/issues/issue-915-wallet-balance-endpoint.test.js
@@ -1,0 +1,129 @@
+'use strict';
+/**
+ * Tests: Issue #915 — GET /wallets/:id/balance with TTL caching
+ */
+
+// Mocks must be hoisted before requires
+jest.mock('../../src/middleware/rbac', () => ({
+  checkPermission: () => (req, res, next) => next(),
+  requireAdmin: () => (req, res, next) => next(),
+  attachUserRole: (req, res, next) => next(),
+}));
+jest.mock('../../src/middleware/apiKey', () => (req, res, next) => next());
+
+const mockGetBalance = jest.fn();
+jest.mock('../../src/config/serviceContainer', () => ({
+  getStellarService: jest.fn().mockReturnValue({ getBalance: mockGetBalance }),
+}));
+
+const mockWalletGetById = jest.fn();
+jest.mock('../../src/routes/models/wallet', () => ({
+  getById: (...a) => mockWalletGetById(...a),
+  getByAddress: jest.fn(),
+  getAll: jest.fn().mockReturnValue([]),
+  create: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('../../src/utils/database', () => ({
+  get: jest.fn(),
+  run: jest.fn(),
+  query: jest.fn().mockResolvedValue([]),
+  all: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+}));
+
+const Cache = require('../../src/utils/cache');
+const request = require('supertest');
+const express = require('express');
+
+function buildApp() {
+  jest.resetModules();
+  const app = express();
+  app.use(express.json());
+  const router = require('../../src/routes/wallet');
+  app.use('/wallets', router);
+  return app;
+}
+
+const WALLET = { id: '42', address: 'GABCDEF1234567890', label: 'Test' };
+
+describe('Issue #915 — GET /wallets/:id/balance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Cache.clear();
+    delete process.env.WALLET_BALANCE_CACHE_TTL_SECONDS;
+    mockWalletGetById.mockReturnValue(WALLET);
+    mockGetBalance.mockResolvedValue({ balance: '100.5000000', asset: 'XLM' });
+  });
+
+  it('returns balance, asset, lastUpdated, cached=false on first (cache miss)', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/wallets/42/balance');
+
+    expect(res.status).toBe(200);
+    expect(res.body.balance).toBe('100.5000000');
+    expect(res.body.asset).toBe('XLM');
+    expect(res.body.lastUpdated).toBeDefined();
+    expect(res.body.cached).toBe(false);
+    expect(res.headers['x-cache']).toBe('MISS');
+  });
+
+  it('returns cached=true and skips Stellar call on second request', async () => {
+    const app = buildApp();
+    await request(app).get('/wallets/42/balance');
+    mockGetBalance.mockClear();
+
+    const res = await request(app).get('/wallets/42/balance');
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(true);
+    expect(res.headers['x-cache']).toBe('HIT');
+    expect(mockGetBalance).not.toHaveBeenCalled();
+  });
+
+  it('?refresh=true forces live query and returns cached=false', async () => {
+    const app = buildApp();
+    // Populate cache first
+    await request(app).get('/wallets/42/balance');
+
+    mockGetBalance.mockResolvedValue({ balance: '200.0000000', asset: 'XLM' });
+    const res = await request(app).get('/wallets/42/balance?refresh=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(false);
+    expect(res.body.balance).toBe('200.0000000');
+    expect(mockGetBalance).toHaveBeenCalled();
+  });
+
+  it('returns 404 when wallet does not exist', async () => {
+    const { NotFoundError, ERROR_CODES } = require('../../src/utils/errors');
+    mockWalletGetById.mockImplementation(() => {
+      throw new NotFoundError('Wallet not found', ERROR_CODES.WALLET_NOT_FOUND);
+    });
+    const app = buildApp();
+    const res = await request(app).get('/wallets/999/balance');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 422 with STELLAR_ACCOUNT_NOT_FOUND when account not on network', async () => {
+    mockGetBalance.mockRejectedValue({ status: 404, code: 'ACCOUNT_NOT_FOUND', message: 'not found' });
+    const app = buildApp();
+    const res = await request(app).get('/wallets/42/balance');
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('STELLAR_ACCOUNT_NOT_FOUND');
+    expect(res.body.error.message).toMatch(/not been funded/i);
+  });
+
+  it('uses WALLET_BALANCE_CACHE_TTL_SECONDS env for TTL', async () => {
+    process.env.WALLET_BALANCE_CACHE_TTL_SECONDS = '60';
+    const WalletService = require('../../src/services/WalletService');
+    const svc = new WalletService();
+    // Just verify it reads the env and doesn't throw
+    expect(svc).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **#914**: Implement configurable data retention policy enforcement — schedules `RetentionService` to run daily at 02:00 UTC, adds new env vars, dry-run mode, and proper logging
- **#915**: Add `GET /wallets/:id/balance` endpoint with TTL caching — fixes missing imports in wallet routes and wires up the balance endpoint with proper 404/422 responses

## Changes

### Issue #914 — Data Retention Policy

- Rewrote `RetentionService.js` with new env vars: `RETENTION_DONATIONS_DAYS` (default 2555), `RETENTION_AUDIT_LOGS_DAYS` (default 365), `RETENTION_IDEMPOTENCY_DAYS` (default 30)
- Setting any period to `0` disables purging for that data type
- `RETENTION_DRY_RUN=true` logs what would be deleted without deleting
- Each run logs: data type, records purged, records remaining, duration
- Donation records are anonymised (memo replaced with SHA-256 hash) rather than hard-deleted
- Added `start()`/`stop()` scheduler methods using `setTimeout` with daily 02:00 UTC firing (configurable via `RETENTION_SCHEDULE_CRON="HH:MM"`)
- Mounted `POST /admin/retention/run` and `GET /admin/retention/status` in `app.js`
- `retentionService.start()` called on server startup; `retentionService.stop()` on graceful shutdown

### Issue #915 — Wallet Balance Endpoint

- `GET /wallets/:id/balance` returns `{ balance, asset, lastUpdated, cached }`
- Balance cached with TTL via `WALLET_BALANCE_CACHE_TTL_SECONDS` (default 30s)
- `?refresh=true` forces live Stellar network query
- Returns HTTP 404 (`WALLET_NOT_FOUND`) for non-existent wallets
- Returns HTTP 422 (`STELLAR_ACCOUNT_NOT_FOUND`) when wallet exists locally but not on Stellar network
- Fixed missing imports in `wallet.js` (`WalletService`, `AuditLogService`, `log`, `parseCursorPaginationQuery`, `getStellarService`) that caused `ReferenceError` at runtime
- Adds test file `tests/issues/issue-915-wallet-balance-endpoint.test.js`

Closes #914
Closes #915