### PR TITLE
feat: implement issues #65, #66, #67, #68

### DIFF
--- a/src/constants/tags.js
+++ b/src/constants/tags.js
@@ -10,6 +10,31 @@ const PREDEFINED_TAGS = [
   'animal-welfare'
 ];
 
+const CUSTOM_TAG_PATTERN = /^[a-z0-9\-_]+$/;
+const CUSTOM_TAG_MAX_LENGTH = 50;
+
+/**
+ * Validate a single tag value.
+ * @param {string} tag
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+function validateTag(tag) {
+  if (typeof tag !== 'string' || tag.length === 0) {
+    return { valid: false, reason: 'Tag must be a non-empty string' };
+  }
+  if (PREDEFINED_TAGS.includes(tag)) return { valid: true };
+  if (tag.length > CUSTOM_TAG_MAX_LENGTH) {
+    return { valid: false, reason: `Custom tag must be ${CUSTOM_TAG_MAX_LENGTH} characters or fewer` };
+  }
+  if (!CUSTOM_TAG_PATTERN.test(tag)) {
+    return { valid: false, reason: 'Custom tag must match /^[a-z0-9-_]+$/' };
+  }
+  return { valid: true };
+}
+
 module.exports = {
-  PREDEFINED_TAGS
+  PREDEFINED_TAGS,
+  CUSTOM_TAG_PATTERN,
+  CUSTOM_TAG_MAX_LENGTH,
+  validateTag,
 };

--- a/src/jobs/cleanupJob.js
+++ b/src/jobs/cleanupJob.js
@@ -24,7 +24,14 @@ async function runCleanup() {
     console.log(`✓ Cleaned up expired transactions.`);
     console.log(`✓ Cleaned up expired wallets.`);
 
-    // 3. Log the cleanup for audit purposes
+    // 3. Clean up expired refresh token revocations (Issue #68)
+    try {
+      const { cleanupExpiredRevocations } = require('../services/JwtService');
+      const deleted = await cleanupExpiredRevocations();
+      console.log(`✓ Cleaned up ${deleted} expired refresh token revocations.`);
+    } catch (_) { /* table may not exist yet */ }
+
+    // 4. Log the cleanup for audit purposes
     await AuditLogService.log({
       category: AuditLogService.CATEGORY.SYSTEM,
       action: 'SOFT_DELETE_CLEANUP',

--- a/src/middleware/requestSigning.js
+++ b/src/middleware/requestSigning.js
@@ -1,0 +1,145 @@
+/**
+ * Request Signing Middleware (Issue #66)
+ *
+ * When REQUIRE_REQUEST_SIGNING=true, all state-changing requests (POST, PUT, PATCH, DELETE)
+ * must include X-Signature, X-Timestamp, and X-Nonce headers.
+ *
+ * Signing scheme: HMAC-SHA256(signingSecret, method + "\n" + path + "\n" + timestamp + "\n" + nonce + "\n" + bodyHash)
+ *
+ * The signing secret is taken from the authenticated API key's key_secret column.
+ * For global enforcement the secret falls back to REQUEST_SIGNING_SECRET env var.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const { getDefaultStore } = require('../utils/nonceStore');
+const log = require('../utils/log');
+
+const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const DEFAULT_WINDOW_SECONDS = parseInt(process.env.REQUEST_SIGNING_WINDOW_SECONDS || '300', 10);
+
+/**
+ * Compute HMAC-SHA256 over the canonical string.
+ * Canonical: METHOD\npath\ntimestamp\nnonce\nbodyHash
+ */
+function computeSignature(secret, method, path, timestamp, nonce, rawBody) {
+  const bodyHash = crypto.createHash('sha256').update(rawBody || '').digest('hex');
+  const canonical = [method.toUpperCase(), path, timestamp, nonce, bodyHash].join('\n');
+  return crypto.createHmac('sha256', secret).update(canonical).digest('hex');
+}
+
+/**
+ * Constant-time string comparison.
+ */
+function safeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Returns the signing secret for the current request.
+ * Prefers the per-API-key secret; falls back to the global env var.
+ */
+function getSecret(req) {
+  return (req.apiKey && req.apiKey.keySecret) || process.env.REQUEST_SIGNING_SECRET || null;
+}
+
+/**
+ * Express middleware factory.
+ * @param {object} [options]
+ * @param {boolean} [options.enabled] - Override REQUIRE_REQUEST_SIGNING env var
+ * @param {number}  [options.windowSeconds] - Override REQUEST_SIGNING_WINDOW_SECONDS
+ */
+function createRequestSigningMiddleware(options = {}) {
+  const enabled =
+    options.enabled !== undefined
+      ? options.enabled
+      : process.env.REQUIRE_REQUEST_SIGNING === 'true';
+
+  const windowSeconds = options.windowSeconds || DEFAULT_WINDOW_SECONDS;
+
+  return async function requestSigningMiddleware(req, res, next) {
+    if (!enabled) return next();
+    if (!STATE_CHANGING_METHODS.has(req.method)) return next();
+
+    const timestamp = req.get('x-timestamp');
+    const signature = req.get('x-signature');
+    const nonce = req.get('x-nonce');
+
+    // All three headers are required
+    if (!timestamp || !signature || !nonce) {
+      return res.status(401).json({
+        success: false,
+        error: {
+          code: 'SIGNATURE_REQUIRED',
+          message: 'X-Signature, X-Timestamp, and X-Nonce headers are required',
+        },
+      });
+    }
+
+    // Validate timestamp window
+    const tsSeconds = Number(timestamp);
+    if (!Number.isFinite(tsSeconds)) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_SIGNATURE', message: 'Invalid X-Timestamp value' },
+      });
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const age = nowSeconds - tsSeconds;
+    if (age > windowSeconds || age < -30) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_SIGNATURE', message: 'Request timestamp expired or too far in the future' },
+      });
+    }
+
+    // Resolve signing secret
+    const secret = getSecret(req);
+    if (!secret) {
+      log.warn('REQUEST_SIGNING', 'No signing secret available; rejecting signed request', { path: req.path });
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_SIGNATURE', message: 'No signing secret configured for this API key' },
+      });
+    }
+
+    // Verify signature
+    const fullPath = req.originalUrl || req.url;
+    const rawBody = req.rawBody || '';
+    const expected = computeSignature(secret, req.method, fullPath, timestamp, nonce, rawBody);
+
+    if (!safeEqual(signature, expected)) {
+      log.warn('REQUEST_SIGNING', 'Signature mismatch', { path: req.path });
+      return res.status(401).json({
+        success: false,
+        error: { code: 'INVALID_SIGNATURE', message: 'Signature mismatch' },
+      });
+    }
+
+    // Nonce replay check
+    try {
+      const nonceStore = getDefaultStore();
+      const { seen } = await nonceStore.check(nonce);
+      if (seen) {
+        log.warn('REQUEST_SIGNING', 'Replayed nonce rejected', { path: req.path });
+        return res.status(401).json({
+          success: false,
+          error: { code: 'INVALID_SIGNATURE', message: 'Nonce has already been used (replay detected)' },
+        });
+      }
+    } catch (err) {
+      log.error('REQUEST_SIGNING', 'Nonce store error', { error: err.message });
+      // Fail open on nonce store errors to avoid blocking legitimate requests
+    }
+
+    next();
+  };
+}
+
+module.exports = { createRequestSigningMiddleware, computeSignature };

--- a/src/routes/admin/reconciliation.js
+++ b/src/routes/admin/reconciliation.js
@@ -1,21 +1,144 @@
 /**
- * Admin Reconciliation Routes
+ * Admin Reconciliation Routes (Issue #67)
  *
- * RESPONSIBILITY: Expose reconciliation discrepancy report and manual resolution
- * OWNER: Backend Team
+ * POST /admin/reconciliation/run          - Trigger a background reconciliation job
+ * GET  /admin/reconciliation/jobs/:jobId  - Poll job status
+ * GET  /admin/reconciliation/jobs/:jobId/report - Fetch completed report
+ *
+ * Also retains:
+ * GET  /admin/reconciliation/report       - Discrepancy report (existing)
+ * POST /admin/reconciliation/resolve/:txId - Resolve a flagged transaction (existing)
  */
 
 'use strict';
 
 const express = require('express');
 const router = express.Router();
+const crypto = require('crypto');
 const { checkPermission } = require('../../middleware/rbac');
 const { PERMISSIONS } = require('../../utils/permissions');
 const serviceContainer = require('../../config/serviceContainer');
 
+// ─── In-memory job store (TTL 7 days) ────────────────────────────────────────
+
+const JOB_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const _jobs = new Map();
+
+function createJob(walletId) {
+  const jobId = `recon-${crypto.randomUUID()}`;
+  _jobs.set(jobId, {
+    jobId,
+    status: 'queued',
+    walletId: walletId || null,
+    createdAt: new Date().toISOString(),
+    startedAt: null,
+    completedAt: null,
+    report: null,
+    error: null,
+    _expiresAt: Date.now() + JOB_TTL_MS,
+  });
+  return jobId;
+}
+
+function getJob(jobId) {
+  const job = _jobs.get(jobId);
+  if (!job) return null;
+  if (Date.now() > job._expiresAt) { _jobs.delete(jobId); return null; }
+  return job;
+}
+
+/**
+ * Run reconciliation and build the report object.
+ * @param {object} service - TransactionReconciliationService instance
+ * @returns {Promise<object>} report
+ */
+async function runReconciliation(service) {
+  const result = await service.reconcile();
+
+  // Build structured report from reconciliation result + discrepancies
+  const { count: mismatchCount, transactions: discrepancyTxs } = service.getDiscrepancies();
+
+  const discrepancies = discrepancyTxs.map(tx => ({
+    transactionId: tx.id,
+    localAmount: tx.amount,
+    onChainAmount: null, // not available without per-tx Horizon lookup
+    type: tx.reconciliation_reason || 'unknown',
+  }));
+
+  return {
+    matched: result.corrected,
+    mismatched: mismatchCount,
+    onlyInDB: result.orphansDetected - result.orphansCompensated,
+    onlyOnChain: result.orphansCompensated,
+    discrepancies,
+    raw: result,
+  };
+}
+
+// ─── Routes ──────────────────────────────────────────────────────────────────
+
+/**
+ * POST /admin/reconciliation/run
+ * Triggers a background reconciliation job. Returns jobId immediately.
+ * Query: ?walletId= (optional, for future per-wallet scoping)
+ */
+router.post('/run', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res) => {
+  const walletId = req.query.walletId || null;
+  const jobId = createJob(walletId);
+  const job = getJob(jobId);
+
+  // Run asynchronously — do not await
+  setImmediate(async () => {
+    job.status = 'running';
+    job.startedAt = new Date().toISOString();
+    try {
+      const service = serviceContainer.getTransactionReconciliationService();
+      job.report = await runReconciliation(service);
+      job.status = 'completed';
+    } catch (err) {
+      job.status = 'failed';
+      job.error = err.message;
+    } finally {
+      job.completedAt = new Date().toISOString();
+    }
+  });
+
+  return res.status(202).json({ success: true, data: { jobId } });
+});
+
+/**
+ * GET /admin/reconciliation/jobs/:jobId
+ * Returns job status: queued | running | completed | failed
+ */
+router.get('/jobs/:jobId', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res) => {
+  const job = getJob(req.params.jobId);
+  if (!job) {
+    return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Job not found or expired' } });
+  }
+  const { report: _r, _expiresAt: _e, ...summary } = job;
+  return res.json({ success: true, data: summary });
+});
+
+/**
+ * GET /admin/reconciliation/jobs/:jobId/report
+ * Returns the full reconciliation report for a completed job.
+ */
+router.get('/jobs/:jobId/report', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res) => {
+  const job = getJob(req.params.jobId);
+  if (!job) {
+    return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Job not found or expired' } });
+  }
+  if (job.status !== 'completed') {
+    return res.status(409).json({ success: false, error: { code: 'JOB_NOT_COMPLETE', message: `Job status is '${job.status}'` } });
+  }
+  return res.json({ success: true, data: job.report });
+});
+
+// ─── Existing endpoints (retained) ───────────────────────────────────────────
+
 /**
  * GET /admin/reconciliation/report
- * Returns all transactions flagged as reconciliation_needed with counts.
+ * Returns all transactions flagged as reconciliation_needed.
  */
 router.get('/report', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res, next) => {
   try {
@@ -38,8 +161,7 @@ router.get('/report', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res, next) =
 
 /**
  * POST /admin/reconciliation/resolve/:txId
- * Manually resolve a flagged transaction by setting its status.
- *
+ * Manually resolve a flagged transaction.
  * Body: { status: 'confirmed' | 'failed' | 'cancelled' }
  */
 router.post('/resolve/:txId', checkPermission(PERMISSIONS.ADMIN_ALL), (req, res, next) => {

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -215,6 +215,10 @@ app.use(require('../middleware/suspiciousPatternDetection'));
 // Attach user role from authentication (must be before routes)
 app.use(attachUserRole());
 
+// Request signing enforcement (Issue #66) — runs after auth so req.apiKey is populated
+const { createRequestSigningMiddleware } = require('../middleware/requestSigning');
+app.use(createRequestSigningMiddleware());
+
 // Track API quota usage (must be after authentication)
 app.use(trackQuotaUsage);
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -101,10 +101,10 @@ router.post('/refresh', authRefreshRateLimiter, payloadSizeLimiter(ENDPOINT_LIMI
       },
     });
   } catch (err) {
-    if (err.code === 'TOKEN_FAMILY_REVOKED') {
+    if (err.code === 'TOKEN_REUSE_DETECTED' || err.code === 'TOKEN_FAMILY_REVOKED') {
       return res.status(401).json({
         success: false,
-        error: { code: 'TOKEN_FAMILY_REVOKED', message: 'Refresh token reuse detected. All sessions have been revoked.' },
+        error: { code: 'TOKEN_REUSE_DETECTED', message: 'Refresh token reuse detected. All sessions have been revoked.' },
       });
     }
     if (err.code === 'TOKEN_REVOKED') {

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -2590,5 +2590,74 @@ router.get('/stats/by-tag', checkPermission(PERMISSIONS.STATS_READ), statsByTagQ
   }
 }));
 
+// ─── Donation Tags (Issue #65) ────────────────────────────────────────────────
+
+const { validateTag } = require('../constants/tags');
+
+/**
+ * GET /donations/:id/tags
+ * Returns the current list of tags for a donation.
+ * Requires donations:read permission.
+ */
+router.get('/:id/tags', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_READ), donationIdParamSchema, asyncHandler(async (req, res) => {
+  const tx = Transaction.getById(req.params.id);
+  if (!tx) return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Donation not found' } });
+  return res.json({ success: true, data: { tags: tx.tags || [] } });
+}));
+
+/**
+ * POST /donations/:id/tags
+ * Add tags to a donation (idempotent — duplicates are ignored).
+ * Body: { tags: string[] }
+ * Requires donations:write (DONATIONS_UPDATE) permission.
+ */
+router.post('/:id/tags', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_UPDATE), donationIdParamSchema, asyncHandler(async (req, res) => {
+  const tx = Transaction.getById(req.params.id);
+  if (!tx) return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Donation not found' } });
+
+  const { tags } = req.body || {};
+  if (!Array.isArray(tags) || tags.length === 0) {
+    return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: "'tags' must be a non-empty array" } });
+  }
+
+  for (const tag of tags) {
+    const result = validateTag(tag);
+    if (!result.valid) {
+      return res.status(400).json({ success: false, error: { code: 'INVALID_TAG', message: result.reason, tag } });
+    }
+  }
+
+  const existing = new Set(tx.tags || []);
+  for (const tag of tags) existing.add(tag);
+  const updated = Array.from(existing);
+
+  const transactions = Transaction.loadTransactions();
+  const idx = transactions.findIndex(t => t.id === tx.id);
+  transactions[idx].tags = updated;
+  Transaction.saveTransactions(transactions);
+
+  return res.json({ success: true, data: { tags: updated } });
+}));
+
+/**
+ * DELETE /donations/:id/tags/:tag
+ * Remove a specific tag from a donation.
+ * Requires donations:write (DONATIONS_UPDATE) permission.
+ */
+router.delete('/:id/tags/:tag', requireApiKey, checkPermission(PERMISSIONS.DONATIONS_UPDATE), asyncHandler(async (req, res) => {
+  const tx = Transaction.getById(req.params.id);
+  if (!tx) return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Donation not found' } });
+
+  const { tag } = req.params;
+  const updated = (tx.tags || []).filter(t => t !== tag);
+
+  const transactions = Transaction.loadTransactions();
+  const idx = transactions.findIndex(t => t.id === tx.id);
+  transactions[idx].tags = updated;
+  Transaction.saveTransactions(transactions);
+
+  return res.json({ success: true, data: { tags: updated } });
+}));
+
 module.exports = router;
 

--- a/src/services/JwtService.js
+++ b/src/services/JwtService.js
@@ -23,6 +23,7 @@ const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const CREATE_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS refresh_tokens (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    jti TEXT NOT NULL UNIQUE,
     token_hash TEXT NOT NULL UNIQUE,
     api_key_id INTEGER NOT NULL,
     family_id TEXT NOT NULL,
@@ -35,12 +36,28 @@ const CREATE_TABLE_SQL = `
   )
 `;
 
+const CREATE_REVOCATIONS_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS refresh_token_revocations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    jti TEXT NOT NULL UNIQUE,
+    api_key_id INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    revoked_at INTEGER NOT NULL,
+    reason TEXT
+  )
+`;
+
 /**
- * Initializes the refresh_tokens table if it does not exist.
+ * Initializes the refresh_tokens and refresh_token_revocations tables.
  * @returns {Promise<void>}
  */
 async function initializeRefreshTokensTable() {
   await db.run(CREATE_TABLE_SQL);
+  // Add jti column to existing tables that predate this change
+  try { await db.run(`ALTER TABLE refresh_tokens ADD COLUMN jti TEXT`); } catch (_) {}
+  await db.run(CREATE_REVOCATIONS_TABLE_SQL);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_revocations_jti ON refresh_token_revocations(jti)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_revocations_expires ON refresh_token_revocations(expires_at)`);
 }
 
 /**
@@ -109,7 +126,7 @@ function verifyAccessToken(token) {
 }
 
 /**
- * Issues a new refresh token, persists its hash, and returns the raw token.
+ * Issues a new refresh token, persists its hash and jti, and returns the raw token.
  * @param {number} apiKeyId
  * @param {string} familyId - Token family identifier (UUID)
  * @returns {Promise<string>} Raw refresh token (shown once)
@@ -118,11 +135,12 @@ async function issueRefreshToken(apiKeyId, familyId) {
   await initializeRefreshTokensTable();
   const raw = crypto.randomBytes(32).toString('hex');
   const hash = crypto.createHash('sha256').update(raw).digest('hex');
+  const jti = crypto.randomUUID();
   const now = Date.now();
   await db.run(
-    `INSERT INTO refresh_tokens (token_hash, api_key_id, family_id, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?)`,
-    [hash, apiKeyId, familyId, now + REFRESH_TOKEN_TTL_MS, now]
+    `INSERT INTO refresh_tokens (jti, token_hash, api_key_id, family_id, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [jti, hash, apiKeyId, familyId, now + REFRESH_TOKEN_TTL_MS, now]
   );
   return raw;
 }
@@ -135,7 +153,7 @@ async function issueRefreshToken(apiKeyId, familyId) {
  * @param {string} rawRefreshToken - The raw refresh token from the client
  * @returns {Promise<{ accessToken: string, refreshToken: string, apiKeyId: number } | null>}
  *   Returns null if the token is invalid or expired.
- * @throws {Error} With code 'TOKEN_FAMILY_REVOKED' if token reuse is detected
+ * @throws {Error} With code 'TOKEN_REUSE_DETECTED' if token reuse is detected
  */
 async function rotateRefreshToken(rawRefreshToken) {
   await initializeRefreshTokensTable();
@@ -148,6 +166,7 @@ async function rotateRefreshToken(rawRefreshToken) {
   if (!row) return null;
 
   // Token already used → revoke entire family (theft detection)
+  // Check this BEFORE the revocations table so reuse always returns TOKEN_REUSE_DETECTED
   if (row.used_at !== null) {
     log.warn('JWT_SERVICE', 'Refresh token reuse detected — revoking family', {
       familyId: row.family_id,
@@ -164,13 +183,13 @@ async function rotateRefreshToken(rawRefreshToken) {
         severity: 'HIGH',
         result: 'FAILURE',
         userId: String(row.api_key_id),
-        details: { familyId: row.family_id, tokenId: row.id },
+        details: { familyId: row.family_id, tokenId: row.id, jti: row.jti },
         reason: 'Refresh token reuse detected; entire token family revoked',
       });
     } catch (_) { /* audit log failure must not block the security response */ }
 
     const err = new Error('Refresh token reuse detected; token family revoked');
-    err.code = 'TOKEN_FAMILY_REVOKED';
+    err.code = 'TOKEN_REUSE_DETECTED';
     throw err;
   }
 
@@ -180,7 +199,30 @@ async function rotateRefreshToken(rawRefreshToken) {
     throw err;
   }
 
+  // Check revocation table by jti (covers tokens revoked via revokeTokenFamily)
+  if (row.jti) {
+    const revocation = await db.get(
+      `SELECT id FROM refresh_token_revocations WHERE jti = ?`,
+      [row.jti]
+    );
+    if (revocation) {
+      const err = new Error('Refresh token has been revoked');
+      err.code = 'TOKEN_REVOKED';
+      throw err;
+    }
+  }
+
   if (row.expires_at < Date.now()) return null;
+
+  // Insert consumed token's jti into revocations table
+  if (row.jti) {
+    const now = Date.now();
+    await db.run(
+      `INSERT OR IGNORE INTO refresh_token_revocations (jti, api_key_id, expires_at, revoked_at, reason)
+       VALUES (?, ?, ?, ?, ?)`,
+      [row.jti, row.api_key_id, row.expires_at, now, 'ROTATED']
+    );
+  }
 
   // Mark old token as used
   await db.run(
@@ -207,6 +249,62 @@ async function revokeTokenFamily(familyId, reason) {
     `UPDATE refresh_tokens SET revoked = 1, revoked_at = ?, revoke_reason = ? WHERE family_id = ?`,
     [now, reason || null, familyId]
   );
+  // Also insert all active jtis from this family into the revocations table
+  const rows = await db.query(
+    `SELECT jti, api_key_id, expires_at FROM refresh_tokens WHERE family_id = ? AND jti IS NOT NULL`,
+    [familyId]
+  );
+  for (const r of rows) {
+    await db.run(
+      `INSERT OR IGNORE INTO refresh_token_revocations (jti, api_key_id, expires_at, revoked_at, reason)
+       VALUES (?, ?, ?, ?, ?)`,
+      [r.jti, r.api_key_id, r.expires_at, now, reason || 'FAMILY_REVOKED']
+    );
+  }
+}
+
+/**
+ * Verifies a raw refresh token is valid and not revoked.
+ * @param {string} rawRefreshToken
+ * @returns {Promise<{ valid: boolean, row?: object, reason?: string }>}
+ */
+async function verifyRefreshToken(rawRefreshToken) {
+  await initializeRefreshTokensTable();
+  const hash = crypto.createHash('sha256').update(rawRefreshToken).digest('hex');
+  const row = await db.get(`SELECT * FROM refresh_tokens WHERE token_hash = ?`, [hash]);
+
+  if (!row) return { valid: false, reason: 'token not found' };
+  if (row.expires_at < Date.now()) return { valid: false, reason: 'token expired' };
+  if (row.revoked) return { valid: false, reason: 'token revoked' };
+  if (row.used_at !== null) return { valid: false, reason: 'token already used' };
+
+  // Check revocations table by jti
+  if (row.jti) {
+    const revocation = await db.get(
+      `SELECT id FROM refresh_token_revocations WHERE jti = ?`,
+      [row.jti]
+    );
+    if (revocation) return { valid: false, reason: 'token revoked (jti)' };
+  }
+
+  return { valid: true, row };
+}
+
+/**
+ * Delete expired entries from refresh_token_revocations to prevent unbounded growth.
+ * Should be called by a background job periodically.
+ * @returns {Promise<number>} Number of rows deleted
+ */
+async function cleanupExpiredRevocations() {
+  await initializeRefreshTokensTable();
+  const now = Date.now();
+  const result = await db.run(
+    `DELETE FROM refresh_token_revocations WHERE expires_at < ?`,
+    [now]
+  );
+  // Also clean up expired refresh_tokens
+  await db.run(`DELETE FROM refresh_tokens WHERE expires_at < ?`, [now]);
+  return result.changes || 0;
 }
 
 /**
@@ -240,11 +338,13 @@ module.exports = {
   initializeRefreshTokensTable,
   issueAccessToken,
   verifyAccessToken,
+  verifyRefreshToken,
   issueRefreshToken,
   issueTokenPair,
   rotateRefreshToken,
   revokeTokenFamily,
   revokeAllForApiKey,
+  cleanupExpiredRevocations,
   ACCESS_TOKEN_TTL_MS,
   REFRESH_TOKEN_TTL_MS,
 };

--- a/tests/issues-65-66-67-68.test.js
+++ b/tests/issues-65-66-67-68.test.js
@@ -1,0 +1,365 @@
+'use strict';
+
+/**
+ * Tests for Issues #65, #66, #67, #68
+ */
+
+process.env.MOCK_STELLAR = 'true';
+process.env.API_KEYS = 'test-key-1,admin-key';
+process.env.NODE_ENV = 'test';
+process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'test_encryption_key_fixed_32bytes_hex_value_here_00';
+
+const crypto = require('crypto');
+
+// ─── Issue #65: Donation Tags ─────────────────────────────────────────────────
+
+describe('Issue #65 — Donation Tags', () => {
+  const { validateTag, PREDEFINED_TAGS } = require('../src/constants/tags');
+  const Transaction = require('../src/routes/models/transaction');
+
+  beforeEach(() => Transaction._clearAllData());
+
+  describe('validateTag', () => {
+    it('accepts predefined tags', () => {
+      expect(validateTag('education').valid).toBe(true);
+      expect(validateTag('health').valid).toBe(true);
+    });
+
+    it('accepts valid custom tags', () => {
+      expect(validateTag('my-custom-tag').valid).toBe(true);
+      expect(validateTag('project_123').valid).toBe(true);
+    });
+
+    it('rejects tags with uppercase letters', () => {
+      expect(validateTag('Education').valid).toBe(false);
+    });
+
+    it('rejects tags with spaces', () => {
+      expect(validateTag('my tag').valid).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(validateTag('').valid).toBe(false);
+    });
+
+    it('rejects tags longer than 50 characters', () => {
+      expect(validateTag('a'.repeat(51)).valid).toBe(false);
+    });
+
+    it('accepts tags exactly 50 characters', () => {
+      expect(validateTag('a'.repeat(50)).valid).toBe(true);
+    });
+  });
+
+  describe('GET /donations/:id/tags', () => {
+    const express = require('express');
+    const donationRoutes = require('../src/routes/donation');
+
+    function makeApp() {
+      const app = express();
+      app.use(express.json());
+      // Bypass auth for tests
+      app.use((req, _res, next) => {
+        req.apiKey = { id: 1, role: 'admin' };
+        req.user = { id: 1, role: 'admin' };
+        next();
+      });
+      app.use('/donations', donationRoutes);
+      return app;
+    }
+
+    it('returns tags for a donation', async () => {
+      const request = require('supertest');
+      const tx = Transaction.create({ amount: '10', donor: 'd', recipient: 'r', tags: ['education'] });
+      const app = makeApp();
+      const res = await request(app).get(`/donations/${tx.id}/tags`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.tags).toContain('education');
+    });
+
+    it('returns 404 for unknown donation', async () => {
+      const request = require('supertest');
+      const app = makeApp();
+      const res = await request(app).get('/donations/nonexistent-id/tags');
+      expect(res.status).toBe(404);
+    });
+
+    it('POST adds a valid predefined tag', async () => {
+      const request = require('supertest');
+      const tx = Transaction.create({ amount: '10', donor: 'd', recipient: 'r', tags: [] });
+      const app = makeApp();
+      const res = await request(app).post(`/donations/${tx.id}/tags`).send({ tags: ['health'] });
+      expect(res.status).toBe(200);
+      expect(res.body.data.tags).toContain('health');
+    });
+
+    it('POST adds a valid custom tag', async () => {
+      const request = require('supertest');
+      const tx = Transaction.create({ amount: '10', donor: 'd', recipient: 'r', tags: [] });
+      const app = makeApp();
+      const res = await request(app).post(`/donations/${tx.id}/tags`).send({ tags: ['my-custom'] });
+      expect(res.status).toBe(200);
+      expect(res.body.data.tags).toContain('my-custom');
+    });
+
+    it('POST rejects invalid tag format', async () => {
+      const request = require('supertest');
+      const tx = Transaction.create({ amount: '10', donor: 'd', recipient: 'r', tags: [] });
+      const app = makeApp();
+      const res = await request(app).post(`/donations/${tx.id}/tags`).send({ tags: ['INVALID TAG'] });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('INVALID_TAG');
+    });
+
+    it('POST is idempotent — duplicate tag not added twice', async () => {
+      const request = require('supertest');
+      const tx = Transaction.create({ amount: '10', donor: 'd', recipient: 'r', tags: ['education'] });
+      const app = makeApp();
+      await request(app).post(`/donations/${tx.id}/tags`).send({ tags: ['education'] });
+      const res = await request(app).get(`/donations/${tx.id}/tags`);
+      const count = res.body.data.tags.filter(t => t === 'education').length;
+      expect(count).toBe(1);
+    });
+
+    it('DELETE removes a tag', async () => {
+      const request = require('supertest');
+      const tx = Transaction.create({ amount: '10', donor: 'd', recipient: 'r', tags: ['education', 'health'] });
+      const app = makeApp();
+      const res = await request(app).delete(`/donations/${tx.id}/tags/education`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.tags).not.toContain('education');
+      expect(res.body.data.tags).toContain('health');
+    });
+  });
+});
+
+// ─── Issue #66: Request Signing Middleware ────────────────────────────────────
+
+describe('Issue #66 — Request Signing Middleware', () => {
+  const { createRequestSigningMiddleware, computeSignature } = require('../src/middleware/requestSigning');
+  const express = require('express');
+  const request = require('supertest');
+
+  const SECRET = 'test-signing-secret-abc123';
+
+  function makeApp(enabled = true) {
+    const app = express();
+    app.use(express.json({
+      verify: (req, _res, buf) => { req.rawBody = buf.toString('utf8'); }
+    }));
+    app.use((req, _res, next) => {
+      req.apiKey = { id: 1, role: 'user', keySecret: SECRET };
+      next();
+    });
+    app.use(createRequestSigningMiddleware({ enabled }));
+    app.post('/test', (req, res) => res.json({ ok: true }));
+    app.get('/test', (req, res) => res.json({ ok: true }));
+    return app;
+  }
+
+  function signedHeaders(method, path, body = '') {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const nonce = crypto.randomUUID();
+    const signature = computeSignature(SECRET, method, path, timestamp, nonce, body);
+    return { 'x-timestamp': timestamp, 'x-nonce': nonce, 'x-signature': signature };
+  }
+
+  it('passes GET requests without headers when signing enabled', async () => {
+    const res = await request(makeApp()).get('/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST without signing headers — SIGNATURE_REQUIRED', async () => {
+    const res = await request(makeApp()).post('/test').send({});
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('SIGNATURE_REQUIRED');
+  });
+
+  it('accepts POST with valid signature', async () => {
+    const body = JSON.stringify({ foo: 'bar' });
+    const headers = signedHeaders('POST', '/test', body);
+    const res = await request(makeApp())
+      .post('/test')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with tampered body — INVALID_SIGNATURE', async () => {
+    const body = JSON.stringify({ foo: 'bar' });
+    const headers = signedHeaders('POST', '/test', body);
+    const res = await request(makeApp())
+      .post('/test')
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(JSON.stringify({ foo: 'tampered' }));
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_SIGNATURE');
+  });
+
+  it('rejects POST with expired timestamp', async () => {
+    const timestamp = String(Math.floor(Date.now() / 1000) - 400); // 400s ago > 300s window
+    const nonce = crypto.randomUUID();
+    const signature = computeSignature(SECRET, 'POST', '/test', timestamp, nonce, '');
+    const res = await request(makeApp())
+      .post('/test')
+      .set({ 'x-timestamp': timestamp, 'x-nonce': nonce, 'x-signature': signature })
+      .send({});
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('INVALID_SIGNATURE');
+  });
+
+  it('passes all requests when signing disabled', async () => {
+    const res = await request(makeApp(false)).post('/test').send({});
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── Issue #67: Reconciliation Job Endpoints ─────────────────────────────────
+
+describe('Issue #67 — Reconciliation Job Endpoints', () => {
+  const express = require('express');
+  const request = require('supertest');
+  const reconciliationRoutes = require('../src/routes/admin/reconciliation');
+
+  function makeApp() {
+    const app = express();
+    app.use(express.json());
+    // Bypass RBAC for tests
+    app.use((req, _res, next) => {
+      req.user = { id: 1, role: 'admin' };
+      req.apiKey = { id: 1, role: 'admin' };
+      next();
+    });
+    app.use('/admin/reconciliation', reconciliationRoutes);
+    return app;
+  }
+
+  it('POST /run returns 202 with a jobId', async () => {
+    const res = await request(makeApp()).post('/admin/reconciliation/run');
+    expect(res.status).toBe(202);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.jobId).toMatch(/^recon-/);
+  });
+
+  it('GET /jobs/:jobId returns job status', async () => {
+    const app = makeApp();
+    const runRes = await request(app).post('/admin/reconciliation/run');
+    const { jobId } = runRes.body.data;
+
+    const statusRes = await request(app).get(`/admin/reconciliation/jobs/${jobId}`);
+    expect(statusRes.status).toBe(200);
+    expect(['queued', 'running', 'completed', 'failed']).toContain(statusRes.body.data.status);
+  });
+
+  it('GET /jobs/:jobId returns 404 for unknown job', async () => {
+    const res = await request(makeApp()).get('/admin/reconciliation/jobs/recon-nonexistent');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /jobs/:jobId/report returns 409 when job not complete', async () => {
+    const app = makeApp();
+    const runRes = await request(app).post('/admin/reconciliation/run');
+    const { jobId } = runRes.body.data;
+
+    // Immediately poll — job may still be queued/running
+    const reportRes = await request(app).get(`/admin/reconciliation/jobs/${jobId}/report`);
+    // Either 409 (not complete) or 200 (already done) — both are valid
+    expect([200, 409]).toContain(reportRes.status);
+  });
+
+  it('GET /jobs/:jobId/report returns report shape when completed', async () => {
+    const app = makeApp();
+    const runRes = await request(app).post('/admin/reconciliation/run');
+    const { jobId } = runRes.body.data;
+
+    // Wait for job to complete
+    await new Promise(r => setTimeout(r, 200));
+
+    const reportRes = await request(app).get(`/admin/reconciliation/jobs/${jobId}/report`);
+    if (reportRes.status === 200) {
+      expect(reportRes.body.data).toHaveProperty('matched');
+      expect(reportRes.body.data).toHaveProperty('mismatched');
+      expect(reportRes.body.data).toHaveProperty('discrepancies');
+    }
+  });
+});
+
+// ─── Issue #68: Refresh Token Revocation ─────────────────────────────────────
+
+describe('Issue #68 — Refresh Token Revocation', () => {
+  const {
+    issueTokenPair,
+    rotateRefreshToken,
+    verifyRefreshToken,
+    cleanupExpiredRevocations,
+    initializeRefreshTokensTable,
+  } = require('../src/services/JwtService');
+
+  beforeAll(async () => {
+    await initializeRefreshTokensTable();
+  });
+
+  it('issues a token pair successfully', async () => {
+    const { accessToken, refreshToken, familyId } = await issueTokenPair(1, { role: 'user' });
+    expect(typeof accessToken).toBe('string');
+    expect(typeof refreshToken).toBe('string');
+    expect(typeof familyId).toBe('string');
+  });
+
+  it('verifyRefreshToken returns valid for a fresh token', async () => {
+    const { refreshToken } = await issueTokenPair(1, { role: 'user' });
+    const result = await verifyRefreshToken(refreshToken);
+    expect(result.valid).toBe(true);
+  });
+
+  it('verifyRefreshToken returns invalid for unknown token', async () => {
+    const result = await verifyRefreshToken('totally-fake-token');
+    expect(result.valid).toBe(false);
+  });
+
+  it('single use succeeds — rotateRefreshToken returns new tokens', async () => {
+    const { refreshToken } = await issueTokenPair(2, { role: 'user' });
+    const result = await rotateRefreshToken(refreshToken);
+    expect(result).not.toBeNull();
+    expect(typeof result.accessToken).toBe('string');
+    expect(typeof result.refreshToken).toBe('string');
+  });
+
+  it('double use is rejected — second rotation throws TOKEN_REUSE_DETECTED', async () => {
+    const { refreshToken } = await issueTokenPair(3, { role: 'user' });
+    await rotateRefreshToken(refreshToken); // first use — OK
+
+    await expect(rotateRefreshToken(refreshToken)).rejects.toMatchObject({
+      code: 'TOKEN_REUSE_DETECTED',
+    });
+  });
+
+  it('after theft detection, new token from same family is also revoked', async () => {
+    const { refreshToken } = await issueTokenPair(4, { role: 'user' });
+    const rotated = await rotateRefreshToken(refreshToken); // first use — OK
+
+    // Simulate theft: use old token again → revokes family
+    await expect(rotateRefreshToken(refreshToken)).rejects.toMatchObject({
+      code: 'TOKEN_REUSE_DETECTED',
+    });
+
+    // New token from same family should now be rejected
+    await expect(rotateRefreshToken(rotated.refreshToken)).rejects.toMatchObject({
+      code: 'TOKEN_REVOKED',
+    });
+  });
+
+  it('verifyRefreshToken returns invalid after token is consumed', async () => {
+    const { refreshToken } = await issueTokenPair(5, { role: 'user' });
+    await rotateRefreshToken(refreshToken);
+    const result = await verifyRefreshToken(refreshToken);
+    expect(result.valid).toBe(false);
+  });
+
+  it('cleanupExpiredRevocations runs without error', async () => {
+    const deleted = await cleanupExpiredRevocations();
+    expect(typeof deleted).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

Implements four issues in a single PR.

### closes #947 — POST /donations/:id/tags
- `GET /donations/:id/tags` — list tags (donations:read)
- `POST /donations/:id/tags` — add tags, idempotent (donations:update)
- `DELETE /donations/:id/tags/:tag` — remove a tag (donations:update)
- `validateTag()` in `constants/tags.js`: accepts predefined tags or custom strings matching `/^[a-z0-9-_]+$/` up to 50 chars

### closes #948 — Request signing verification middleware
- New `src/middleware/requestSigning.js`: HMAC-SHA256 over `METHOD+path+timestamp+nonce+bodyHash`
- Enabled globally via `REQUIRE_REQUEST_SIGNING=true`
- Applies to POST/PUT/PATCH/DELETE; GET/HEAD pass through
- Returns `SIGNATURE_REQUIRED` (missing headers) or `INVALID_SIGNATURE`
- Nonce replay protection; configurable window via `REQUEST_SIGNING_WINDOW_SECONDS` (default 300s)

### closes #949 — Async reconciliation job endpoints
- `POST /admin/reconciliation/run` — triggers background job, returns `{ jobId }` immediately (202)
- `GET /admin/reconciliation/jobs/:jobId` — poll status: queued/running/completed/failed
- `GET /admin/reconciliation/jobs/:jobId/report` — fetch completed report with matched/mismatched/discrepancies
- Jobs retained for 7 days; existing `/report` and `/resolve/:txId` endpoints retained

### closes #950 — Refresh token revocation with jti
- Added `jti` column to `refresh_tokens` table
- Created `refresh_token_revocations` table (jti, expires_at) for single-use enforcement
- `rotateRefreshToken` inserts consumed jti into revocations on each rotation
- `revokeTokenFamily` inserts all family jtis into revocations
- New `verifyRefreshToken()` checks used_at, revoked flag, and revocations table
- New `cleanupExpiredRevocations()` wired into the cleanup job (prevents unbounded growth)
- Token reuse now throws `TOKEN_REUSE_DETECTED` (was `TOKEN_FAMILY_REVOKED`)

## Tests
33 tests in `tests/issues-65-66-67-68.test.js`, all passing.