### PR TITLE
fix: persistence, rate limit store, SSE pub/sub, HSM fencing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 API_KEYS=ci_key npm run validate-env
       - run: npm run test:coverage:ci
       - run: npm run openapi:check
+      - run: npm run check:no-json-persistence
       - run: npm audit --audit-level=high
 
   smoke:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:load:jest": "jest tests/implement-load-testing-suite.test.js --testTimeout=60000 --forceExit",
     "test:smoke": "jest --config jest.config.smoke.js --forceExit",
     "changelog": "node scripts/generate-changelog.js",
-    "changelog:write": "node scripts/generate-changelog.js --write"
+    "changelog:write": "node scripts/generate-changelog.js --write",
+    "check:no-json-persistence": "node scripts/check-no-json-persistence.js"
   },
   "dependencies": {
     "csv-parse": "^6.2.1",

--- a/scripts/check-no-json-persistence.js
+++ b/scripts/check-no-json-persistence.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * CI guard — fail if any production source file references the legacy JSON stores
+ * in executable code (not in comments).
+ *
+ * Patterns that must not appear in src/ executable code:
+ *   - data/donations.json
+ *   - data/users.json
+ *   - data/wallets.json
+ *   - DB_JSON_PATH / WALLETS_JSON_PATH env var references
+ *
+ * Run: node scripts/check-no-json-persistence.js
+ * Exit 0 = clean, Exit 1 = violations found.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const SRC_DIR = path.join(ROOT, 'src');
+
+const BANNED = [
+  /data\/donations\.json/,
+  /data\/users\.json/,
+  /data\/wallets\.json/,
+  /DB_JSON_PATH/,
+  /WALLETS_JSON_PATH/,
+];
+
+// Directories to skip entirely
+const SKIP_DIRS = new Set(['node_modules', '.git', 'coverage', 'migrations']);
+
+// Files allowed to mention the old paths (schema history docs / migration files)
+const ALLOWED_FILE_PATTERNS = [
+  /src[/\\]migrations[/\\]/,
+  /src[/\\]scripts[/\\]migrations[/\\]/,
+];
+
+function isCommentLine(line) {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+}
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (entry.name.endsWith('.js')) files.push(full);
+  }
+  return files;
+}
+
+const violations = [];
+
+for (const file of walk(SRC_DIR)) {
+  const rel = path.relative(ROOT, file);
+
+  // Allow migration/schema files to reference old names for documentation
+  if (ALLOWED_FILE_PATTERNS.some(p => p.test(rel))) continue;
+
+  const content = fs.readFileSync(file, 'utf8');
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (isCommentLine(lines[i])) continue;
+    for (const pattern of BANNED) {
+      if (pattern.test(lines[i])) {
+        violations.push(`${rel}:${i + 1}: ${lines[i].trim()}`);
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('\n[check-no-json-persistence] FAIL — legacy JSON store references found in src/:\n');
+  for (const v of violations) console.error('  ' + v);
+  console.error('\nRemove these references and use the SQLite-backed models instead.\n');
+  process.exit(1);
+}
+
+console.log('[check-no-json-persistence] OK — no legacy JSON store references found in src/');
+process.exit(0);

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -286,7 +286,6 @@ const buildConfig = (env, isProduction, isTest) => {
   const database = {
     type: process.env.DB_TYPE || 'sqlite',
     path: process.env.DB_PATH || './donations.db',
-    jsonPath: process.env.DB_JSON_PATH || path.join(__dirname, '../../data/donations.json'),
   };
 
   // API Keys configuration

--- a/src/config/stellar.js
+++ b/src/config/stellar.js
@@ -33,5 +33,4 @@ module.exports = {
   useMockStellar: process.env.USE_MOCK_STELLAR === 'true',
   port: process.env.PORT || 3000,
   ...activeEnv,
-  dbPath: process.env.DB_JSON_PATH || path.join(__dirname, '../../data/donations.json'),
 };

--- a/src/middleware/RateLimitStore.js
+++ b/src/middleware/RateLimitStore.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const log = require('../utils/log');
+
+class RateLimitStore {
+  incrementAndCheck(_key, _limit, _windowSeconds) {
+    throw new Error('RateLimitStore.incrementAndCheck() must be implemented');
+  }
+  close() {}
+}
+
+class MemoryRateLimitStore extends RateLimitStore {
+  constructor() {
+    super();
+    this._windows = new Map();
+  }
+
+  incrementAndCheck(key, limit, windowSeconds) {
+    const now = Date.now();
+    const windowMs = windowSeconds * 1000;
+    const cutoff = now - windowMs;
+
+    let ts = this._windows.get(key) || [];
+    ts = ts.filter(t => t > cutoff);
+
+    const resetAt = ts.length > 0 ? ts[0] + windowMs : now + windowMs;
+
+    if (ts.length >= limit) {
+      this._windows.set(key, ts);
+      return { allowed: false, count: ts.length, remaining: 0, resetAt };
+    }
+
+    ts.push(now);
+    this._windows.set(key, ts);
+    return { allowed: true, count: ts.length, remaining: limit - ts.length, resetAt };
+  }
+
+  clear() { this._windows.clear(); }
+}
+
+/**
+ * Redis-backed store — atomic INCR+EXPIRE via Lua so no double-allow across replicas.
+ * failOpen (default true): allow requests when Redis is unavailable.
+ * failOpen false: deny requests when Redis is unavailable.
+ */
+class RedisRateLimitStore extends RateLimitStore {
+  constructor(redisClient, options = {}) {
+    super();
+    this._client = redisClient;
+    this._failOpen = options.failOpen !== undefined
+      ? Boolean(options.failOpen)
+      : process.env.RATE_LIMIT_FAIL_OPEN !== 'false';
+  }
+
+  async incrementAndCheck(key, limit, windowSeconds) {
+    try {
+      const lua = `
+        local c = redis.call("INCR", KEYS[1])
+        if c == 1 then redis.call("EXPIRE", KEYS[1], ARGV[1]) end
+        local ttl = redis.call("PTTL", KEYS[1])
+        return {c, ttl}
+      `;
+      let res;
+      try {
+        res = await this._client.eval(lua, 1, key, String(windowSeconds));
+      } catch (_) {
+        res = await this._client.eval(lua, { keys: [key], arguments: [String(windowSeconds)] });
+      }
+      const count = Array.isArray(res) ? Number(res[0]) : Number(res);
+      const ttlMs = Array.isArray(res) ? Math.max(Number(res[1]), 0) : windowSeconds * 1000;
+      const resetAt = Date.now() + ttlMs;
+      return { allowed: count <= limit, count, remaining: Math.max(0, limit - count), resetAt };
+    } catch (err) {
+      log.error('RATE_LIMIT_STORE', 'Redis error', { key, error: err.message, policy: this._failOpen ? 'fail-open' : 'fail-closed' });
+      if (this._failOpen) return { allowed: true, count: 0, remaining: limit, resetAt: Date.now() + windowSeconds * 1000 };
+      return { allowed: false, count: limit, remaining: 0, resetAt: Date.now() + windowSeconds * 1000 };
+    }
+  }
+
+  close() { try { this._client.quit && this._client.quit(); } catch (_) {} }
+}
+
+const _defaultMemoryStore = new MemoryRateLimitStore();
+
+function getRateLimitStore(redisClient = null) {
+  const type = (process.env.RATE_LIMIT_STORE || 'memory').toLowerCase();
+  if (type === 'redis') {
+    const client = redisClient || _tryGetRedisClient();
+    if (!client) {
+      log.warn('RATE_LIMIT_STORE', 'Redis requested but unavailable; using memory store');
+      return _defaultMemoryStore;
+    }
+    return new RedisRateLimitStore(client);
+  }
+  return _defaultMemoryStore;
+}
+
+function _tryGetRedisClient() {
+  try {
+    const Redis = require('ioredis');
+    const url = process.env.REDIS_URL;
+    return url ? new Redis(url) : null;
+  } catch (_) { return null; }
+}
+
+module.exports = { RateLimitStore, MemoryRateLimitStore, RedisRateLimitStore, getRateLimitStore, _defaultMemoryStore };

--- a/src/middleware/perKeyRateLimit.js
+++ b/src/middleware/perKeyRateLimit.js
@@ -1,13 +1,15 @@
-/**
- * Per-API-Key Rate Limiting Middleware
- * Sliding window algorithm using in-memory store (Redis-compatible interface).
- */
+'use strict';
+
+const { getRateLimitStore } = require('./RateLimitStore');
 
 const DEFAULT_RATE_LIMIT = 100;
 const DEFAULT_WINDOW_SECONDS = 60;
 
-// In-memory store: keyId -> array of request timestamps (ms)
-const store = new Map();
+let _store = null;
+function getStore() {
+  if (!_store) _store = getRateLimitStore();
+  return _store;
+}
 
 function buildRateLimitHeaders(limit, remaining, resetAt) {
   const resetUnix = String(Math.ceil(resetAt / 1000));
@@ -21,62 +23,38 @@ function buildRateLimitHeaders(limit, remaining, resetAt) {
   };
 }
 
-function checkRateLimit(keyId, limit, windowSeconds) {
-  const now = Date.now();
-  const windowMs = windowSeconds * 1000;
-  const cutoff = now - windowMs;
-
-  if (!store.has(keyId)) store.set(keyId, []);
-  const timestamps = store.get(keyId).filter(t => t > cutoff);
-
-  const remaining = limit - timestamps.length;
-  const resetAt = timestamps.length > 0 ? timestamps[0] + windowMs : now + windowMs;
-
-  if (remaining <= 0) {
-    store.set(keyId, timestamps);
-    return { allowed: false, limit, remaining: 0, resetAt };
-  }
-
-  timestamps.push(now);
-  store.set(keyId, timestamps);
-  return { allowed: true, limit, remaining: remaining - 1, resetAt };
-}
-
-// Exposed for testing
-function clearStore() {
-  store.clear();
-}
-
-const perKeyRateLimit = (req, res, next) => {
+const perKeyRateLimit = async (req, res, next) => {
   const keyInfo = req.apiKey;
-  // Skip for legacy/unauthenticated keys
   if (!keyInfo || keyInfo.isLegacy || !keyInfo.id) return next();
 
   const limit = keyInfo.rateLimitPerMinute || keyInfo.rateLimit || DEFAULT_RATE_LIMIT;
   const windowSeconds = keyInfo.rateLimitWindowSeconds || DEFAULT_WINDOW_SECONDS;
 
-  const result = checkRateLimit(keyInfo.id, limit, windowSeconds);
-  const headers = buildRateLimitHeaders(result.limit, result.remaining, result.resetAt);
-  res.set(headers);
+  const result = await getStore().incrementAndCheck(keyInfo.id, limit, windowSeconds);
+  res.set(buildRateLimitHeaders(limit, result.remaining, result.resetAt));
 
   if (!result.allowed) {
-    res.set('Retry-After', String(Math.ceil((result.resetAt - Date.now()) / 1000)));
+    const retryAfter = Math.ceil((result.resetAt - Date.now()) / 1000);
+    res.set('Retry-After', String(retryAfter));
     return res.status(429).json({
       success: false,
-      error: {
-        code: 'RATE_LIMIT_EXCEEDED',
-        message: 'Rate limit exceeded. Please retry after the reset time.',
-        retryAfter: Math.ceil((result.resetAt - Date.now()) / 1000),
-      },
+      error: { code: 'RATE_LIMIT_EXCEEDED', message: 'Rate limit exceeded.', retryAfter },
     });
   }
 
   return next();
 };
 
+function clearStore() {
+  const s = getStore();
+  if (typeof s.clear === 'function') s.clear();
+}
+
+function _setStore(store) { _store = store; }
+
 module.exports = perKeyRateLimit;
 module.exports.buildRateLimitHeaders = buildRateLimitHeaders;
-module.exports.checkRateLimit = checkRateLimit;
 module.exports.clearStore = clearStore;
+module.exports._setStore = _setStore;
 module.exports.DEFAULT_RATE_LIMIT = DEFAULT_RATE_LIMIT;
 module.exports.DEFAULT_WINDOW_SECONDS = DEFAULT_WINDOW_SECONDS;

--- a/src/migrations/018_wallets_table.js
+++ b/src/migrations/018_wallets_table.js
@@ -1,0 +1,30 @@
+'use strict';
+
+exports.name = '018_wallets_table';
+
+exports.up = async (db) => {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS wallets (
+      id TEXT PRIMARY KEY,
+      address TEXT NOT NULL UNIQUE,
+      label TEXT,
+      ownerName TEXT,
+      notes TEXT,
+      leaderboard_visibility INTEGER DEFAULT 1,
+      last_synced_at TEXT,
+      last_cursor TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT,
+      deletedAt TEXT
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_wallets_address ON wallets(address)
+  `);
+};
+
+exports.down = async (db) => {
+  await db.run('DROP INDEX IF EXISTS idx_wallets_address');
+  await db.run('DROP TABLE IF EXISTS wallets');
+};

--- a/src/migrations/019_donations_store.js
+++ b/src/migrations/019_donations_store.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// This table backs the Transaction model (previously data/donations.json).
+// It stores the full donation record as a JSON blob alongside indexed columns
+// for efficient querying, avoiding any float coercion of stroop amounts.
+
+exports.name = '019_donations_store';
+
+exports.up = async (db) => {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS donations_store (
+      id TEXT PRIMARY KEY,
+      donor TEXT,
+      recipient TEXT,
+      amount_stroops INTEGER,
+      amount_text TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      idempotency_key TEXT UNIQUE,
+      stellar_tx_id TEXT UNIQUE,
+      timestamp TEXT NOT NULL,
+      status_updated_at TEXT,
+      deleted_at TEXT,
+      data TEXT NOT NULL
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_donations_store_donor ON donations_store(donor)
+  `);
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_donations_store_recipient ON donations_store(recipient)
+  `);
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_donations_store_status ON donations_store(status)
+  `);
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_donations_store_stellar_tx ON donations_store(stellar_tx_id)
+  `);
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_donations_store_idempotency ON donations_store(idempotency_key)
+  `);
+};
+
+exports.down = async (db) => {
+  await db.run('DROP INDEX IF EXISTS idx_donations_store_idempotency');
+  await db.run('DROP INDEX IF EXISTS idx_donations_store_stellar_tx');
+  await db.run('DROP INDEX IF EXISTS idx_donations_store_status');
+  await db.run('DROP INDEX IF EXISTS idx_donations_store_recipient');
+  await db.run('DROP INDEX IF EXISTS idx_donations_store_donor');
+  await db.run('DROP TABLE IF EXISTS donations_store');
+};

--- a/src/models/transaction.js
+++ b/src/models/transaction.js
@@ -1,5 +1,14 @@
-const fs = require('fs');
-const path = require('path');
+/**
+ * Transaction Model - Data Access Layer (SQLite-backed)
+ * No longer reads from or writes to data/donations.json.
+ *
+ * Uses an in-memory store initialised from SQLite on first access.
+ * All mutations are persisted to SQLite (fire-and-forget with error logging).
+ * The synchronous public API is preserved for backward compatibility.
+ */
+
+'use strict';
+
 const { v4: uuidv4 } = require('uuid');
 const donationEvents = require('../events/donationEvents');
 const {
@@ -8,61 +17,124 @@ const {
   assertValidState,
   assertValidTransition,
 } = require('../utils/transactionStateMachine');
+const log = require('../utils/log');
+
+// ── In-memory store ──────────────────────────────────────────────────────────
+
+/** @type {Map<string, object>} id -> transaction object */
+const _store = new Map();
+let _loaded = false;
+let _loading = null; // Promise<void> | null
+
+/**
+ * Persist a single record to SQLite (fire-and-forget).
+ * Stroop amounts are stored as exact integers to avoid float coercion.
+ */
+function _persist(tx) {
+  const Database = require('../utils/database');
+  const amountStroops = Number.isInteger(tx.amount) ? tx.amount : null;
+  const data = JSON.stringify(tx);
+
+  Database.run(
+    `INSERT INTO donations_store
+       (id, donor, recipient, amount_stroops, amount_text, status,
+        idempotency_key, stellar_tx_id, timestamp, status_updated_at, deleted_at, data)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       status = excluded.status,
+       stellar_tx_id = excluded.stellar_tx_id,
+       status_updated_at = excluded.status_updated_at,
+       deleted_at = excluded.deleted_at,
+       data = excluded.data`,
+    [
+      tx.id,
+      tx.donor || null,
+      tx.recipient || null,
+      amountStroops,
+      String(tx.amount ?? ''),
+      tx.status || 'pending',
+      tx.idempotencyKey || null,
+      tx.stellarTxId || null,
+      tx.timestamp || new Date().toISOString(),
+      tx.statusUpdatedAt || null,
+      tx.deleted_at || null,
+      data,
+    ]
+  ).catch(err => log.error('TRANSACTION_MODEL', 'SQLite persist failed', { id: tx.id, error: err.message }));
+}
+
+/**
+ * Load all records from SQLite into the in-memory store.
+ * Called once lazily; subsequent calls are no-ops.
+ */
+async function _ensureLoaded() {
+  if (_loaded) return;
+  if (_loading) return _loading;
+
+  _loading = (async () => {
+    try {
+      const Database = require('../utils/database');
+      const rows = await Database.all('SELECT data FROM donations_store');
+      for (const row of rows) {
+        try {
+          const tx = JSON.parse(row.data);
+          _store.set(tx.id, tx);
+        } catch (_) { /* skip corrupt rows */ }
+      }
+      _loaded = true;
+    } catch (err) {
+      // If DB isn't ready yet (e.g. first startup before migrations), start empty
+      log.warn('TRANSACTION_MODEL', 'Could not load from SQLite, starting empty', { error: err.message });
+      _loaded = true;
+    } finally {
+      _loading = null;
+    }
+  })();
+
+  return _loading;
+}
+
+// Kick off the load immediately so most requests find the store ready
+_ensureLoaded().catch(() => {});
+
+// ── Model class ──────────────────────────────────────────────────────────────
 
 class Transaction {
+  /** @deprecated No longer used — retained for test compatibility only */
   static getDbPath() {
-    return process.env.DB_JSON_PATH || path.join(__dirname, '../../data/donations.json');
-  }
-
-  static ensureDbDir() {
-    const dir = path.dirname(this.getDbPath());
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-  }
-
-  static loadTransactions() {
-    this.ensureDbDir();
-    const dbPath = this.getDbPath();
-    if (!fs.existsSync(dbPath)) {
-      return [];
-    }
-    try {
-      const data = fs.readFileSync(dbPath, 'utf8');
-      return JSON.parse(data);
-    } catch (error) {
-      return [];
-    }
-  }
-
-  static saveTransactions(transactions) {
-    this.ensureDbDir();
-    fs.writeFileSync(this.getDbPath(), JSON.stringify(transactions, null, 2));
+    return null;
   }
 
   /**
-   * Set the event emitter instance (for testing)
-   * @param {Object} emitter - Event emitter to use
+   * Synchronous helper — returns the in-memory array.
+   * If the store hasn't been loaded from SQLite yet, returns what's already
+   * in memory (empty on very first request before load completes).
    */
+  static loadTransactions() {
+    return Array.from(_store.values());
+  }
+
+  /** @deprecated No-op — writes go through _persist(). */
+  static saveTransactions(_transactions) {
+    // intentionally empty — no file I/O
+  }
+
   static setEventEmitter(emitter) {
     this.eventEmitter = emitter;
   }
 
   static create(transactionData) {
-    const transactions = this.loadTransactions();
-
-    if (transactionData.idempotencyKey) {
-      const existingTransaction = transactions.find(
-        t => t.idempotencyKey === transactionData.idempotencyKey
-      );
-
-      if (existingTransaction) {
-        return existingTransaction;
-      }
-    }
-
     const normalizedStatus = normalizeState(transactionData.status || TRANSACTION_STATES.PENDING);
     assertValidState(normalizedStatus, 'status');
+
+    // Idempotency check
+    if (transactionData.idempotencyKey) {
+      for (const tx of _store.values()) {
+        if (tx.idempotencyKey === transactionData.idempotencyKey) {
+          return tx;
+        }
+      }
+    }
 
     const nowIso = new Date().toISOString();
     const newTransaction = {
@@ -90,15 +162,17 @@ class Transaction {
       currentFee: transactionData.currentFee || null,
       lastFeeBumpAt: transactionData.lastFeeBumpAt || null,
     };
-    transactions.push(newTransaction);
-    this.saveTransactions(transactions);
 
-    if (this.eventEmitter) {
-      const eventName = this.eventEmitter.constructor?.EVENTS?.CREATED || 'donation.created';
-      if (typeof this.eventEmitter.emitLifecycleEvent === 'function') {
-        this.eventEmitter.emitLifecycleEvent(eventName, newTransaction);
-      } else if (typeof this.eventEmitter.emit === 'function') {
-        this.eventEmitter.emit(eventName, newTransaction);
+    _store.set(newTransaction.id, newTransaction);
+    _persist(newTransaction);
+
+    const emitter = this.eventEmitter;
+    if (emitter) {
+      const eventName = emitter.constructor?.EVENTS?.CREATED || 'donation.created';
+      if (typeof emitter.emitLifecycleEvent === 'function') {
+        emitter.emitLifecycleEvent(eventName, newTransaction);
+      } else if (typeof emitter.emit === 'function') {
+        emitter.emit(eventName, newTransaction);
       }
     }
 
@@ -107,53 +181,20 @@ class Transaction {
 
   static getPaginated({ limit = 10, offset = 0 } = {}) {
     const transactions = this.loadTransactions();
-
-    const total = transactions.length;
-
-
     limit = parseInt(limit);
     offset = parseInt(offset);
-
-
-    const paginatedData = transactions.slice(offset, offset + limit);
-
     return {
-      data: paginatedData,
+      data: transactions.slice(offset, offset + limit),
       pagination: {
-        total,
+        total: transactions.length,
         limit,
         offset,
-        hasMore: offset + limit < total
-      }
+        hasMore: offset + limit < transactions.length,
+      },
     };
   }
 
-  /**
-   * Get paginated transactions using cursor-based pagination with optional date filtering and sender/recipient filtering.
-   *
-   * When startDate or endDate are provided the results are filtered to only
-   * include transactions whose timestamp falls within the specified range.
-   * When senderPublicKey or recipientPublicKey are provided, results are filtered
-   * to only include transactions matching those participants.
-   * The date range and filters are encoded in the cursor so subsequent pages automatically
-   * apply the same filter without the caller needing to repeat the parameters.
-   *
-   * Cursor format (no date filter):  "<epochMs>_<id>"
-   * Cursor format (with date filter): base64(JSON { t, id, sd?, ed?, spk?, rpk? })
-   *
-   * @param {Object}  options
-   * @param {number}  [options.limit=20]    - Items per page (max 100)
-   * @param {string}  [options.cursor=null] - Opaque pagination cursor
-   * @param {string}  [options.startDate]   - ISO 8601 start of date range (inclusive)
-   * @param {string}  [options.endDate]     - ISO 8601 end of date range (inclusive)
-   * @param {string}  [options.senderPublicKey]   - Filter by sender public key
-   * @param {string}  [options.recipientPublicKey] - Filter by recipient public key
-   * @returns {{ data: Array, nextCursor: string|null, hasMore: boolean }}
-   */
   static getCursorPaginated({ limit = 20, cursor = null, startDate, endDate, senderPublicKey, recipientPublicKey } = {}) {
-    const transactions = this.loadTransactions();
-
-    // Decode cursor — may carry embedded date range and filters
     let cursorTime = null;
     let cursorId = null;
     let effectiveStartDate = startDate;
@@ -162,20 +203,17 @@ class Transaction {
     let effectiveRecipientPublicKey = recipientPublicKey;
 
     if (cursor) {
-      // Try new base64-JSON format first (used when date filters are active)
       try {
         const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
         if (decoded && typeof decoded.t === 'number') {
           cursorTime = decoded.t;
           cursorId = decoded.id;
-          // Restore encoded date range so it applies on every page
           if (decoded.sd) effectiveStartDate = decoded.sd;
           if (decoded.ed) effectiveEndDate = decoded.ed;
           if (decoded.spk) effectiveSenderPublicKey = decoded.spk;
           if (decoded.rpk) effectiveRecipientPublicKey = decoded.rpk;
         }
       } catch {
-        // Fall back to legacy "timestamp_id" format
         const parts = cursor.split('_');
         if (parts.length >= 2) {
           cursorTime = parseInt(parts[0]);
@@ -184,10 +222,8 @@ class Transaction {
       }
     }
 
-    // Exclude soft-deleted records
-    let active = transactions.filter(t => !t.deleted_at);
+    let active = Array.from(_store.values()).filter(t => !t.deleted_at);
 
-    // Apply date range filter at the data level (equivalent to SQL WHERE timestamp BETWEEN)
     if (effectiveStartDate) {
       const start = new Date(effectiveStartDate).getTime();
       active = active.filter(t => new Date(t.timestamp).getTime() >= start);
@@ -196,8 +232,6 @@ class Transaction {
       const end = new Date(effectiveEndDate).getTime();
       active = active.filter(t => new Date(t.timestamp).getTime() <= end);
     }
-
-    // Apply sender/recipient filters
     if (effectiveSenderPublicKey) {
       active = active.filter(t => t.donor === effectiveSenderPublicKey);
     }
@@ -205,7 +239,6 @@ class Transaction {
       active = active.filter(t => t.recipient === effectiveRecipientPublicKey);
     }
 
-    // Sort by timestamp DESC, then by id DESC for consistent ordering
     const sorted = active.sort((a, b) => {
       const timeA = new Date(a.timestamp).getTime();
       const timeB = new Date(b.timestamp).getTime();
@@ -214,35 +247,23 @@ class Transaction {
     });
 
     let startIndex = 0;
-
-    // If cursor provided, find the starting position within the (filtered) sorted list
     if (cursorTime !== null && cursorId !== null) {
       startIndex = sorted.findIndex(t => {
         const txTime = new Date(t.timestamp).getTime();
         return txTime < cursorTime || (txTime === cursorTime && t.id.localeCompare(cursorId) < 0);
       });
-
-      // If cursor not found, return empty results
-      if (startIndex === -1) {
-        return { data: [], nextCursor: null, hasMore: false };
-      }
+      if (startIndex === -1) return { data: [], nextCursor: null, hasMore: false };
     }
 
-    // Get the page of results
     const pageLimit = Math.min(parseInt(limit), 100);
     const paginatedData = sorted.slice(startIndex, startIndex + pageLimit);
-
-    // Check if there are more results
     const hasMore = startIndex + pageLimit < sorted.length;
 
-    // Generate next cursor from the last item, embedding the date range and filters when present
     let nextCursor = null;
     if (hasMore && paginatedData.length > 0) {
       const lastItem = paginatedData[paginatedData.length - 1];
       const lastTimestamp = new Date(lastItem.timestamp).getTime();
-
       if (effectiveStartDate || effectiveEndDate || effectiveSenderPublicKey || effectiveRecipientPublicKey) {
-        // Encode date range and filters into cursor so next page uses the same filter
         const cursorPayload = { t: lastTimestamp, id: lastItem.id };
         if (effectiveStartDate) cursorPayload.sd = effectiveStartDate;
         if (effectiveEndDate) cursorPayload.ed = effectiveEndDate;
@@ -258,186 +279,147 @@ class Transaction {
   }
 
   static getById(id) {
-    const transactions = this.loadTransactions();
-    const tx = transactions.find(t => t.id === id);
-    // Return null for soft-deleted records (treat as not found)
+    const tx = _store.get(id);
     if (tx && tx.deleted_at) return null;
-    return tx;
+    return tx || null;
   }
 
   static getByDateRange(startDate, endDate) {
-    const transactions = this.loadTransactions();
-    return transactions.filter(t => {
+    return Array.from(_store.values()).filter(t => {
       const txDate = new Date(t.timestamp);
       return txDate >= startDate && txDate <= endDate;
     });
   }
 
   static getAll({ includeDeleted = false } = {}) {
-    const transactions = this.loadTransactions();
-    if (includeDeleted) return transactions;
-    return transactions.filter(t => !t.deleted_at);
+    const all = Array.from(_store.values());
+    return includeDeleted ? all : all.filter(t => !t.deleted_at);
   }
 
   static updateStatus(id, status, stellarData = {}) {
-    const transactions = this.loadTransactions();
-    const index = transactions.findIndex(t => t.id === id);
+    const tx = _store.get(id);
+    if (!tx) throw new Error(`Transaction not found: ${id}`);
 
-    if (index === -1) {
-      throw new Error(`Transaction not found: ${id}`);
-    }
-
-    const currentStatus = normalizeState(transactions[index].status);
+    const currentStatus = normalizeState(tx.status);
     const nextStatus = normalizeState(status);
-
     assertValidState(currentStatus, 'current status');
     assertValidState(nextStatus, 'target status');
     assertValidTransition(currentStatus, nextStatus);
 
-    const previousStatusTimestamp = new Date(transactions[index].statusUpdatedAt || transactions[index].timestamp || 0).getTime();
+    const previousStatusTimestamp = new Date(tx.statusUpdatedAt || tx.timestamp || 0).getTime();
     const nextStatusTimestamp = new Date(Math.max(Date.now(), previousStatusTimestamp + 1)).toISOString();
 
-    transactions[index].status = nextStatus;
-    transactions[index].statusUpdatedAt = nextStatusTimestamp;
+    const updated = { ...tx, status: nextStatus, statusUpdatedAt: nextStatusTimestamp };
 
-    if (stellarData.transactionId) {
-      transactions[index].stellarTxId = stellarData.transactionId;
-    }
-    if (stellarData.ledger) {
-      transactions[index].stellarLedger = stellarData.ledger;
-    }
-    if (stellarData.confirmedAt) {
-      transactions[index].confirmedAt = stellarData.confirmedAt;
-    }
-    if (Object.prototype.hasOwnProperty.call(stellarData, 'notes')) {
-      transactions[index].notes = stellarData.notes;
-    }
+    if (stellarData.transactionId) updated.stellarTxId = stellarData.transactionId;
+    if (stellarData.ledger) updated.stellarLedger = stellarData.ledger;
+    if (stellarData.confirmedAt) updated.confirmedAt = stellarData.confirmedAt;
+    if (Object.prototype.hasOwnProperty.call(stellarData, 'notes')) updated.notes = stellarData.notes;
     if (Object.prototype.hasOwnProperty.call(stellarData, 'tags')) {
-      transactions[index].tags = Array.isArray(stellarData.tags) ? stellarData.tags : [];
+      updated.tags = Array.isArray(stellarData.tags) ? stellarData.tags : [];
     }
 
-    this.saveTransactions(transactions);
-    const updatedTransaction = transactions[index];
+    _store.set(id, updated);
+    _persist(updated);
 
-    if (this.eventEmitter) {
+    const emitter = this.eventEmitter;
+    if (emitter) {
       const statusEventMap = {
-        [TRANSACTION_STATES.SUBMITTED]: this.eventEmitter.constructor?.EVENTS?.SUBMITTED,
-        [TRANSACTION_STATES.CONFIRMED]: this.eventEmitter.constructor?.EVENTS?.CONFIRMED,
-        [TRANSACTION_STATES.FAILED]: this.eventEmitter.constructor?.EVENTS?.FAILED,
+        [TRANSACTION_STATES.SUBMITTED]: emitter.constructor?.EVENTS?.SUBMITTED,
+        [TRANSACTION_STATES.CONFIRMED]: emitter.constructor?.EVENTS?.CONFIRMED,
+        [TRANSACTION_STATES.FAILED]: emitter.constructor?.EVENTS?.FAILED,
       };
       const eventName = statusEventMap[nextStatus];
-
       if (eventName) {
-        if (typeof this.eventEmitter.emitLifecycleEvent === 'function') {
-          this.eventEmitter.emitLifecycleEvent(eventName, updatedTransaction);
-        } else if (typeof this.eventEmitter.emit === 'function') {
-          this.eventEmitter.emit(eventName, updatedTransaction);
+        if (typeof emitter.emitLifecycleEvent === 'function') {
+          emitter.emitLifecycleEvent(eventName, updated);
+        } else if (typeof emitter.emit === 'function') {
+          emitter.emit(eventName, updated);
         }
       }
     }
 
-    return updatedTransaction;
+    return updated;
   }
 
-  /**
-   * Update fee bump metadata for a transaction.
-   * @param {string} id - Transaction ID
-   * @param {Object} feeBumpData - Fee bump data to update
-   * @param {number} [feeBumpData.feeBumpCount] - New fee bump count
-   * @param {number} [feeBumpData.currentFee] - New current fee in stroops
-   * @param {string} [feeBumpData.lastFeeBumpAt] - ISO timestamp of fee bump
-   * @param {string} [feeBumpData.envelopeXdr] - Updated envelope XDR (fee bump envelope)
-   * @param {string} [feeBumpData.stellarTxId] - New Stellar transaction hash
-   * @returns {Object} Updated transaction
-   */
   static updateFeeBumpData(id, feeBumpData) {
-    const transactions = this.loadTransactions();
-    const index = transactions.findIndex(t => t.id === id);
+    const tx = _store.get(id);
+    if (!tx) throw new Error(`Transaction not found: ${id}`);
 
-    if (index === -1) {
-      throw new Error(`Transaction not found: ${id}`);
-    }
+    const updated = { ...tx };
+    if (feeBumpData.feeBumpCount !== undefined) updated.feeBumpCount = feeBumpData.feeBumpCount;
+    if (feeBumpData.currentFee !== undefined) updated.currentFee = feeBumpData.currentFee;
+    if (feeBumpData.lastFeeBumpAt !== undefined) updated.lastFeeBumpAt = feeBumpData.lastFeeBumpAt;
+    if (feeBumpData.envelopeXdr !== undefined) updated.envelopeXdr = feeBumpData.envelopeXdr;
+    if (feeBumpData.stellarTxId !== undefined) updated.stellarTxId = feeBumpData.stellarTxId;
 
-    if (feeBumpData.feeBumpCount !== undefined) {
-      transactions[index].feeBumpCount = feeBumpData.feeBumpCount;
-    }
-    if (feeBumpData.currentFee !== undefined) {
-      transactions[index].currentFee = feeBumpData.currentFee;
-    }
-    if (feeBumpData.lastFeeBumpAt !== undefined) {
-      transactions[index].lastFeeBumpAt = feeBumpData.lastFeeBumpAt;
-    }
-    if (feeBumpData.envelopeXdr !== undefined) {
-      transactions[index].envelopeXdr = feeBumpData.envelopeXdr;
-    }
-    if (feeBumpData.stellarTxId !== undefined) {
-      transactions[index].stellarTxId = feeBumpData.stellarTxId;
-    }
-
-    this.saveTransactions(transactions);
-    return transactions[index];
+    _store.set(id, updated);
+    _persist(updated);
+    return updated;
   }
 
   static getByStatus(status) {
-    const transactions = this.loadTransactions();
-    return transactions.filter(t => t.status === status);
+    return Array.from(_store.values()).filter(t => t.status === status);
   }
 
   static getByStellarTxId(stellarTxId) {
-    const transactions = this.loadTransactions();
-    return transactions.find(t => t.stellarTxId === stellarTxId);
+    for (const tx of _store.values()) {
+      if (tx.stellarTxId === stellarTxId) return tx;
+    }
+    return undefined;
   }
 
   static getDailyTotalByDonor(donor, date = new Date()) {
-    const transactions = this.loadTransactions();
     const startOfDay = new Date(date);
     startOfDay.setHours(0, 0, 0, 0);
-
     const endOfDay = new Date(date);
     endOfDay.setHours(23, 59, 59, 999);
 
-    return transactions
+    return Array.from(_store.values())
       .filter(t => {
         const txDate = new Date(t.timestamp);
         return t.donor === donor &&
-          txDate >= startOfDay &&
-          txDate <= endOfDay &&
-          t.status !== 'failed' &&
-          t.status !== 'cancelled';
+          txDate >= startOfDay && txDate <= endOfDay &&
+          t.status !== 'failed' && t.status !== 'cancelled';
       })
       .reduce((total, t) => total + t.amount, 0);
   }
 
-  // Test helper for integration suites.
-  static _clearAllData() {
-    this.saveTransactions([]);
-  }
-
-  /**
-   * Update NFT certificate fields on a transaction record.
-   * @param {string} id - Transaction ID
-   * @param {Object} nftData
-   * @param {string} [nftData.nft_asset_code]
-   * @param {string} [nftData.nft_issuer]
-   * @param {string} [nftData.nft_tx_hash]
-   * @param {string} [nftData.nft_minted_at]
-   * @param {string} [nftData.nft_mint_error]
-   * @returns {Object} Updated transaction
-   */
   static updateNftData(id, nftData) {
-    const transactions = this.loadTransactions();
-    const index = transactions.findIndex(t => t.id === id);
-    if (index === -1) throw new Error(`Transaction not found: ${id}`);
+    const tx = _store.get(id);
+    if (!tx) throw new Error(`Transaction not found: ${id}`);
 
+    const updated = { ...tx };
     const fields = ['nft_asset_code', 'nft_issuer', 'nft_tx_hash', 'nft_minted_at', 'nft_mint_error'];
     for (const field of fields) {
       if (Object.prototype.hasOwnProperty.call(nftData, field)) {
-        transactions[index][field] = nftData[field];
+        updated[field] = nftData[field];
       }
     }
 
-    this.saveTransactions(transactions);
-    return transactions[index];
+    _store.set(id, updated);
+    _persist(updated);
+    return updated;
+  }
+
+  /** Test helper — wipe all in-memory and SQLite donation data. */
+  static _clearAllData() {
+    _store.clear();
+    _loaded = true;
+    const Database = require('../utils/database');
+    Database.run('DELETE FROM donations_store').catch(err =>
+      log.error('TRANSACTION_MODEL', 'Failed to clear donations_store', { error: err.message })
+    );
+  }
+
+  /**
+   * Reload the in-memory store from SQLite.
+   * Useful after test setup or data import.
+   */
+  static async _reloadFromDb() {
+    _loaded = false;
+    _store.clear();
+    await _ensureLoaded();
   }
 }
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,18 +1,27 @@
 /**
- * User Model - Data Access Layer
+ * User Model - Data Access Layer (SQLite-backed)
+ * No longer reads from data/users.json — all lookups go through SQLite.
  */
 
-const users = require('../../data/users.json');
+const Database = require('../utils/database');
 
 class User {
-  static getById(id) {
+  static async getById(id) {
     if (!id) return null;
-    return users.find(u => u.id === id) || null;
+    const row = await Database.get(
+      'SELECT * FROM users WHERE id = ? AND deleted_at IS NULL',
+      [id]
+    );
+    return row || null;
   }
 
-  static getByWallet(address) {
+  static async getByWallet(address) {
     if (!address) return null;
-    return users.find(u => u.wallet === address || u.publicKey === address) || null;
+    const row = await Database.get(
+      'SELECT * FROM users WHERE publicKey = ? AND deleted_at IS NULL',
+      [address]
+    );
+    return row || null;
   }
 }
 

--- a/src/models/wallet.js
+++ b/src/models/wallet.js
@@ -1,13 +1,15 @@
-const fs = require('fs');
-const path = require('path');
+/**
+ * Wallet Model - Data Access Layer (SQLite-backed)
+ * No longer reads from or writes to data/wallets.json.
+ */
 
-const WALLETS_DB_PATH = process.env.WALLETS_JSON_PATH || './data/wallets.json';
+const { v4: uuidv4 } = require('uuid');
+const Database = require('../utils/database');
 
 /** Encrypted field names on wallet records */
 const ENCRYPTED_FIELDS = ['label', 'notes'];
 
 function getEncryptionService() {
-  // Lazy-require to avoid circular deps and allow tests to override env
   return require('../services/EncryptionService');
 }
 
@@ -32,116 +34,120 @@ function decryptWalletFields(wallet) {
       try { result[field] = svc.decryptField(result[field]); } catch (_) { /* leave as-is */ }
     }
   }
+  // Normalise leaderboard_visibility back to boolean
+  if (result.leaderboard_visibility !== undefined) {
+    result.leaderboard_visibility = result.leaderboard_visibility !== 0;
+  }
   return result;
 }
 
+function rowToWallet(row) {
+  if (!row) return null;
+  return decryptWalletFields({ ...row });
+}
+
 class Wallet {
-  static ensureDbDir() {
-    const dir = path.dirname(WALLETS_DB_PATH);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-  }
-
-  static loadWallets() {
-    this.ensureDbDir();
-    if (!fs.existsSync(WALLETS_DB_PATH)) {
-      return [];
-    }
-    try {
-      const data = fs.readFileSync(WALLETS_DB_PATH, 'utf8');
-      return JSON.parse(data);
-    } catch (error) {
-      return [];
-    }
-  }
-
-  static saveWallets(wallets) {
-    this.ensureDbDir();
-    fs.writeFileSync(WALLETS_DB_PATH, JSON.stringify(wallets, null, 2));
-  }
-
-  // Test helper for integration suites: wipe all persisted wallet data.
-  static _clearAllData() {
-    this.saveWallets([]);
-  }
-
-  static create(walletData) {
-    const wallets = this.loadWallets();
-    const newWallet = {
-      id: Date.now().toString(),
-      address: walletData.address,
-      label: walletData.label || null,
-      ownerName: walletData.ownerName || null,
-      createdAt: new Date().toISOString(),
-      deletedAt: null, // Initialized for soft-delete support
-      last_synced_at: null,
-      last_cursor: null,
-      ...walletData
-    };
-    wallets.push(encryptWalletFields(newWallet));
-    this.saveWallets(wallets);
-    return newWallet;
-  }
-
-  /**
-   * Returns only wallets that have NOT been soft-deleted
-   */
-  static getAll() {
-    const wallets = this.loadWallets();
-    return wallets.filter(w => !w.deletedAt).map(decryptWalletFields);
-  }
-
-  /**
-   * Returns a specific wallet only if not soft-deleted.
-   * Ids are stored as strings (Date.now().toString()); accept numeric input.
-   */
-  static getById(id) {
-    const wallets = this.loadWallets();
-    return decryptWalletFields(wallets.find(w => String(w.id) === String(id) && !w.deletedAt));
-  }
-
-  /**
-   * Returns a specific address only if not soft-deleted
-   */
-  static getByAddress(address) {
-    const wallets = this.loadWallets();
-    return decryptWalletFields(wallets.find(w => w.address === address && !w.deletedAt));
-  }
-
-  /**
-   * Internal method for admin/cleanup to see deleted records
-   */
-  static getAllDeleted() {
-    const wallets = this.loadWallets();
-    return wallets.filter(w => !!w.deletedAt);
-  }
-
-  static update(id, updates) {
-    const wallets = this.loadWallets();
-    const index = wallets.findIndex(w => String(w.id) === String(id) && !w.deletedAt);
-    if (index === -1) return null;
-
-    wallets[index] = encryptWalletFields({
-      ...wallets[index],
-      ...updates,
-      updatedAt: new Date().toISOString()
+  static async create(walletData) {
+    const id = walletData.id || uuidv4();
+    const now = new Date().toISOString();
+    const record = encryptWalletFields({
+      ...walletData,
+      id,
+      createdAt: walletData.createdAt || now,
+      deletedAt: null,
+      last_synced_at: walletData.last_synced_at || null,
+      last_cursor: walletData.last_cursor || null,
     });
-    this.saveWallets(wallets);
-    return decryptWalletFields(wallets[index]);
+
+    await Database.run(
+      `INSERT INTO wallets
+         (id, address, label, ownerName, notes, leaderboard_visibility, last_synced_at, last_cursor, createdAt, updatedAt, deletedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        record.id,
+        record.address,
+        record.label || null,
+        record.ownerName || null,
+        record.notes || null,
+        record.leaderboard_visibility !== false ? 1 : 0,
+        record.last_synced_at || null,
+        record.last_cursor || null,
+        record.createdAt,
+        record.updatedAt || null,
+        null,
+      ]
+    );
+
+    return rowToWallet(record);
   }
 
-  /**
-   * Soft delete: sets the deletedAt timestamp instead of removing from array
-   */
-  static softDelete(id) {
-    const wallets = this.loadWallets();
-    const index = wallets.findIndex(w => String(w.id) === String(id));
-    if (index === -1) return false;
+  static async getAll() {
+    const rows = await Database.all('SELECT * FROM wallets WHERE deletedAt IS NULL');
+    return rows.map(rowToWallet);
+  }
 
-    wallets[index].deletedAt = new Date().toISOString();
-    this.saveWallets(wallets);
-    return true;
+  static async getById(id) {
+    const row = await Database.get(
+      'SELECT * FROM wallets WHERE id = ? AND deletedAt IS NULL',
+      [String(id)]
+    );
+    return rowToWallet(row);
+  }
+
+  static async getByAddress(address) {
+    const row = await Database.get(
+      'SELECT * FROM wallets WHERE address = ? AND deletedAt IS NULL',
+      [address]
+    );
+    return rowToWallet(row);
+  }
+
+  static async getAllDeleted() {
+    const rows = await Database.all('SELECT * FROM wallets WHERE deletedAt IS NOT NULL');
+    return rows.map(rowToWallet);
+  }
+
+  static async update(id, updates) {
+    const existing = await this.getById(id);
+    if (!existing) return null;
+
+    const merged = encryptWalletFields({
+      ...existing,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    });
+
+    await Database.run(
+      `UPDATE wallets SET
+         label = ?, ownerName = ?, notes = ?, leaderboard_visibility = ?,
+         last_synced_at = ?, last_cursor = ?, updatedAt = ?
+       WHERE id = ? AND deletedAt IS NULL`,
+      [
+        merged.label || null,
+        merged.ownerName || null,
+        merged.notes || null,
+        merged.leaderboard_visibility !== false ? 1 : 0,
+        merged.last_synced_at || null,
+        merged.last_cursor || null,
+        merged.updatedAt,
+        String(id),
+      ]
+    );
+
+    return rowToWallet(merged);
+  }
+
+  static async softDelete(id) {
+    const result = await Database.run(
+      'UPDATE wallets SET deletedAt = ? WHERE id = ? AND deletedAt IS NULL',
+      [new Date().toISOString(), String(id)]
+    );
+    return (result && result.changes > 0) || false;
+  }
+
+  /** Test helper — wipe all wallet data. */
+  static async _clearAllData() {
+    await Database.run('DELETE FROM wallets');
   }
 }
 

--- a/src/scripts/reencrypt-memos.js
+++ b/src/scripts/reencrypt-memos.js
@@ -9,11 +9,11 @@
  *   npm run migrate:reencrypt
  *
  * The script:
- *   1. Loads all transactions from data/donations.json
+ *   1. Loads all transactions from SQLite (donations_store table)
  *   2. Identifies memos using old key versions (versioned format "v<n>:…")
  *   3. Decrypts each memo with the recipient's Stellar key
  *   4. Re-encrypts with the current active key version
- *   5. Saves the updated transactions back to data/donations.json
+ *   5. Saves the updated transactions back via the Transaction model
  *
  * Requirements:
  *   - The current active key version must be set in data/memo-keys/keys.json
@@ -28,29 +28,11 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
 const memoKeyManager = require('../utils/memoKeyManager');
 const MemoEncryptionService = require('../services/MemoEncryptionService');
-
-const DONATIONS_PATH = process.env.DB_JSON_PATH ||
-  path.join(__dirname, '../../data/donations.json');
+const Transaction = require('../models/transaction');
 
 const DRY_RUN = process.env.DRY_RUN === 'true';
-
-function loadTransactions() {
-  if (!fs.existsSync(DONATIONS_PATH)) return [];
-  try {
-    return JSON.parse(fs.readFileSync(DONATIONS_PATH, 'utf8'));
-  } catch (err) {
-    console.error('Failed to load transactions:', err.message);
-    process.exit(1);
-  }
-}
-
-function saveTransactions(transactions) {
-  fs.writeFileSync(DONATIONS_PATH, JSON.stringify(transactions, null, 2));
-}
 
 function loadRecipientSecrets() {
   if (!process.env.RECIPIENT_SECRETS) return {};
@@ -71,7 +53,9 @@ async function main() {
   console.log(`Active key version: ${activeVersion}`);
   console.log(`Key versions in store: ${allVersions.map(k => `v${k.version}${k.retiredAt ? ' (retired)' : ' (active)'}`).join(', ')}`);
 
-  const transactions = loadTransactions();
+  // Load from in-memory store (seeded from SQLite on startup)
+  await Transaction._reloadFromDb();
+  const transactions = Transaction.getAll({ includeDeleted: true });
   const recipientSecrets = loadRecipientSecrets();
 
   const toReencrypt = [];
@@ -81,7 +65,6 @@ async function main() {
   for (const tx of transactions) {
     if (!tx.memoEnvelope) continue;
 
-    // Only process versioned memos
     if (typeof tx.memoEnvelope !== 'string' || !/^v\d+:/.test(tx.memoEnvelope)) {
       skipped.push({ id: tx.id, reason: 'legacy format (not versioned)' });
       continue;
@@ -120,7 +103,6 @@ async function main() {
 
   let succeeded = 0;
   let failed = 0;
-  const updatedTransactions = [...transactions];
 
   for (const { tx, keyVersion } of toReencrypt) {
     const recipientSecret = recipientSecrets[tx.recipient];
@@ -131,25 +113,27 @@ async function main() {
     }
 
     try {
-      // Decrypt with old key version
       const plaintext = MemoEncryptionService.decryptMemoForRecipient(
         tx.memoEnvelope,
         recipientSecret
       );
 
-      // Re-encrypt with current active key version
       const { memoEnvelope: newVersionedMemo, encryptionMetadata } =
         MemoEncryptionService.encryptMemoForRecipient(plaintext, tx.recipient);
 
       if (!DRY_RUN) {
-        const idx = updatedTransactions.findIndex(t => t.id === tx.id);
-        if (idx !== -1) {
-          updatedTransactions[idx] = {
-            ...updatedTransactions[idx],
-            memoEnvelope: newVersionedMemo,
-            encryptionMetadata,
-          };
-        }
+        // Update via model so the change is persisted to SQLite
+        const Database = require('../utils/database');
+        await Database.run(
+          `UPDATE donations_store
+             SET data = json_patch(data, ?), status_updated_at = ?
+           WHERE id = ?`,
+          [
+            JSON.stringify({ memoEnvelope: newVersionedMemo, encryptionMetadata }),
+            new Date().toISOString(),
+            tx.id,
+          ]
+        );
       }
 
       console.log(`  [OK] tx ${tx.id}: re-encrypted from v${keyVersion} → v${activeVersion}`);
@@ -158,11 +142,6 @@ async function main() {
       console.error(`  [FAIL] tx ${tx.id}: ${err.message}`);
       failed++;
     }
-  }
-
-  if (!DRY_RUN && succeeded > 0) {
-    saveTransactions(updatedTransactions);
-    console.log(`\nSaved ${succeeded} re-encrypted memo(s) to ${DONATIONS_PATH}`);
   }
 
   console.log(`\nResult: ${succeeded} succeeded, ${failed} failed`);

--- a/src/services/PubSubAdapter.js
+++ b/src/services/PubSubAdapter.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { EventEmitter } = require('events');
+const log = require('../utils/log');
+
+/**
+ * PubSubAdapter — pluggable pub/sub backend for SseManager.
+ *
+ * In-process backend (default): EventEmitter — single instance only.
+ * Redis backend: uses ioredis pub/sub — events cross instances.
+ *
+ * Select via PUBSUB_ADAPTER env var: 'memory' (default) | 'redis'
+ */
+
+class PubSubAdapter {
+  async publish(channel, message) { throw new Error('Not implemented'); }
+  subscribe(channel, handler) { throw new Error('Not implemented'); }
+  async close() {}
+}
+
+class MemoryPubSubAdapter extends PubSubAdapter {
+  constructor() {
+    super();
+    this._emitter = new EventEmitter();
+    this._emitter.setMaxListeners(100);
+  }
+
+  async publish(channel, message) {
+    this._emitter.emit(channel, message);
+  }
+
+  subscribe(channel, handler) {
+    this._emitter.on(channel, handler);
+  }
+
+  unsubscribe(channel, handler) {
+    this._emitter.off(channel, handler);
+  }
+}
+
+class RedisPubSubAdapter extends PubSubAdapter {
+  constructor(publishClient, subscribeClient) {
+    super();
+    this._pub = publishClient;
+    this._sub = subscribeClient;
+    this._handlers = new Map(); // channel -> Set<handler>
+  }
+
+  async publish(channel, message) {
+    await this._pub.publish(channel, JSON.stringify(message));
+  }
+
+  subscribe(channel, handler) {
+    if (!this._handlers.has(channel)) {
+      this._handlers.set(channel, new Set());
+      this._sub.subscribe(channel);
+      this._sub.on('message', (ch, msg) => {
+        if (ch !== channel) return;
+        let parsed;
+        try { parsed = JSON.parse(msg); } catch (_) { return; }
+        for (const h of (this._handlers.get(ch) || [])) {
+          try { h(parsed); } catch (e) { log.error('PUBSUB', 'Handler error', { error: e.message }); }
+        }
+      });
+    }
+    this._handlers.get(channel).add(handler);
+  }
+
+  async close() {
+    try { await this._sub.quit(); } catch (_) {}
+    try { await this._pub.quit(); } catch (_) {}
+  }
+}
+
+let _instance = null;
+
+function getPubSubAdapter() {
+  if (_instance) return _instance;
+  const type = (process.env.PUBSUB_ADAPTER || 'memory').toLowerCase();
+  if (type === 'redis') {
+    try {
+      const Redis = require('ioredis');
+      const url = process.env.REDIS_URL;
+      if (url) {
+        _instance = new RedisPubSubAdapter(new Redis(url), new Redis(url));
+        return _instance;
+      }
+    } catch (_) {}
+    log.warn('PUBSUB', 'Redis adapter requested but unavailable; using memory');
+  }
+  _instance = new MemoryPubSubAdapter();
+  return _instance;
+}
+
+function _setAdapter(adapter) { _instance = adapter; }
+
+module.exports = { PubSubAdapter, MemoryPubSubAdapter, RedisPubSubAdapter, getPubSubAdapter, _setAdapter };

--- a/src/services/SseManager.js
+++ b/src/services/SseManager.js
@@ -1,15 +1,16 @@
 /**
  * SseManager
- * Manages SSE connections for streaming endpoints (transaction feed,
- * leaderboard, campaign progress). Clients are keyed by clientId.
- * Supports filtering by walletAddress / status / amount / campaignId / window,
- * heartbeats, per-key connection limits, and a bounded event replay buffer
- * for Last-Event-ID reconnection.
+ * Manages SSE connections. Events are published through the PubSubAdapter so
+ * they reach clients connected to any instance (cross-instance fan-out).
+ * Single-instance behaviour is preserved when no shared backend is configured.
  */
 
-const MAX_CONNECTIONS_PER_KEY = 5;
+const { getPubSubAdapter } = require('./PubSubAdapter');
+
+const MAX_CONNECTIONS_PER_KEY = parseInt(process.env.SSE_MAX_CONNECTIONS_PER_KEY || '5');
 const HEARTBEAT_INTERVAL_MS = 30_000;
-const EVENT_BUFFER_SIZE = 100;
+const EVENT_BUFFER_SIZE = parseInt(process.env.SSE_EVENT_BUFFER_SIZE || '100');
+const SSE_CHANNEL = 'sse:broadcast';
 
 class SseManager {
   constructor() {
@@ -23,6 +24,11 @@ class SseManager {
     this.MAX_CONNECTIONS_PER_KEY = MAX_CONNECTIONS_PER_KEY;
     this.HEARTBEAT_INTERVAL_MS = HEARTBEAT_INTERVAL_MS;
     this.EVENT_BUFFER_SIZE = EVENT_BUFFER_SIZE;
+
+    // Subscribe to cross-instance broadcasts
+    getPubSubAdapter().subscribe(SSE_CHANNEL, ({ event, data, id }) => {
+      this._deliverLocally(event, data, id);
+    });
   }
 
   /**
@@ -76,18 +82,26 @@ class SseManager {
 
   /**
    * Broadcast a generic SSE event to all matching clients.
-   * The event is recorded in the replay buffer so reconnecting clients can
-   * catch up via Last-Event-ID.
+   * Publishes through the PubSubAdapter so all instances receive it.
    * @param {string} event
    * @param {object} data
    */
   broadcast(event, data) {
     const id = this._nextEventId++;
+    // Record in replay buffer (bounded)
     this._eventBuffer.push({ id, event, data });
     if (this._eventBuffer.length > EVENT_BUFFER_SIZE) {
       this._eventBuffer.shift();
     }
+    // Publish cross-instance; the subscription in the constructor delivers locally
+    getPubSubAdapter().publish(SSE_CHANNEL, { event, data, id }).catch(() => {
+      // If publish fails, still deliver locally
+      this._deliverLocally(event, data, id);
+    });
+  }
 
+  /** Deliver an event to local clients only (called from pub/sub handler). */
+  _deliverLocally(event, data, id) {
     const payload = this._formatSse(event, data, id);
     for (const client of this._clients.values()) {
       if (this._matches(client.filters, data)) {

--- a/src/services/signing/HSMSigningProvider.js
+++ b/src/services/signing/HSMSigningProvider.js
@@ -1,79 +1,63 @@
 /**
- * HSM Signing Provider (Stub)
- * 
- * RESPONSIBILITY: Sign transactions using Hardware Security Module
- * OWNER: Security Team
- * 
- * Stub implementation demonstrating HSM integration pattern.
- * Production implementation would use PKCS#11 library.
+ * HSM Signing Provider
+ *
+ * IMPORTANT: This provider is NOT yet implemented (PKCS#11 integration pending).
+ * Selecting it will throw a HsmNotImplementedError at startup so operators
+ * receive an explicit failure instead of a silent fallback to software signing.
+ *
+ * There is NO automatic fallback to software signing. Any fallback must be an
+ * explicit, separately-configured opt-in.
+ *
+ * PKCS#11 implementation checklist (for the future implementer):
+ *   [ ] Load PKCS#11 library via HSM_LIBRARY_PATH
+ *   [ ] Open session with HSM_SLOT_ID + HSM_PIN
+ *   [ ] Locate signing key by HSM_KEY_IDENTIFIER
+ *   [ ] Sign the Stellar transaction hash (CKM_ECDSA)
+ *   [ ] Assert private key is non-extractable (CKA_EXTRACTABLE = false)
+ *   [ ] Handle CKR_SESSION_HANDLE_INVALID / token disconnect — re-open session
+ *   [ ] Serialise concurrent sign requests (one session per slot)
+ *   [ ] Verify produced signature against Stellar SDK before returning
+ *   [ ] Implement health check as a real test-sign or session ping
  */
+
+'use strict';
 
 const SigningProvider = require('./SigningProvider');
-const log = require('../../utils/log');
 
-/**
- * HSM-based signing provider using PKCS#11 interface
- * This is a stub implementation showing the integration pattern
- */
+class HsmNotImplementedError extends Error {
+  constructor() {
+    super(
+      'HSM signing provider is not yet implemented. ' +
+      'Configure SIGNING_PROVIDER=software to use software signing, ' +
+      'or implement the PKCS#11 integration before enabling HSM in production.'
+    );
+    this.name = 'HsmNotImplementedError';
+    this.code = 'HSM_NOT_IMPLEMENTED';
+  }
+}
+
 class HSMSigningProvider extends SigningProvider {
   constructor(config = {}) {
     super();
-    this.libraryPath = config.libraryPath || process.env.HSM_LIBRARY_PATH;
-    this.slotId = config.slotId || process.env.HSM_SLOT_ID;
-    this.pin = config.pin || process.env.HSM_PIN;
-    
-    log.info('HSM_PROVIDER', 'Initialized HSM signing provider (stub)', {
-      libraryPath: this.libraryPath,
-      slotId: this.slotId,
-    });
+    // Fail immediately at construction time so the error surfaces at startup,
+    // not at the moment a payment is being signed.
+    throw new HsmNotImplementedError();
   }
 
-  /**
-   * Sign a transaction using HSM
-   * @param {Transaction} transaction - Built Stellar transaction
-   * @param {string} keyIdentifier - HSM key identifier
-   * @returns {Promise<Transaction>} Signed transaction
-   */
-  async sign(transaction, keyIdentifier) {
-    // TODO: Implement PKCS#11 signing
-    // 1. Connect to HSM using libraryPath
-    // 2. Open session with slotId and pin
-    // 3. Find key by keyIdentifier
-    // 4. Sign transaction hash with HSM key
-    // 5. Attach signature to transaction
-    
-    throw new Error('HSM signing not yet implemented - stub only');
+  // The methods below are never reached; they exist for documentation only.
+
+  async sign(_transaction, _keyIdentifier) {
+    throw new HsmNotImplementedError();
   }
 
-  /**
-   * Get public key from HSM
-   * @param {string} keyIdentifier - HSM key identifier
-   * @returns {Promise<string>} Stellar public key
-   */
-  async getPublicKey(keyIdentifier) {
-    // TODO: Implement HSM public key retrieval
-    // 1. Connect to HSM
-    // 2. Find key by keyIdentifier
-    // 3. Extract public key
-    // 4. Convert to Stellar format
-    
-    throw new Error('HSM public key retrieval not yet implemented - stub only');
+  async getPublicKey(_keyIdentifier) {
+    throw new HsmNotImplementedError();
   }
 
-  /**
-   * Check HSM connectivity and configuration
-   * @returns {Promise<boolean>} True if HSM is accessible
-   */
   async healthCheck() {
-    // TODO: Implement HSM health check
-    // 1. Verify library path exists
-    // 2. Connect to HSM
-    // 3. Verify slot is accessible
-    // 4. Test authentication with PIN
-    
-    log.warn('HSM_PROVIDER', 'Health check not implemented - returning false');
     return false;
   }
 }
 
 module.exports = HSMSigningProvider;
+module.exports.HsmNotImplementedError = HsmNotImplementedError;

--- a/src/services/signing/index.js
+++ b/src/services/signing/index.js
@@ -1,38 +1,42 @@
-/**
- * Signing Provider Factory
- * 
- * RESPONSIBILITY: Create and configure signing providers
- * OWNER: Security Team
- */
+'use strict';
 
 const SoftwareSigningProvider = require('./SoftwareSigningProvider');
-const HSMSigningProvider = require('./HSMSigningProvider');
 const log = require('../../utils/log');
 
 /**
- * Get the configured signing provider based on environment
- * @returns {SigningProvider} Configured signing provider instance
+ * Return the configured signing provider.
+ * SIGNING_PROVIDER env var: 'software' (default) | 'hsm'
+ *
+ * If 'hsm' is configured, HSMSigningProvider constructor throws HsmNotImplementedError
+ * immediately so the process fails at startup rather than silently at payment time.
+ * There is NO automatic fallback to software signing for HSM — that would destroy
+ * the key-custody guarantee. Any fallback must be an explicit opt-in.
  */
 function getSigningProvider() {
-  const providerType = process.env.SIGNING_PROVIDER || 'software';
-  
-  switch (providerType.toLowerCase()) {
-    case 'software':
-      log.info('SIGNING', 'Using software signing provider');
-      return new SoftwareSigningProvider();
-      
-    case 'hsm':
-      log.info('SIGNING', 'Using HSM signing provider');
-      return new HSMSigningProvider();
-      
-    default:
-      log.warn('SIGNING', `Unknown provider type: ${providerType}, falling back to software`);
-      return new SoftwareSigningProvider();
+  const providerType = (process.env.SIGNING_PROVIDER || 'software').toLowerCase();
+
+  if (providerType === 'software') {
+    log.info('SIGNING', 'Using software signing provider');
+    return new SoftwareSigningProvider();
   }
+
+  if (providerType === 'hsm') {
+    // Intentionally NOT wrapped in try/catch — the HsmNotImplementedError must
+    // propagate to the caller so startup fails loudly.
+    const HSMSigningProvider = require('./HSMSigningProvider');
+    log.info('SIGNING', 'Initialising HSM signing provider');
+    return new HSMSigningProvider();
+  }
+
+  // Unknown provider — fail loudly; do not silently degrade.
+  throw new Error(
+    `Unknown SIGNING_PROVIDER value: "${providerType}". ` +
+    'Valid values: "software", "hsm".'
+  );
 }
 
 module.exports = {
   getSigningProvider,
   SoftwareSigningProvider,
-  HSMSigningProvider,
+  get HSMSigningProvider() { return require('./HSMSigningProvider'); },
 };

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -80,22 +80,22 @@ const sanitizeString = (str) => {
 };
 
 /**
- * Check if a wallet/user exists by ID
+ * Check if a wallet/user exists by ID (async)
  */
-const walletExists = (id) => {
+const walletExists = async (id) => {
   if (!id && id !== 0) return false;
   const User = require('../models/user');
-  const user = User.getById(id);
+  const user = await User.getById(id);
   return user !== null && user !== undefined;
 };
 
 /**
- * Check if a wallet address exists
+ * Check if a wallet address exists (async)
  */
-const walletAddressExists = (address) => {
+const walletAddressExists = async (address) => {
   if (!address) return false;
   const User = require('../models/user');
-  const user = User.getByWallet(address);
+  const user = await User.getByWallet(address);
   return user !== null && user !== undefined;
 };
 


### PR DESCRIPTION
## Summary

Resolves four issues in one PR: removes the dual JSON/SQLite persistence hazard, makes rate limiting horizontally scalable, enables cross-instance SSE fan-out, and fences off the unimplemented HSM signing stub.

---

### Closes #1081 — Unify persistence layer (remove JSON stores)

**Problem:** `data/donations.json`, `data/users.json`, `data/wallets.json` coexisted with SQLite, creating two unsynchronised sources of truth.

**Changes:**
- `src/models/wallet.js` — rewritten to use a new `wallets` SQLite table (migration `018_wallets_table.js`)
- `src/models/transaction.js` — in-memory store seeded from SQLite (`donations_store` table, migration `019_donations_store.js`); synchronous API preserved; amounts stored as exact integer stroops to prevent float coercion
- `src/models/user.js` — static `data/users.json` require replaced with async SQLite queries against the existing `users` table
- `src/utils/validators.js` — `walletExists`/`walletAddressExists` updated to async
- `src/config/index.js`, `src/config/stellar.js` — `DB_JSON_PATH`/`jsonPath` references removed
- `src/scripts/reencrypt-memos.js` — rewritten to load transactions via `Transaction._reloadFromDb()` and write back via SQLite
- `scripts/check-no-json-persistence.js` — new CI guard; greps `src/` for banned JSON path references in executable code and exits 1 on any match
- `.github/workflows/ci.yml`, `package.json` — guard wired into CI pipeline

---

### Closes #1082 — RateLimitStore interface (horizontally scalable rate limiting)

**Problem:** `perKeyRateLimit.js` stored counters in a process-local `Map`; behind a load balancer each replica enforced limits independently, giving clients N× their limit.

**Changes:**
- `src/middleware/RateLimitStore.js` — new file:
  - `RateLimitStore` base interface
  - `MemoryRateLimitStore`: sliding-window, TTL-bounded (no unbounded growth)
  - `RedisRateLimitStore`: atomic increment via Lua `INCR+EXPIRE` — the check is atomic across replicas so the global limit is never exceeded at the boundary
  - Configurable fail-open/fail-closed via `RATE_LIMIT_FAIL_OPEN` env var (default: fail-open)
  - Backend selected via `RATE_LIMIT_STORE` env var (`memory` | `redis`)
- `src/middleware/perKeyRateLimit.js` — delegates to `RateLimitStore`; counters survive restarts with Redis backend

---

### Closes #1083 — SSE pub/sub abstraction (cross-instance event delivery)

**Problem:** `SseManager` kept clients in a process-local `Map`; events produced on instance A never reached clients connected to instance B.

**Changes:**
- `src/services/PubSubAdapter.js` — new file:
  - `MemoryPubSubAdapter`: in-process EventEmitter (default, preserves single-instance behaviour)
  - `RedisPubSubAdapter`: ioredis pub/sub — events from any instance fan out to all instances; selected via `PUBSUB_ADAPTER=redis` + `REDIS_URL`
- `src/services/SseManager.js`:
  - `broadcast()` publishes through `PubSubAdapter` instead of writing to local clients directly
  - Constructor subscribes to `sse:broadcast` channel so incoming messages from any instance are delivered to local connected clients
  - Per-instance connection cap configurable via `SSE_MAX_CONNECTIONS_PER_KEY`

---

### Closes #1085 — HSM stub fenced off from production use

**Problem:** `HSMSigningProvider` was an unimplemented stub; selecting it could silently fall back to software signing, destroying key-custody guarantees.

**Changes:**
- `src/services/signing/HSMSigningProvider.js` — constructor throws `HsmNotImplementedError` immediately at instantiation (startup failure, not payment-time failure); `healthCheck()` returns `false`; PKCS#11 implementation checklist in file header
- `src/services/signing/index.js` — silent fallback to software signing removed; unknown `SIGNING_PROVIDER` value throws instead of silently degrading; HSM error propagates to startup

---

## Configuration reference

| Env var | Values | Default | Purpose |
|---|---|---|---|
| `RATE_LIMIT_STORE` | `memory` / `redis` | `memory` | Rate limit backend |
| `RATE_LIMIT_FAIL_OPEN` | `true` / `false` | `true` | Allow requests when Redis is down |
| `PUBSUB_ADAPTER` | `memory` / `redis` | `memory` | SSE pub/sub backend |
| `REDIS_URL` | Redis connection URL | — | Used by both Redis backends |
| `SSE_MAX_CONNECTIONS_PER_KEY` | integer | `5` | Per-instance SSE connection cap |
| `SIGNING_PROVIDER` | `software` / `hsm` | `software` | Transaction signing backend |

Closes #1081
Closes #1082
Closes #1083
Closes #1085