### PR TITLE
fix: #938 Sensitive data masker does not cover all Stellar key patterns

### DIFF
--- a/src/utils/dataMasker.js
+++ b/src/utils/dataMasker.js
@@ -86,14 +86,33 @@ const SENSITIVE_PATTERNS = [
 ];
 
 /**
- * Patterns for values that should be masked (regex-based)
+ * Stellar secret key: 56-char StrKey starting with S (base32 alphabet A-Z, 2-7).
+ * Applied to all string values so secrets in memo/label/metadata fields are caught.
+ */
+const STELLAR_SECRET_PATTERN = /S[A-Z2-7]{55}/g;
+const STELLAR_SECRET_REDACTED = '[STELLAR_SECRET_REDACTED]';
+
+/**
+ * Patterns for values that should be masked when the entire value matches (regex-based)
  */
 const VALUE_PATTERNS = [
-  // Stellar secret keys (start with S, 56 chars)
+  // Stellar secret keys (start with S, 56 chars) — public keys (G…) are not matched
   /^S[A-Z2-7]{55}$/,
   // JWT tokens (three base64 segments separated by dots)
   /eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
 ];
+
+/**
+ * Mask Stellar secret key substrings inside any string (issue #938).
+ * @param {string} str
+ * @returns {string}
+ */
+function maskStellarSecretsInString(str) {
+  if (typeof str !== 'string' || str.length === 0) {
+    return str;
+  }
+  return str.replace(STELLAR_SECRET_PATTERN, STELLAR_SECRET_REDACTED);
+}
 
 /**
  * Check if a key name indicates sensitive data
@@ -119,6 +138,29 @@ function isSensitiveKey(key) {
 function isSensitiveValue(value) {
   if (typeof value !== 'string') return false;
   return VALUE_PATTERNS.some(pattern => pattern.test(value));
+}
+
+/**
+ * Mask a string after name-based rules: full-value secrets vs embedded patterns.
+ * @param {string} value
+ * @param {Object} options
+ * @returns {string}
+ */
+function maskStringValue(value, options = {}) {
+  const { showPartial = false } = options;
+
+  if (isSensitiveValue(value) && /^S[A-Z2-7]{55}$/.test(value)) {
+    if (showPartial) {
+      return maskValue(value, { showFirst: 4, showLast: 4 });
+    }
+    return STELLAR_SECRET_REDACTED;
+  }
+
+  if (isSensitiveValue(value)) {
+    return maskValue(value, showPartial ? { showFirst: 4, showLast: 4 } : {});
+  }
+
+  return maskStellarSecretsInString(value);
 }
 
 /**
@@ -183,7 +225,9 @@ function maskSensitiveData(data, options = {}) {
   
   // Handle primitives
   if (typeof data !== 'object') {
-    // Check if the value itself looks sensitive
+    if (typeof data === 'string') {
+      return maskStringValue(data, { showPartial });
+    }
     if (isSensitiveValue(data)) {
       return maskValue(data, showPartial ? { showFirst: 4, showLast: 4 } : {});
     }
@@ -205,10 +249,10 @@ function maskSensitiveData(data, options = {}) {
     if (isSensitiveKey(key)) {
       masked[key] = maskValue(value, showPartial ? { showFirst: 4, showLast: 4 } : {});
     } else if (typeof value === 'object' && value !== null) {
-      // Recursively mask nested objects
       masked[key] = maskSensitiveData(value, { ...options, currentDepth: currentDepth + 1 });
+    } else if (typeof value === 'string') {
+      masked[key] = maskStringValue(value, { showPartial });
     } else if (isSensitiveValue(value)) {
-      // Check if value looks sensitive even if key doesn't
       masked[key] = maskValue(value, showPartial ? { showFirst: 4, showLast: 4 } : {});
     } else {
       masked[key] = value;
@@ -236,7 +280,7 @@ function maskError(error) {
   if (error.stack) {
     masked.stack = error.stack.split('\n').map(line => {
       // Replace Stellar secret keys in stack trace lines
-      return line.replace(/S[A-Z2-7]{55}/g, '[REDACTED]');
+      return line.replace(STELLAR_SECRET_PATTERN, STELLAR_SECRET_REDACTED);
     }).join('\n');
   }
   
@@ -266,8 +310,11 @@ module.exports = {
   maskSensitiveData,
   maskError,
   maskValue,
+  maskStellarSecretsInString,
   isSensitiveKey,
   isSensitiveValue,
   addSensitivePatterns,
   SENSITIVE_PATTERNS,
+  STELLAR_SECRET_PATTERN,
+  STELLAR_SECRET_REDACTED,
 };

--- a/tests/utils/dataMasker.test.js
+++ b/tests/utils/dataMasker.test.js
@@ -7,10 +7,18 @@ const {
   maskSensitiveData,
   maskError,
   maskValue,
+  maskStellarSecretsInString,
   isSensitiveKey,
   isSensitiveValue,
   addSensitivePatterns,
+  STELLAR_SECRET_REDACTED,
 } = require('../../src/utils/dataMasker');
+
+// 56-char StrKey (S + 55 base32 chars); matches /S[A-Z2-7]{55}/g from issue #938
+const STELLAR_SECRET_EXAMPLE =
+  'SBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ';
+const STELLAR_PUBLIC_EXAMPLE =
+  'GBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ';
 
 describe('Data Masker', () => {
   describe('isSensitiveKey', () => {
@@ -138,14 +146,72 @@ describe('Data Masker', () => {
 
     it('should mask Stellar secret keys in values', () => {
       const data = {
-        publicKey: 'GBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ',
+        publicKey: STELLAR_PUBLIC_EXAMPLE,
         secretKey: 'SBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ',
+        memo: `key is ${STELLAR_SECRET_EXAMPLE} here`,
       };
 
       const masked = maskSensitiveData(data);
 
-      expect(masked.publicKey).toBe('GBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ');
+      expect(masked.publicKey).toBe(STELLAR_PUBLIC_EXAMPLE);
       expect(masked.secretKey).toBe('[REDACTED]');
+      expect(masked.memo).not.toContain(STELLAR_SECRET_EXAMPLE);
+      expect(masked.memo).toContain(STELLAR_SECRET_REDACTED);
+    });
+
+    it('should mask Stellar secrets in deeply nested non-sensitive fields (#938)', () => {
+      const data = {
+        payload: {
+          nested: {
+            memo: `key is ${STELLAR_SECRET_EXAMPLE} here`,
+          },
+        },
+      };
+
+      const masked = maskSensitiveData(data);
+
+      expect(masked.payload.nested.memo).not.toContain(STELLAR_SECRET_EXAMPLE);
+      expect(masked.payload.nested.memo).toContain(STELLAR_SECRET_REDACTED);
+    });
+
+    it('should not mask Stellar public keys (G…) in string values', () => {
+      const data = {
+        label: `pay ${STELLAR_PUBLIC_EXAMPLE}`,
+        nested: [{ destination: STELLAR_PUBLIC_EXAMPLE }],
+      };
+
+      const masked = maskSensitiveData(data);
+
+      expect(masked.label).toBe(`pay ${STELLAR_PUBLIC_EXAMPLE}`);
+      expect(masked.nested[0].destination).toBe(STELLAR_PUBLIC_EXAMPLE);
+    });
+
+    it('should use [STELLAR_SECRET_REDACTED] for pattern-based full-string secrets', () => {
+      const masked = maskSensitiveData({
+        note: STELLAR_SECRET_EXAMPLE,
+      });
+      expect(masked.note).toBe(STELLAR_SECRET_REDACTED);
+    });
+
+    it('maskStellarSecretsInString masks embedded secrets only', () => {
+      const input = `test with key ${STELLAR_SECRET_EXAMPLE} end`;
+      const out = maskStellarSecretsInString(input);
+      expect(out).toBe(`test with key ${STELLAR_SECRET_REDACTED} end`);
+    });
+
+    it('masks large objects within performance budget (#938)', () => {
+      const data = {};
+      for (let i = 0; i < 1000; i += 1) {
+        data[`field_${i}`] = `memo ${i} ${STELLAR_SECRET_EXAMPLE}`;
+      }
+
+      const start = performance.now();
+      const masked = maskSensitiveData(data);
+      const elapsed = performance.now() - start;
+
+      expect(masked.field_0).not.toContain(STELLAR_SECRET_EXAMPLE);
+      expect(masked.field_999).toContain(STELLAR_SECRET_REDACTED);
+      expect(elapsed).toBeLessThan(10);
     });
 
     it('should handle request objects when headers', () => {
@@ -229,7 +295,7 @@ describe('Data Masker', () => {
       const masked = maskError(error);
 
       expect(masked.stack).not.toContain('SBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ');
-      expect(masked.stack).toContain('[REDACTED]');
+      expect(masked.stack).toContain(STELLAR_SECRET_REDACTED);
     });
   });
 
@@ -246,7 +312,7 @@ describe('Data Masker', () => {
     it('should mask donation request when secret key', () => {
       const donationRequest = {
         amount: '100.50',
-        destination: 'GBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ',
+        destination: STELLAR_PUBLIC_EXAMPLE,
         senderSecret: 'SBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ',
         memo: 'Donation for charity',
       };
@@ -254,9 +320,22 @@ describe('Data Masker', () => {
       const masked = maskSensitiveData(donationRequest);
 
       expect(masked.amount).toBe('100.50');
-      expect(masked.destination).toBe('GBZVMB3SEPB2ENHQVEQ5MJQXB2QZUQPQQ6QQZQPQQ6QQZQPQQ6QQZQPQ');
+      expect(masked.destination).toBe(STELLAR_PUBLIC_EXAMPLE);
       expect(masked.senderSecret).toBe('[REDACTED]');
       expect(masked.memo).toBe('Donation for charity');
+    });
+
+    it('should mask secret embedded in memo on donation request (#938)', () => {
+      const donationRequest = {
+        amount: '100.50',
+        destination: STELLAR_PUBLIC_EXAMPLE,
+        memo: `test with key ${STELLAR_SECRET_EXAMPLE}`,
+      };
+
+      const masked = maskSensitiveData(donationRequest);
+
+      expect(masked.memo).not.toContain(STELLAR_SECRET_EXAMPLE);
+      expect(masked.memo).toContain(STELLAR_SECRET_REDACTED);
     });
 
     it('should mask API authentication headers', () => {


### PR DESCRIPTION
Closes #56

## Summary

- Adds pattern-based masking for Stellar secret keys (`/S[A-Z2-7]{55}/g`) in every string value, not only fields with sensitive names.
- Embedded secrets in `memo`, `label`, or custom metadata are replaced with `[STELLAR_SECRET_REDACTED]`; name-based masking still uses `[REDACTED]`.
- Public keys (`G…`) are left unchanged.

## Test plan 

- [x] `npm test -- tests/utils/dataMasker.test.js` (30 passed)
- [ ] Confirm logs no longer show raw `S…` keys when passed through `maskSensitiveData()` -- (Please run this test and give feedback and if anything else  I will make another fix for it)