### PR TITLE
Add timestamped HMAC signatures to outbound webhooks and verification…

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ The scheduler runs automatically when the server starts and checks for due donat
 
 ### Getting Started
 - **[API Examples](docs/API_EXAMPLES.md)** - Complete request/response examples for all endpoints
+- **[Webhook verification](docs/WEBHOOK_VERIFICATION.md)** - Verify outbound webhook authenticity with timestamped HMAC signatures
 - **[Quick Start Guide](QUICK_START.md)** - Getting started quickly
 - **[Troubleshooting Guide](docs/DEVELOPER_TROUBLESHOOTING_GUIDE.md)** - Solutions for common issues
 - **[Quick Reference](docs/TROUBLESHOOTING_QUICK_REFERENCE.md)** - Fast fixes for common problems

--- a/docs/WEBHOOK_VERIFICATION.md
+++ b/docs/WEBHOOK_VERIFICATION.md
@@ -1,0 +1,72 @@
+# Webhook Verification
+
+Outbound webhooks from this API are signed so consumers can verify authenticity.
+
+## Headers
+
+Each webhook delivery includes the following HTTP headers:
+
+- `X-Signature`: `sha256=<hex>` HMAC-SHA256 signature.
+- `X-Signature-Timestamp`: ISO 8601 timestamp used in the HMAC payload.
+- `X-Webhook-Signature`: legacy-compatible duplicate of `X-Signature`.
+- `X-Webhook-Timestamp`: legacy-compatible duplicate of `X-Signature-Timestamp`.
+
+## Signature computation
+
+The signature is computed using the webhook endpoint's secret and the raw JSON body exactly as sent.
+
+The signed input is:
+
+```text
+<timestamp>.<body>
+```
+
+Where:
+
+- `<timestamp>` is the value of `X-Signature-Timestamp`.
+- `<body>` is the raw JSON string sent in the request body.
+
+## Verification example (Node.js)
+
+```js
+const crypto = require('crypto');
+
+function verifyWebhook({ secret, rawBody, signatureHeader, timestampHeader }) {
+  const signature = signatureHeader || '';
+  const timestamp = timestampHeader || '';
+
+  if (!signature || !timestamp) {
+    return { valid: false, reason: 'Missing signature or timestamp header' };
+  }
+
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+
+  const expectedHeader = `sha256=${expected}`;
+  if (signature !== expectedHeader) {
+    return { valid: false, reason: 'Signature mismatch' };
+  }
+
+  const ageMs = Date.now() - new Date(timestamp).getTime();
+  if (Number.isNaN(ageMs) || ageMs > 5 * 60 * 1000 || ageMs < -30 * 1000) {
+    return { valid: false, reason: 'Timestamp expired or invalid' };
+  }
+
+  return { valid: true };
+}
+
+module.exports = { verifyWebhook };
+```
+
+## Replay protection
+
+Consumers should enforce a timestamp window in addition to verifying the HMAC signature.
+
+A recommended policy is:
+
+- accept timestamps no older than 5 minutes
+- reject timestamps more than 30 seconds in the future
+
+This ensures that replayed webhook deliveries cannot be reused indefinitely.

--- a/src/services/WebhookService.js
+++ b/src/services/WebhookService.js
@@ -530,10 +530,11 @@ class WebhookService {
    */
   async _deliverWithRetry(webhook, event, payload, attempt) {
     const correlationHeaders = generateCorrelationHeaders();
+    const timestamp = new Date().toISOString();
     const body = JSON.stringify({
       event,
       data: payload,
-      timestamp: new Date().toISOString(),
+      timestamp,
       correlationContext: {
         correlationId: correlationHeaders['X-Correlation-ID'],
         traceId: correlationHeaders['X-Trace-ID'],
@@ -543,10 +544,10 @@ class WebhookService {
     const plaintextSecret = webhook.secret
       ? EncryptionService.decryptField(webhook.secret)
       : '';
-    const signature = WebhookService._sign(body, plaintextSecret);
+    const signature = WebhookService._sign(body, plaintextSecret, timestamp);
 
     try {
-      const result = await WebhookService._httpPost(webhook.url, body, signature, correlationHeaders, !!webhook.tls_skip_verify);
+      const result = await WebhookService._httpPost(webhook.url, body, signature, timestamp, correlationHeaders, !!webhook.tls_skip_verify);
       
       // Log successful delivery
       const Database = require('../utils/database');
@@ -592,19 +593,22 @@ class WebhookService {
 
   /**
    * Compute HMAC-SHA256 signature for a payload.
+   * If a timestamp is provided, sign over timestamp + '.' + raw body.
    * @param {string} body
    * @param {string} secret
+   * @param {string} [timestamp]
    * @returns {string}
    */
-  static _sign(body, secret) {
-    return crypto.createHmac('sha256', secret).update(body).digest('hex');
+  static _sign(body, secret, timestamp) {
+    const payload = timestamp ? `${timestamp}.${body}` : body;
+    return crypto.createHmac('sha256', secret).update(payload).digest('hex');
   }
 
   /**
    * POST a JSON body to a URL with a timeout.
    * @private
    */
-  static _httpPost(url, body, signature, correlationHeaders = {}, tlsSkipVerify = false) {
+  static _httpPost(url, body, signature, timestamp, correlationHeaders = {}, tlsSkipVerify = false) {
     return new Promise((resolve, reject) => {
       const parsed = new URL(url);
       const lib = parsed.protocol === 'https:' ? https : http;
@@ -617,7 +621,10 @@ class WebhookService {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(body),
           'User-Agent': 'Stella-Donation-API/1.0',
+          'X-Signature': `sha256=${signature}`,
+          'X-Signature-Timestamp': timestamp,
           'X-Webhook-Signature': `sha256=${signature}`,
+          'X-Webhook-Timestamp': timestamp,
           ...correlationHeaders,
         },
         // Explicitly enforce TLS verification regardless of NODE_TLS_REJECT_UNAUTHORIZED

--- a/tests/webhooks/webhooks.test.js
+++ b/tests/webhooks/webhooks.test.js
@@ -74,6 +74,8 @@ process.env.MOCK_STELLAR = 'true';
 process.env.API_KEYS = 'test-key-1';
 
 const crypto = require('crypto');
+const http = require('http');
+const https = require('https');
 const request = require('supertest');
 const express = require('express');
 const WebhookService = require('../../src/services/WebhookService');
@@ -164,9 +166,53 @@ describe('WebhookService HMAC signing', () => {
     expect(sig).toBe(expected);
   });
 
+  it('_sign can include timestamp in the signed payload', () => {
+    const body = '{"event":"transaction.confirmed"}';
+    const secret = 'test-secret';
+    const timestamp = '2026-06-25T12:00:00.000Z';
+    const sig = WebhookService._sign(body, secret, timestamp);
+    const expected = crypto.createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+    expect(sig).toBe(expected);
+  });
+
   it('different secrets produce different signatures', () => {
     const body = '{"event":"test"}';
     expect(WebhookService._sign(body, 'secret-a')).not.toBe(WebhookService._sign(body, 'secret-b'));
+  });
+
+  it('_httpPost includes signature and timestamp headers', async () => {
+    const body = '{"event":"test"}';
+    const signature = 'deadbeef';
+    const timestamp = '2026-06-25T12:00:00.000Z';
+    const req = {
+      on: jest.fn().mockReturnThis(),
+      write: jest.fn(),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+
+    const requestSpy = jest.spyOn(https, 'request').mockImplementation((options, callback) => {
+      process.nextTick(() => callback({ statusCode: 200, resume: jest.fn() }));
+      return req;
+    });
+
+    await expect(
+      WebhookService._httpPost('https://example.com/hook', body, signature, timestamp, {}, false)
+    ).resolves.toEqual({ delivered: true, statusCode: 200 });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Signature': `sha256=${signature}`,
+          'X-Signature-Timestamp': timestamp,
+          'X-Webhook-Signature': `sha256=${signature}`,
+          'X-Webhook-Timestamp': timestamp,
+        }),
+      }),
+      expect.any(Function)
+    );
+
+    requestSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
… docs

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed


Closes #1120 