### PR TITLE
 feat: expand README troubleshooting, add shared CSV serializer, add PR template (#1104 #1114 #1098)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+## Linked Issue
+
+Closes #<!-- issue number -->
+
+## Type of Change
+
+<!-- Check all that apply -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code quality
+- [ ] Documentation
+- [ ] Tests
+- [ ] CI / tooling
+
+## Test Evidence
+
+<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->
+
+```
+npm test
+```
+
+## Checklist
+
+- [ ] Lint passes (`npm run lint`)
+- [ ] All tests pass (`npm test`)
+- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
+- [ ] Database migration included if schema changed
+- [ ] Documentation updated if behaviour changed

--- a/README.md
+++ b/README.md
@@ -452,10 +452,86 @@ Having issues? We've got you covered!
 - **Port in use?** Kill process: `kill -9 $(lsof -ti:3000)`
 - **Dependencies broken?** Fresh install: `rm -rf node_modules package-lock.json && npm install`
 
-### Common Issues
-- Missing `.env` file → `cp .env.example .env`
-- API keys required → Add `API_KEYS=dev_key_123` to `.env`
-- Use mock mode for development → `MOCK_STELLAR=true`
+### Common Issues and Fixes
+
+#### `Error: ENCRYPTION_KEY is required in production`
+The server refuses to start without an encryption key when `NODE_ENV=production`.
+
+```bash
+# Generate a key
+npm run generate-key
+# Copy the output into .env
+ENCRYPTION_KEY=<64-char hex output>
+```
+
+If you are running locally, set `NODE_ENV=development` to skip enforcement, or provide a key regardless (recommended).
+
+#### Server exits immediately with "No valid API keys configured"
+`API_KEYS` is missing or empty. Add at least one key to `.env`:
+
+```env
+API_KEYS=dev_key_1234567890
+```
+
+To use the database-backed key system instead (recommended for production):
+
+```bash
+npm run keys:create -- --name "My Key" --role user --expires 365
+```
+
+#### Database not initialized / `SQLITE_ERROR: no such table`
+Run the init script before the first start:
+
+```bash
+npm run init-db
+```
+
+If the database exists but is missing new tables introduced by a migration, run:
+
+```bash
+npm run migrate
+```
+
+#### Port 3000 already in use
+Kill whatever process owns the port:
+
+```bash
+kill -9 $(lsof -ti:3000)
+```
+
+Or change the port in `.env`:
+
+```env
+PORT=3001
+```
+
+#### Optional integrations failing silently
+
+The following integrations are **completely optional**. If their env vars are absent the feature is disabled and the API continues working:
+
+| Integration | Required vars | Fallback behaviour |
+|-------------|---------------|--------------------|
+| CoinGecko price oracle | `COINGECKO_API_KEY` | Public rate-limited endpoint is used |
+| IPFS certificate pinning | `PINATA_API_KEY`, `PINATA_SECRET_KEY` | Certificates stored in local memory only |
+| Email receipts (SMTP) | `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` | Email delivery skipped/graceful failure |
+| Geographic IP blocking | `GEO_BLOCKED_COUNTRIES`, `MAXMIND_DB_PATH` | All IPs allowed; no geo rules applied |
+| KMS key wrapping | `KMS_KEY_ID`, `AWS_REGION` | Software-only encryption is used |
+| Webhooks (external) | `WEBHOOK_SECRET` | Outbound webhooks still fire; no signature |
+
+To confirm which integrations are active at runtime, call `GET /health` — the response includes dependency status.
+
+#### Missing `.env` file
+```bash
+cp .env.example .env
+# Then edit .env — at minimum set ENCRYPTION_KEY and API_KEYS
+```
+
+#### Mock mode for local development
+Avoid needing a real Stellar account during development:
+
+```env
+MOCK_STELLAR=true
+```
 
 ### Get Help
 - **[Full Troubleshooting Guide](docs/DEVELOPER_TROUBLESHOOTING_GUIDE.md)** - Comprehensive solutions
@@ -468,6 +544,139 @@ Enable detailed logging for troubleshooting:
 ```bash
 DEBUG_MODE=true LOG_VERBOSE=true npm start
 ```
+
+---
+
+## ⚙️ Environment Variable Reference
+
+All variables are read from the `.env` file in the project root (see `.env.example`).
+
+### Server
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PORT` | No | `3000` | Port the HTTP server listens on (1–65535) |
+| `NODE_ENV` | No | `development` | Runtime environment (`development` \| `production` \| `test`) |
+
+### Authentication
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `API_KEYS` | **Yes** (legacy) | — | Comma-separated list of accepted API keys. Not needed when using database-backed keys exclusively. |
+
+### Encryption
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ENCRYPTION_KEY` | **Yes** in production | — | 64-character hex string (32 bytes) used to encrypt sensitive data. Generate with `npm run generate-key`. Changing this makes previously-encrypted data unrecoverable. |
+
+### Stellar Network
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `STELLAR_NETWORK` | No | `testnet` | Target network: `testnet` \| `mainnet` \| `futurenet` |
+| `MOCK_STELLAR` | No | `true` | When `true`, no outbound Stellar calls are made. Recommended for local dev and CI. |
+| `HORIZON_URL` | No | network default | Override the Horizon API endpoint |
+
+### Database
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DB_PATH` | No | `./data/stellar_donations.db` | Path to the SQLite file |
+| `DB_POOL_SIZE` | No | `5` | Number of pooled SQLite connections |
+| `DB_ACQUIRE_TIMEOUT` | No | `10000` | Milliseconds to wait for a connection before timing out |
+
+### CORS
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CORS_ALLOWED_ORIGINS` | No | `http://localhost:3000,...` | Comma-separated allowed origins for browser clients |
+| `CORS_ALLOWED_METHODS` | No | standard verbs | Override allowed HTTP methods |
+| `CORS_ALLOWED_HEADERS` | No | standard headers | Override allowed request headers |
+| `CORS_MAX_AGE` | No | `86400` | Preflight cache duration in seconds |
+
+### Logging
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DEBUG_MODE` | No | `false` | Enable verbose debug logging. **Never enable in production.** |
+| `LOG_TO_FILE` | No | `false` | Write logs to files in addition to stdout |
+| `LOG_DIR` | No | `./logs` | Directory for log files (used when `LOG_TO_FILE=true`) |
+| `LOG_VERBOSE` | No | `false` | Include request/response bodies in console output |
+
+### Donation Limits
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MIN_DONATION_AMOUNT` | No | `0.01` | Minimum donation amount in XLM |
+| `MAX_DONATION_AMOUNT` | No | `10000` | Maximum donation amount in XLM |
+| `MAX_DAILY_DONATION_PER_DONOR` | No | `0` (no limit) | Daily cap per donor in XLM |
+
+### Rate Limiting
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `RATE_LIMIT` | No | `100` | Maximum requests per IP per window |
+| `AUTH_TOKEN_RATE_LIMIT` | No | `10` | Auth token endpoint requests per minute per IP |
+| `AUTH_REFRESH_RATE_LIMIT` | No | `20` | Auth refresh endpoint requests per minute per IP |
+
+### Optional Integrations
+
+All variables in this section are **optional**. Omitting them disables the integration gracefully.
+
+#### CoinGecko (Price Oracle)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `COINGECKO_API_KEY` | — | API key for XLM/fiat rates. Without it the public (rate-limited) endpoint is used. |
+
+#### IPFS Certificate Pinning (Pinata)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PINATA_API_KEY` | — | Pinata API key for IPFS certificate pinning |
+| `PINATA_SECRET_KEY` | — | Pinata secret key |
+| `IPFS_GATEWAY_URL` | `https://gateway.pinata.cloud/ipfs` | Public IPFS gateway base URL |
+
+#### Email Receipts (SMTP)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SMTP_HOST` | — | SMTP relay hostname |
+| `SMTP_PORT` | `587` | SMTP port |
+| `SMTP_SECURE` | `false` | Use TLS (`true`) or STARTTLS (`false`) |
+| `SMTP_USER` | — | SMTP authentication username |
+| `SMTP_PASS` | — | SMTP authentication password |
+| `SMTP_FROM` | — | Sender address (must be verified with your provider) |
+
+#### Geographic IP Blocking
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GEO_BLOCKED_COUNTRIES` | — | Comma-separated ISO country codes to block (e.g. `RU,IR,KP`) |
+| `GEO_ALLOWED_COUNTRIES` | — | Comma-separated ISO country codes to always allow (overrides blocked list) |
+| `GEO_ALLOWED_IPS` | — | Comma-separated IPs / CIDR ranges that bypass geo-blocking |
+| `MAXMIND_DB_PATH` | `./data/GeoLite2-Country.mmdb` | Path to MaxMind GeoLite2 database file |
+
+#### KMS Key Wrapping
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KMS_KEY_ID` | — | AWS KMS key ID or ARN for envelope encryption |
+| `AWS_REGION` | — | AWS region for KMS calls |
+
+#### Webhooks
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WEBHOOK_SECRET` | — | HMAC secret used to sign outbound webhook payloads |
+| `SIGNED_URL_EXPIRY_MS` | `3600000` (1 hour) | Expiry for signed export download URLs |
+
+#### Service Account
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SERVICE_SECRET_KEY` | — | Stellar secret key for service-side signing. **Never commit a real key.** |
 
 ## 🔧 Configuration
 

--- a/src/routes/impact.js
+++ b/src/routes/impact.js
@@ -17,6 +17,7 @@ const { checkPermission } = require('../middleware/rbac');
 const { PERMISSIONS } = require('../utils/permissions');
 const Transaction = require('../models/transaction');
 const { SDG_CATEGORIES} = require('../services/ImpactMetricService');
+const { serialize: csvSerialize } = require('../utils/csvSerializer');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -143,18 +144,27 @@ router.post('/report/export', requireApiKey, checkPermission(PERMISSIONS.DONATIO
     const totalAmount = txs.reduce((sum, tx) => sum + (parseFloat(tx.amount) || 0), 0);
 
     if (format === 'csv') {
-      const lines = [
-        'SDG Code,Goal,Title,Total Amount (XLM),Donation Count',
-        ...breakdown.map(s =>
-          `${s.code},${s.goal},"${s.title}",${s.totalAmount.toFixed(7)},${s.count}`
-        ),
-        '',
-        `Total,,All SDGs,${totalAmount.toFixed(7)},${txs.length}`,
+      const headers = ['SDG Code', 'Goal', 'Title', 'Total Amount (XLM)', 'Donation Count'];
+      const rows = [
+        ...breakdown.map(s => ({
+          'SDG Code': s.code,
+          'Goal': s.goal,
+          'Title': s.title,
+          'Total Amount (XLM)': s.totalAmount.toFixed(7),
+          'Donation Count': s.count,
+        })),
+        {
+          'SDG Code': 'Total',
+          'Goal': '',
+          'Title': 'All SDGs',
+          'Total Amount (XLM)': totalAmount.toFixed(7),
+          'Donation Count': txs.length,
+        },
       ];
 
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader('Content-Disposition', `attachment; filename="impact-report-${Date.now()}.csv"`);
-      return res.send(lines.join('\n'));
+      return res.send(csvSerialize(headers, rows));
     }
 
     // PDF: return a minimal text-based PDF

--- a/src/services/AuditLogExportService.js
+++ b/src/services/AuditLogExportService.js
@@ -16,6 +16,7 @@ const Database = require('../utils/database');
 const log = require('../utils/log');
 const { ValidationError, NotFoundError, ERROR_CODES } = require('../utils/errors');
 const crypto = require('crypto');
+const { serialize: csvSerialize } = require('../utils/csvSerializer');
 
 /**
  * Export status constants
@@ -170,7 +171,6 @@ class AuditLogExportService {
       return '';
     }
 
-    // CSV headers
     const headers = [
       'id',
       'timestamp',
@@ -183,39 +183,10 @@ class AuditLogExportService {
       'ipAddress',
       'resource',
       'reason',
-      'details'
+      'details',
     ];
 
-    const csvRows = [headers.join(',')];
-
-    // CSV data rows
-    for (const log of logs) {
-      const row = [
-        log.id,
-        log.timestamp,
-        log.category,
-        log.action,
-        log.severity,
-        log.result,
-        log.userId || '',
-        log.requestId || '',
-        log.ipAddress || '',
-        log.resource || '',
-        log.reason || '',
-        JSON.stringify(log.details || {})
-      ].map(field => {
-        // Escape CSV fields
-        const stringField = String(field);
-        if (stringField.includes(',') || stringField.includes('"') || stringField.includes('\n')) {
-          return `"${stringField.replace(/"/g, '""')}"`;
-        }
-        return stringField;
-      });
-
-      csvRows.push(row.join(','));
-    }
-
-    return csvRows.join('\n');
+    return csvSerialize(headers, logs);
   }
 
   /**

--- a/src/services/DonationExportService.js
+++ b/src/services/DonationExportService.js
@@ -17,6 +17,7 @@ const Database = require('../utils/database');
 const log = require('../utils/log');
 const { ValidationError, NotFoundError } = require('../utils/errors');
 const { ERROR_CODES } = require('../utils/errors');
+const { serialize: csvSerialize } = require('../utils/csvSerializer');
 
 const EXPORT_DIR = path.join(__dirname, '../../data/exports');
 const EXPORT_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -306,23 +307,7 @@ class DonationExportService {
       'timestamp',
       'transactionHash',
     ];
-
-    const csvEscape = (value) => {
-      if (value === null || value === undefined) return '';
-      const str = String(value);
-      if (str.includes('"') || str.includes(',') || str.includes('\n')) {
-        return `"${str.replace(/"/g, '""')}"`;
-      }
-      return str;
-    };
-
-    const rows = [headers.join(',')];
-    for (const donation of donations) {
-      const row = headers.map((h) => csvEscape(donation[h])).join(',');
-      rows.push(row);
-    }
-
-    return rows.join('\n');
+    return csvSerialize(headers, donations);
   }
 
   /**

--- a/src/utils/csvSerializer.js
+++ b/src/utils/csvSerializer.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * Hardened CSV serializer (Issue #1114)
+ *
+ * Handles:
+ * - Embedded commas, double-quotes, newlines, carriage returns
+ * - Formula-injection neutralization (=, +, -, @, tab, carriage-return prefixes)
+ * - UTF-8 BOM prefix for correct Excel opening
+ * - Consistent quoting rules across all CSV producers
+ */
+
+/** Characters that trigger formula injection in spreadsheet apps */
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r']);
+
+/**
+ * Escape a single CSV field value.
+ *
+ * Rules:
+ *  1. Null / undefined → empty string
+ *  2. Objects → JSON-stringified
+ *  3. Fields starting with a formula prefix get a leading single-quote neutralizer
+ *  4. Fields containing comma, double-quote, newline, or carriage-return are
+ *     wrapped in double-quotes; internal double-quotes are doubled
+ *
+ * @param {*} value - The raw field value
+ * @returns {string} Safe CSV field (may or may not be quoted)
+ */
+function escapeField(value) {
+  if (value === null || value === undefined) return '';
+
+  let str;
+  if (typeof value === 'object') {
+    str = JSON.stringify(value);
+  } else {
+    str = String(value);
+  }
+
+  // Neutralize formula-injection prefixes
+  if (FORMULA_PREFIXES.has(str.charAt(0))) {
+    str = `'${str}`;
+  }
+
+  // Quote if the field contains special characters
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+
+  return str;
+}
+
+/**
+ * Serialize an array of row objects to a CSV string.
+ *
+ * @param {string[]} headers      - Ordered list of column names (used as header row and object keys)
+ * @param {Object[]} rows         - Array of plain objects; missing keys become empty strings
+ * @param {Object}  [options]
+ * @param {boolean} [options.bom=false]   - Prepend UTF-8 BOM (for Excel compatibility)
+ * @param {string}  [options.delimiter=','] - Field delimiter (default comma)
+ * @param {string}  [options.lineEnding='\n'] - Row terminator (default LF)
+ * @returns {string} Complete CSV text
+ */
+function serialize(headers, rows, options = {}) {
+  const {
+    bom = false,
+    delimiter = ',',
+    lineEnding = '\n',
+  } = options;
+
+  const output = [];
+
+  if (bom) {
+    output.push('\uFEFF');
+  }
+
+  // Header row
+  output.push(headers.map(h => escapeField(h)).join(delimiter));
+
+  // Data rows
+  for (const row of rows) {
+    const cells = headers.map(h => escapeField(row[h]));
+    output.push(cells.join(delimiter));
+  }
+
+  return output.join(lineEnding);
+}
+
+module.exports = { escapeField, serialize };

--- a/tests/utils/csv-serializer.test.js
+++ b/tests/utils/csv-serializer.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const { escapeField, serialize } = require('../../src/utils/csvSerializer');
+
+describe('csvSerializer', () => {
+  describe('escapeField', () => {
+    it('returns empty string for null', () => {
+      expect(escapeField(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+      expect(escapeField(undefined)).toBe('');
+    });
+
+    it('passes through plain strings unchanged', () => {
+      expect(escapeField('hello')).toBe('hello');
+    });
+
+    it('wraps fields containing a comma in double-quotes', () => {
+      expect(escapeField('hello, world')).toBe('"hello, world"');
+    });
+
+    it('wraps fields containing a double-quote and escapes it', () => {
+      expect(escapeField('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    it('wraps fields containing a newline', () => {
+      expect(escapeField('line1\nline2')).toBe('"line1\nline2"');
+    });
+
+    it('wraps fields containing a carriage return', () => {
+      expect(escapeField('line1\rline2')).toBe('"line1\rline2"');
+    });
+
+    it('neutralizes = formula prefix', () => {
+      expect(escapeField('=CMD')).toBe("'=CMD");
+    });
+
+    it('neutralizes + formula prefix', () => {
+      expect(escapeField('+1')).toBe("'+1");
+    });
+
+    it('neutralizes - formula prefix', () => {
+      expect(escapeField('-1')).toBe("'-1");
+    });
+
+    it('neutralizes @ formula prefix', () => {
+      expect(escapeField('@SUM')).toBe("'@SUM");
+    });
+
+    it('serializes objects via JSON.stringify', () => {
+      const obj = { key: 'val' };
+      const result = escapeField(obj);
+      expect(result).toContain('"key"');
+      expect(result).toContain('"val"');
+    });
+
+    it('handles numbers', () => {
+      expect(escapeField(42)).toBe('42');
+    });
+
+    it('handles booleans', () => {
+      expect(escapeField(true)).toBe('true');
+    });
+  });
+
+  describe('serialize', () => {
+    const headers = ['id', 'name', 'amount'];
+    const rows = [
+      { id: 1, name: 'Alice', amount: 10.5 },
+      { id: 2, name: 'Bob', amount: 20.0 },
+    ];
+
+    it('produces correct header row', () => {
+      const csv = serialize(headers, rows);
+      const lines = csv.split('\n');
+      expect(lines[0]).toBe('id,name,amount');
+    });
+
+    it('produces correct data rows', () => {
+      const csv = serialize(headers, rows);
+      const lines = csv.split('\n');
+      expect(lines[1]).toBe('1,Alice,10.5');
+      expect(lines[2]).toBe('2,Bob,20');
+    });
+
+    it('handles empty rows array', () => {
+      const csv = serialize(headers, []);
+      expect(csv).toBe('id,name,amount');
+    });
+
+    it('handles missing fields as empty strings', () => {
+      const csv = serialize(headers, [{ id: 1 }]);
+      const lines = csv.split('\n');
+      expect(lines[1]).toBe('1,,');
+    });
+
+    it('escapes embedded commas in data', () => {
+      const csv = serialize(['name'], [{ name: 'Smith, John' }]);
+      expect(csv).toBe('name\n"Smith, John"');
+    });
+
+    it('escapes embedded quotes in data', () => {
+      const csv = serialize(['name'], [{ name: 'say "hi"' }]);
+      expect(csv).toBe('name\n"say ""hi"""');
+    });
+
+    it('escapes embedded newlines in data', () => {
+      const csv = serialize(['notes'], [{ notes: 'line1\nline2' }]);
+      expect(csv).toBe('notes\n"line1\nline2"');
+    });
+
+    it('neutralizes formula-injection payloads', () => {
+      const csv = serialize(['formula'], [{ formula: '=HYPERLINK("evil")' }]);
+      expect(csv).toContain("'=");
+    });
+
+    it('prepends UTF-8 BOM when bom option is true', () => {
+      const csv = serialize(headers, [], { bom: true });
+      expect(csv.charCodeAt(0)).toBe(0xfeff);
+    });
+
+    it('respects custom delimiter', () => {
+      const csv = serialize(headers, rows, { delimiter: ';' });
+      const lines = csv.split('\n');
+      expect(lines[0]).toBe('id;name;amount');
+    });
+
+    it('respects custom line ending', () => {
+      const csv = serialize(headers, rows, { lineEnding: '\r\n' });
+      expect(csv).toContain('\r\n');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1104
closes #1114
closes #1098 

 
 Description:
  
  This PR addresses three issues in a single branch: documentation improvements, a security-hardened CSV serializer, and a pull request template.
  
  
  Changes
  
  Expand README troubleshooting and environment-variable reference (closes #1104)
  
  The README troubleshooting section was minimal and didn't cover the most common failure modes developers encounter. This update adds:
  
  - Detailed fixes for each common failure:
    - ENCRYPTION_KEY is required in production — explains how to generate and set the key, and the NODE_ENV=development bypass for local use
    - No valid API keys configured — how to add API_KEYS to .env or switch to database-backed keys
    - SQLITE_ERROR: no such table — when to run npm run init-db vs npm run migrate
    - Port already in use — how to kill the process or change the port
    - Silent optional integration failures — a table mapping each integration (CoinGecko, IPFS/Pinata, SMTP, geo/MaxMind, KMS, webhooks) to its required
  env vars and its graceful fallback behaviour
  
  - Full categorized environment variable reference table consistent with .env.example, covering all variables across: Server, Authentication, Encryption,
  Stellar Network, Database, CORS, Logging, Donation Limits, Rate Limiting, and all optional integrations — each marked required or optional with its
  default value and purpose.
  
  
  Shared hardened CSV serializer — replace all ad-hoc escaping (closes #1114)
  
  Multiple endpoints were producing CSV output using duplicated, inconsistent string concatenation that was vulnerable to formula injection and could
  produce malformed output for embedded commas, quotes, or newlines.
  
  New file: src/utils/csvSerializer.js
  
  A single shared serializer with:
  
  - escapeField(value) — null/undefined → empty string; objects → JSON-stringified; fields with ,, ", \n, \r → properly double-quoted with internal quotes
  doubled
  - Formula-injection neutralization: fields starting with =, +, -, @, \t, or \r get a leading ' prefix (standard spreadsheet neutralization)
  - serialize(headers, rows, options) — builds a complete CSV string; supports optional UTF-8 BOM (for Excel), custom delimiter, and custom line ending
  
  Updated producers (all now delegate to csvSerialize()):
  
  - src/services/DonationExportService.js — convertToCSV() replaced
  - src/services/AuditLogExportService.js — convertToCSV() replaced
  - src/routes/impact.js — POST /impact/report/export CSV path replaced
  
  Tests: tests/utils/csv-serializer.test.js — 25 unit tests covering:
  
  - Null, undefined, numbers, booleans, objects
  - Embedded commas, double-quotes, newlines, carriage returns
  - Formula-injection payloads (=CMD, +1, -1, @SUM)
  - BOM prefix, custom delimiter, custom line ending
  - Missing fields, empty row arrays
  
  All 25 tests pass.
  
  
   Add pull request template (closes #1098)
  
  The repo had issue templates but no PR template. Added .github/PULL_REQUEST_TEMPLATE.md prompting contributors for:
  
  - Summary of changes
  - Linked issue number
  - Type of change (bug fix / feature / refactor / docs / tests / CI)
  - Test evidence (output or commands run)
  - Checklist: lint passing, tests passing, openapi:check passing, migrations included if schema changed, docs updated
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Commits
  
  7f3d95b docs: expand README troubleshooting and env-var reference (#1104)
  f441a74 feat: introduce shared CSV serializer, replace ad-hoc escaping (#1114)
  da6e7c6 ci: add pull request template (#1098)
  

  
  