### PR TITLE
feat: implement issues #69, #70, #71

### DIFF
--- a/src/routes/admin/db.js
+++ b/src/routes/admin/db.js
@@ -192,4 +192,65 @@ router.get('/stats', dbStatsRateLimiter, checkPermission(PERMISSIONS.ADMIN_ALL),
   }
 });
 
+// In-memory vacuum job store
+const vacuumJobs = new Map();
+let activeVacuumJobId = null;
+
+/**
+ * POST /admin/db/vacuum
+ * Starts a background VACUUM job. Returns immediately with a jobId.
+ * Only one vacuum job may run at a time.
+ */
+router.post('/vacuum', checkPermission(PERMISSIONS.ADMIN_ALL), async (req, res) => {
+  if (activeVacuumJobId && vacuumJobs.get(activeVacuumJobId)?.status === 'running') {
+    return res.status(409).json({ success: false, error: { code: 'VACUUM_IN_PROGRESS', message: 'A vacuum job is already running' } });
+  }
+
+  const jobId = `vacuum-${Date.now()}`;
+  activeVacuumJobId = jobId;
+  vacuumJobs.set(jobId, { status: 'running', startedAt: Date.now() });
+
+  // Run in background
+  setImmediate(async () => {
+    const job = vacuumJobs.get(jobId);
+    try {
+      const dbPath = process.env.DB_PATH || path.join(__dirname, '../../../data/stellar_donations.db');
+      let sizeBefore = 0;
+      try { sizeBefore = fs.statSync(dbPath).size; } catch (_) {}
+
+      await Database.run('PRAGMA wal_checkpoint(FULL)');
+      await Database.run('VACUUM');
+
+      let sizeAfter = 0;
+      try { sizeAfter = fs.statSync(dbPath).size; } catch (_) {}
+
+      job.status = 'completed';
+      job.sizeBefore = sizeBefore;
+      job.sizeAfter = sizeAfter;
+      job.reclaimedBytes = sizeBefore - sizeAfter;
+      job.durationMs = Date.now() - job.startedAt;
+    } catch (err) {
+      job.status = 'failed';
+      job.error = err.message;
+      job.durationMs = Date.now() - job.startedAt;
+    } finally {
+      activeVacuumJobId = null;
+    }
+  });
+
+  res.json({ success: true, jobId });
+});
+
+/**
+ * GET /admin/db/vacuum/:jobId
+ * Returns the status of a vacuum job.
+ */
+router.get('/vacuum/:jobId', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res) => {
+  const job = vacuumJobs.get(req.params.jobId);
+  if (!job) {
+    return res.status(404).json({ success: false, error: { code: 'JOB_NOT_FOUND', message: 'Vacuum job not found' } });
+  }
+  res.json({ success: true, data: { jobId: req.params.jobId, ...job } });
+});
+
 module.exports = router;

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -492,6 +492,9 @@ app.get('/suspicious-patterns', require('../middleware/rbac').requireAdmin(), (r
   });
 });
 
+// Database admin endpoints (admin only) — Issue #70
+app.use('/admin/db', dbAdminRoutes);
+
 // Data retention admin endpoints (admin only)
 app.use('/admin/retention', retentionAdminRoutes);
 

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -1301,18 +1301,51 @@ router.get('/pending', checkPermission(PERMISSIONS.DONATIONS_READ), asyncHandler
  * Must be registered before /:id to prevent Express matching "recent" as an id.
  *
  * Query params:
- *   - limit {integer} max results to return (default 10, max 100)
+ *   - limit {integer} max results to return (default 10, max configurable via RECENT_DONATIONS_MAX_LIMIT, default 100)
  */
+const Cache = require('../utils/cache');
+const RECENT_MAX_LIMIT = parseInt(process.env.RECENT_DONATIONS_MAX_LIMIT || '100', 10);
+const RECENT_CACHE_TTL_MS = parseInt(process.env.RECENT_DONATIONS_CACHE_TTL_SECONDS || '5', 10) * 1000;
+
+// Invalidate recent donations cache when a new donation is created
+donationEvents.on(donationEvents.EVENTS.CREATED, () => {
+  Cache.clearPrefix('donations:recent:');
+});
+
 router.get('/recent', checkPermission(PERMISSIONS.DONATIONS_READ), asyncHandler(async (req, res, next) => {
   try {
-    const limit = Math.min(parseInt(req.query.limit, 10) || 10, 100);
+    const rawLimit = req.query.limit;
+
+    let limit = 10;
+    if (rawLimit !== undefined) {
+      const parsed = Number(rawLimit);
+      if (!Number.isInteger(parsed) || parsed <= 0 || String(rawLimit).trim() !== String(Math.floor(parsed))) {
+        return res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_LIMIT', message: 'limit must be a positive integer' },
+        });
+      }
+      limit = Math.min(parsed, RECENT_MAX_LIMIT);
+    }
+
+    const cacheKey = `donations:recent:${limit}`;
+    const cached = Cache.get(cacheKey);
+    if (cached) {
+      res.setHeader('X-Cache', 'HIT');
+      return res.json(cached);
+    }
+
     const Database = require('../utils/database');
     const [rows, countRow] = await Promise.all([
-      Database.query(`SELECT * FROM transactions ORDER BY timestamp DESC LIMIT ?`, [limit]),
-      Database.get(`SELECT COUNT(*) AS total FROM transactions`),
+      Database.query('SELECT * FROM transactions ORDER BY timestamp DESC LIMIT ?', [limit]),
+      Database.get('SELECT COUNT(*) AS total FROM transactions'),
     ]);
+
     res.setHeader('X-Total-Count', String(countRow ? countRow.total : rows.length));
-    res.json({ success: true, data: rows, count: rows.length });
+    const body = { success: true, data: rows, count: rows.length };
+    Cache.set(cacheKey, body, RECENT_CACHE_TTL_MS);
+    res.setHeader('X-Cache', 'MISS');
+    res.json(body);
   } catch (error) {
     next(error);
   }

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -1859,4 +1859,89 @@ router.post('/:id/fund', requireApiKey, checkPermission(PERMISSIONS.WALLETS_UPDA
   }
 }));
 
+const Cache = require('../utils/cache');
+const WALLET_ANALYTICS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * GET /wallets/:id/analytics
+ * Returns aggregated donation analytics for a wallet (by DB id).
+ * Requires wallets:read permission. Cached for 5 minutes.
+ */
+router.get('/:id/analytics', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, asyncHandler(async (req, res) => {
+  const walletId = parseInt(req.params.id, 10);
+
+  const wallet = await Database.get('SELECT id FROM users WHERE id = ?', [walletId]);
+  if (!wallet) {
+    return res.status(404).json({ success: false, error: { code: 'WALLET_NOT_FOUND', message: 'Wallet not found' } });
+  }
+
+  const cacheKey = `wallet:analytics:${walletId}`;
+  const cached = Cache.get(cacheKey);
+  if (cached) return res.json(cached);
+
+  const [outRows, inRows] = await Promise.all([
+    Database.query('SELECT amount, receiverId, timestamp FROM transactions WHERE senderId = ?', [walletId]),
+    Database.query('SELECT amount, senderId, timestamp FROM transactions WHERE receiverId = ?', [walletId]),
+  ]);
+
+  // Aggregate outgoing (donor)
+  const totalDonated = outRows.reduce((s, r) => s + r.amount, 0);
+  const donationCount = outRows.length;
+  const averageDonationAmount = donationCount > 0 ? totalDonated / donationCount : 0;
+  const largestDonation = donationCount > 0 ? Math.max(...outRows.map(r => r.amount)) : 0;
+
+  // Top 5 recipients
+  const recipientTotals = {};
+  for (const r of outRows) {
+    recipientTotals[r.receiverId] = (recipientTotals[r.receiverId] || 0) + r.amount;
+  }
+  const topRecipients = Object.entries(recipientTotals)
+    .sort((a, b) => b[1] - a[1]).slice(0, 5)
+    .map(([id, total]) => ({ walletId: Number(id), total }));
+
+  // Aggregate incoming (recipient)
+  const totalReceived = inRows.reduce((s, r) => s + r.amount, 0);
+  const receiptCount = inRows.length;
+
+  // Top 5 donors
+  const donorTotals = {};
+  for (const r of inRows) {
+    donorTotals[r.senderId] = (donorTotals[r.senderId] || 0) + r.amount;
+  }
+  const topDonors = Object.entries(donorTotals)
+    .sort((a, b) => b[1] - a[1]).slice(0, 5)
+    .map(([id, total]) => ({ walletId: Number(id), total }));
+
+  // Donations by month (last 12 months) — outgoing
+  const now = new Date();
+  const donationsByMonth = [];
+  for (let i = 11; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const month = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    const monthRows = outRows.filter(r => {
+      const t = new Date(r.timestamp);
+      return t.getFullYear() === d.getFullYear() && t.getMonth() === d.getMonth();
+    });
+    donationsByMonth.push({ month, amount: monthRows.reduce((s, r) => s + r.amount, 0), count: monthRows.length });
+  }
+
+  // First/last donation timestamps
+  const allTimestamps = outRows.map(r => r.timestamp).filter(Boolean).sort();
+  const firstDonationAt = allTimestamps.length > 0 ? allTimestamps[0] : null;
+  const lastDonationAt = allTimestamps.length > 0 ? allTimestamps[allTimestamps.length - 1] : null;
+
+  const body = {
+    success: true,
+    data: {
+      totalDonated, totalReceived, donationCount, receiptCount,
+      averageDonationAmount, largestDonation,
+      topRecipients, topDonors, donationsByMonth,
+      firstDonationAt, lastDonationAt,
+    },
+  };
+
+  Cache.set(cacheKey, body, WALLET_ANALYTICS_CACHE_TTL_MS);
+  return res.json(body);
+}));
+
 module.exports = router;

--- a/tests/issues/issues-69-70-71.test.js
+++ b/tests/issues/issues-69-70-71.test.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * Tests for:
+ *   Issue #69 - GET /wallets/:id/analytics
+ *   Issue #70 - POST /admin/db/vacuum + GET /admin/db/vacuum/:jobId
+ *   Issue #71 - GET /donations/recent with limit cap and caching
+ */
+
+const request = require('supertest');
+const express = require('express');
+const Database = require('../../src/utils/database');
+const Cache = require('../../src/utils/cache');
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function adminMiddleware(req, res, next) {
+  req.user = { id: 1, role: 'admin' };
+  req.apiKey = { id: 1, role: 'admin', permissions: ['*'] };
+  next();
+}
+
+function userMiddleware(req, res, next) {
+  req.user = { id: 2, role: 'user' };
+  req.apiKey = { id: 2, role: 'user', permissions: ['wallets:read', 'donations:read'] };
+  next();
+}
+
+function errorHandler(err, req, res, next) {
+  void next;
+  res.status(err.status || err.statusCode || 500).json({
+    success: false,
+    error: { code: err.code || 'ERROR', message: err.message },
+  });
+}
+
+// ─── Issue #69 ────────────────────────────────────────────────────────────────
+
+describe('Issue #69 — GET /wallets/:id/analytics', () => {
+  let app;
+  let walletId;
+  let wallet2Id;
+
+  beforeAll(async () => {
+    // Create test wallets
+    const w1 = await Database.run(
+      "INSERT INTO users (publicKey) VALUES (?)",
+      [`GTEST69A${Date.now()}`]
+    );
+    walletId = w1.id;
+
+    const w2 = await Database.run(
+      "INSERT INTO users (publicKey) VALUES (?)",
+      [`GTEST69B${Date.now()}`]
+    );
+    wallet2Id = w2.id;
+
+    // Insert some transactions: walletId sends to wallet2Id
+    await Database.run(
+      "INSERT INTO transactions (senderId, receiverId, amount, timestamp) VALUES (?, ?, ?, ?)",
+      [walletId, wallet2Id, 10.5, new Date().toISOString()]
+    );
+    await Database.run(
+      "INSERT INTO transactions (senderId, receiverId, amount, timestamp) VALUES (?, ?, ?, ?)",
+      [walletId, wallet2Id, 5.0, new Date().toISOString()]
+    );
+    // wallet2Id sends to walletId
+    await Database.run(
+      "INSERT INTO transactions (senderId, receiverId, amount, timestamp) VALUES (?, ?, ?, ?)",
+      [wallet2Id, walletId, 3.0, new Date().toISOString()]
+    );
+
+    const walletRouter = require('../../src/routes/wallet');
+    app = express();
+    app.use(express.json());
+    app.use(userMiddleware);
+    app.use('/wallets', walletRouter);
+    app.use(errorHandler);
+  });
+
+  afterAll(async () => {
+    Cache.clearPrefix('wallet:analytics:');
+    await Database.run('DELETE FROM transactions WHERE senderId = ? OR receiverId = ?', [walletId, walletId]);
+    await Database.run('DELETE FROM transactions WHERE senderId = ? OR receiverId = ?', [wallet2Id, wallet2Id]);
+    await Database.run('DELETE FROM users WHERE id IN (?, ?)', [walletId, wallet2Id]);
+  });
+
+  it('returns 200 with correct aggregated analytics for wallet with transactions', async () => {
+    const res = await request(app).get(`/wallets/${walletId}/analytics`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const d = res.body.data;
+    expect(d.donationCount).toBe(2);
+    expect(d.totalDonated).toBeCloseTo(15.5);
+    expect(d.receiptCount).toBe(1);
+    expect(d.totalReceived).toBeCloseTo(3.0);
+    expect(d.averageDonationAmount).toBeCloseTo(7.75);
+    expect(d.largestDonation).toBeCloseTo(10.5);
+    expect(Array.isArray(d.topRecipients)).toBe(true);
+    expect(Array.isArray(d.topDonors)).toBe(true);
+    expect(Array.isArray(d.donationsByMonth)).toBe(true);
+    expect(d.donationsByMonth).toHaveLength(12);
+    expect(d.firstDonationAt).not.toBeNull();
+    expect(d.lastDonationAt).not.toBeNull();
+  });
+
+  it('returns 200 with all-zero values for wallet with no transactions', async () => {
+    const w3 = await Database.run("INSERT INTO users (publicKey) VALUES (?)", [`GTEST69C${Date.now()}`]);
+    const res = await request(app).get(`/wallets/${w3.id}/analytics`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.donationCount).toBe(0);
+    expect(res.body.data.totalDonated).toBe(0);
+    expect(res.body.data.receiptCount).toBe(0);
+    expect(res.body.data.firstDonationAt).toBeNull();
+    await Database.run('DELETE FROM users WHERE id = ?', [w3.id]);
+  });
+
+  it('returns 404 for non-existent wallet', async () => {
+    const res = await request(app).get('/wallets/999999/analytics');
+    expect(res.status).toBe(404);
+  });
+
+  it('caches the response (second call returns same data)', async () => {
+    Cache.clearPrefix('wallet:analytics:');
+    const res1 = await request(app).get(`/wallets/${walletId}/analytics`);
+    const res2 = await request(app).get(`/wallets/${walletId}/analytics`);
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(res2.body.data.donationCount).toBe(res1.body.data.donationCount);
+  });
+});
+
+// ─── Issue #70 ────────────────────────────────────────────────────────────────
+
+describe('Issue #70 — POST /admin/db/vacuum', () => {
+  let app;
+  let dbRouter;
+
+  beforeAll(() => {
+    dbRouter = require('../../src/routes/admin/db');
+    app = express();
+    app.use(express.json());
+    app.use(adminMiddleware);
+    app.use('/admin/db', dbRouter);
+    app.use(errorHandler);
+  });
+
+  it('POST /admin/db/vacuum returns 200 with a jobId immediately', async () => {
+    const res = await request(app).post('/admin/db/vacuum');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.jobId).toBe('string');
+    expect(res.body.jobId).toMatch(/^vacuum-/);
+  });
+
+  it('GET /admin/db/vacuum/:jobId returns job status', async () => {
+    // Wait for any previous job to finish before starting a new one
+    for (let i = 0; i < 30; i++) {
+      const probe = await request(app).post('/admin/db/vacuum');
+      if (probe.status === 200) {
+        const { jobId } = probe.body;
+        let statusRes;
+        for (let j = 0; j < 30; j++) {
+          await new Promise(r => setTimeout(r, 100));
+          statusRes = await request(app).get(`/admin/db/vacuum/${jobId}`);
+          if (statusRes.body.data?.status !== 'running') break;
+        }
+        expect(statusRes.status).toBe(200);
+        expect(['completed', 'failed']).toContain(statusRes.body.data.status);
+        if (statusRes.body.data.status === 'completed') {
+          expect(typeof statusRes.body.data.sizeBefore).toBe('number');
+          expect(typeof statusRes.body.data.sizeAfter).toBe('number');
+          expect(typeof statusRes.body.data.reclaimedBytes).toBe('number');
+          expect(typeof statusRes.body.data.durationMs).toBe('number');
+        }
+        return;
+      }
+      await new Promise(r => setTimeout(r, 100));
+    }
+    throw new Error('Could not start a vacuum job within timeout');
+  });
+
+  it('returns 404 for unknown jobId', async () => {
+    const res = await request(app).get('/admin/db/vacuum/vacuum-nonexistent');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 for non-admin user', async () => {
+    const nonAdminApp = express();
+    nonAdminApp.use(express.json());
+    nonAdminApp.use(userMiddleware);
+    nonAdminApp.use('/admin/db', dbRouter);
+    nonAdminApp.use(errorHandler);
+
+    const res = await request(nonAdminApp).post('/admin/db/vacuum');
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── Issue #71 ────────────────────────────────────────────────────────────────
+
+describe('Issue #71 — GET /donations/recent', () => {
+  let app;
+  let testUserIds = [];
+
+  beforeAll(async () => {
+    // Insert a few test transactions
+    const u1 = await Database.run("INSERT INTO users (publicKey) VALUES (?)", [`GTEST71A${Date.now()}`]);
+    const u2 = await Database.run("INSERT INTO users (publicKey) VALUES (?)", [`GTEST71B${Date.now()}`]);
+    testUserIds = [u1.id, u2.id];
+
+    for (let i = 0; i < 5; i++) {
+      await Database.run(
+        "INSERT INTO transactions (senderId, receiverId, amount, timestamp) VALUES (?, ?, ?, ?)",
+        [u1.id, u2.id, i + 1, new Date(Date.now() - i * 1000).toISOString()]
+      );
+    }
+
+    const donationRouter = require('../../src/routes/donation');
+    app = express();
+    app.use(express.json());
+    app.use(userMiddleware);
+    app.use('/donations', donationRouter);
+    app.use(errorHandler);
+  });
+
+  afterAll(async () => {
+    Cache.clearPrefix('donations:recent:');
+    for (const id of testUserIds) {
+      await Database.run('DELETE FROM transactions WHERE senderId = ? OR receiverId = ?', [id, id]);
+      await Database.run('DELETE FROM users WHERE id = ?', [id]);
+    }
+  });
+
+  beforeEach(() => {
+    Cache.clearPrefix('donations:recent:');
+  });
+
+  it('returns 200 with default limit of 10', async () => {
+    const res = await request(app).get('/donations/recent');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.length).toBeLessThanOrEqual(10);
+  });
+
+  it('respects custom limit within cap', async () => {
+    const res = await request(app).get('/donations/recent?limit=3');
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeLessThanOrEqual(3);
+  });
+
+  it('caps limit at RECENT_DONATIONS_MAX_LIMIT (100)', async () => {
+    const res = await request(app).get('/donations/recent?limit=9999');
+    expect(res.status).toBe(200);
+    // Should not error — just capped
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('returns 400 with INVALID_LIMIT for non-integer limit', async () => {
+    const res = await request(app).get('/donations/recent?limit=abc');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_LIMIT');
+  });
+
+  it('returns 400 with INVALID_LIMIT for negative limit', async () => {
+    const res = await request(app).get('/donations/recent?limit=-5');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_LIMIT');
+  });
+
+  it('returns 400 with INVALID_LIMIT for zero limit', async () => {
+    const res = await request(app).get('/donations/recent?limit=0');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_LIMIT');
+  });
+
+  it('returns 400 with INVALID_LIMIT for float limit', async () => {
+    const res = await request(app).get('/donations/recent?limit=1.5');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_LIMIT');
+  });
+
+  it('caches response (X-Cache: HIT on second call)', async () => {
+    const res1 = await request(app).get('/donations/recent?limit=5');
+    expect(res1.status).toBe(200);
+    expect(res1.headers['x-cache']).toBe('MISS');
+
+    const res2 = await request(app).get('/donations/recent?limit=5');
+    expect(res2.status).toBe(200);
+    expect(res2.headers['x-cache']).toBe('HIT');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves three issues in a single PR.

### closes #951  — GET /wallets/:id/analytics
- New endpoint returning aggregated wallet analytics (totalDonated, totalReceived, donationCount, receiptCount, averageDonationAmount, largestDonation, topRecipients, topDonors, donationsByMonth, firstDonationAt, lastDonationAt)
- Requires `wallets:read` permission, cached 5 min, 404 for missing wallet, zeros for wallet with no transactions

### closes #952— POST /admin/db/vacuum
- `POST /admin/db/vacuum` starts background VACUUM job, returns jobId immediately
- `GET /admin/db/vacuum/:jobId` polls status; completed job returns sizeBefore, sizeAfter, reclaimedBytes, durationMs
- Runs `PRAGMA wal_checkpoint(FULL)` before VACUUM, 409 on concurrent jobs, admin-only
- Also mounts `dbAdminRoutes` at `/admin/db` in app.js (was imported but never mounted)

### closes #953 — GET /donations/recent limit cap + caching
- Invalid limit (non-integer, negative, zero, float) returns HTTP 400 `INVALID_LIMIT`
- Capped at `RECENT_DONATIONS_MAX_LIMIT` env var (default 100), default 10
- 5-second response cache with `X-Cache` header, invalidated on `donation.created`

## Tests
16/16 passing in `tests/issues/issues-69-70-71.test.js`