### PR TITLE
fix: persist CorporateMatching/SEP10 state, sanitize errors, durable audit log

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -108,7 +108,7 @@ function errorHandler(err, req, res, next) {
   const isProduction = process.env.NODE_ENV === 'production';
   const lang = parseLanguage(req.headers && req.headers['accept-language']);
 
-  // Log 1: detailed context
+  // Log detailed context server-side only
   log.error("ERROR_HANDLER", "Error occurred", {
     requestId: req.id,
     path: req.path,
@@ -119,22 +119,12 @@ function errorHandler(err, req, res, next) {
       code: err.errorCode || err.code,
       numericCode: err.numericCode,
       statusCode: err.statusCode || err.status,
-      ...(!isProduction && { stack: err.stack }),
+      stack: err.stack, // server-side only, never sent to client
       ...(err.details && { details: maskSensitiveData(err.details) }),
     },
     ...(req.get && { userAgent: req.get("User-Agent") }),
     ...(req.ip && { ip: req.ip }),
     timestamp: new Date().toISOString(),
-  });
-
-  // Log 2: simple audit trail
-  log.error('ERROR_HANDLER', 'Error occurred', {
-    requestId: req.id,
-    path: req.path,
-    method: req.method,
-    error: err.message,
-    code: err.errorCode || err.code,
-    numericCode: err.numericCode,
   });
 
   res.set('Content-Language', lang);
@@ -147,6 +137,9 @@ function errorHandler(err, req, res, next) {
     if (translated) errorBody.error.message = translated;
     if (!isProduction) {
       errorBody.error.debug = { name: err.name };
+    } else {
+      // Strip any details that might contain internal info in production
+      delete errorBody.error.details;
     }
     // Set X-Limit-Reset header for velocity limit errors
     if (err.statusCode === 429 && err.resetAt) {

--- a/src/migrations/024_corporate_matching_and_sep10_challenges.js
+++ b/src/migrations/024_corporate_matching_and_sep10_challenges.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Migration 024: Persist CorporateMatchingService state and SEP-10 challenge store
+ * Fixes #1134 and #1135
+ */
+
+const name = '024_corporate_matching_and_sep10_challenges';
+
+async function up(db) {
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS corporate_employers (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      matchRatio INTEGER NOT NULL,
+      annualCap REAL NOT NULL,
+      addedAt TEXT NOT NULL
+    )
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS corporate_claims (
+      id TEXT PRIMARY KEY,
+      donorId TEXT NOT NULL,
+      employerId TEXT NOT NULL,
+      donationAmount REAL NOT NULL,
+      matchAmount REAL NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      createdAt TEXT NOT NULL,
+      reviewedAt TEXT,
+      rejectReason TEXT,
+      txId TEXT
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_corporate_claims_employer_donor
+    ON corporate_claims(employerId, donorId, status, createdAt)
+  `);
+
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS sep10_challenges (
+      challengeId TEXT PRIMARY KEY,
+      account TEXT NOT NULL,
+      expiresAt INTEGER NOT NULL,
+      issuedAt INTEGER NOT NULL,
+      used INTEGER NOT NULL DEFAULT 0,
+      usedAt INTEGER
+    )
+  `);
+
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_sep10_challenges_expires
+    ON sep10_challenges(expiresAt)
+  `);
+}
+
+async function down(db) {
+  await db.run('DROP TABLE IF EXISTS sep10_challenges');
+  await db.run('DROP TABLE IF EXISTS corporate_claims');
+  await db.run('DROP TABLE IF EXISTS corporate_employers');
+}
+
+module.exports = { name, up, down };

--- a/src/services/AuditLogService.js
+++ b/src/services/AuditLogService.js
@@ -125,12 +125,6 @@ const auditLogMetrics = {
   totalFailures: 0,
 };
 
-/** In-memory buffer for pending audit log entries */
-const _pendingBuffer = [];
-const _BUFFER_FLUSH_THRESHOLD = 20;
-const BUFFER_FLUSH_INTERVAL_MS = 2000;
-let _autoFlushTimer = null;
-
 class AuditLogService {
   /**
    * Return a snapshot of audit log failure metrics.
@@ -388,79 +382,31 @@ class AuditLogService {
   }
 
   /**
-   * Write all buffered entries to the database in a single transaction.
-   * Has a 5-second timeout; on timeout the buffered entries are written to stderr and the
-   * buffer is cleared so that shutdown can proceed.
-   * Safe to call multiple times (idempotent).
+   * Flush pending audit entries to the database.
+   * All audit entries are written synchronously on each call to _log(), so this
+   * is a no-op kept for API compatibility with the shutdown sequence.
    * @returns {Promise<void>}
    */
   static async flush() {
-    if (_pendingBuffer.length === 0) return;
-
-    const entries = _pendingBuffer.splice(0, _pendingBuffer.length);
-
-    const writeEntries = async () => {
-      await db.run('BEGIN TRANSACTION');
-      try {
-        for (const entry of entries) {
-          await db.run(
-            `INSERT INTO audit_logs (
-              id, timestamp, category, action, severity, result,
-              userId, requestId, ipAddress, resource, reason,
-              details, integrityHash
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-            [
-              entry.id, entry.timestamp, entry.category, entry.action, entry.severity, entry.result,
-              entry.userId, entry.requestId, entry.ipAddress, entry.resource, entry.reason,
-              entry.details, entry.integrityHash
-            ]
-          );
-        }
-        await db.run('COMMIT');
-      } catch (err) {
-        await db.run('ROLLBACK').catch(() => {});
-        throw err;
-      }
-    };
-
-    const FLUSH_TIMEOUT_MS = 5000;
-    try {
-      await Promise.race([
-        writeEntries(),
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('flush timeout')), FLUSH_TIMEOUT_MS)
-        ),
-      ]);
-    } catch (err) {
-      process.stderr.write(
-        JSON.stringify({ event: 'audit_flush_failed', error: err.message, entries }) + '\n'
-      );
-    }
+    // All writes are direct (write-through). Nothing to flush.
   }
 
   /**
-   * Start the periodic auto-flush timer.
+   * Start periodic maintenance (cleans up any stale state).
+   * Kept for API compatibility with server bootstrap.
    * @returns {void}
    */
   static startAutoFlush() {
-    if (_autoFlushTimer) return;
-    _autoFlushTimer = setInterval(() => {
-      if (_pendingBuffer.length > 0) {
-        AuditLogService.flush().catch(() => {});
-      }
-    }, BUFFER_FLUSH_INTERVAL_MS);
-    if (_autoFlushTimer.unref) _autoFlushTimer.unref();
+    // No buffer — direct writes only. No timer needed.
   }
 
   /**
-   * Stop the periodic auto-flush timer.
+   * Stop periodic maintenance.
+   * Kept for API compatibility with server bootstrap.
    * @returns {void}
    */
   static stopAutoFlush() {
-    if (_autoFlushTimer) {
-      clearInterval(_autoFlushTimer);
-      _autoFlushTimer = null;
-    }
+    // No-op.
   }
 
   /**

--- a/src/services/CorporateMatchingService.js
+++ b/src/services/CorporateMatchingService.js
@@ -1,101 +1,71 @@
 /**
  * CorporateMatchingService
  * Manages employer allowlist, match ratios, annual caps, and the claim workflow.
+ * State is persisted to the database (fixes #1134).
  */
 
 const crypto = require('crypto');
+const db = require('../utils/database');
 
 class CorporateMatchingService {
   constructor(stellarService = null) {
-    /** @type {Map<string, {name: string, matchRatio: number, annualCap: number, addedAt: string}>} */
-    this.employers = new Map();
-
-    /** @type {Map<string, {id: string, donorId: string, employerId: string, donationAmount: number, matchAmount: number, status: string, createdAt: string, reviewedAt?: string, txId?: string}>} */
-    this.claims = new Map();
-
     this.stellarService = stellarService;
   }
 
   // ─── Employer Management ────────────────────────────────────────────────────
 
-  /**
-   * Add or update an employer in the allowlist.
-   * @param {string} employerId - Unique employer identifier
-   * @param {string} name - Display name
-   * @param {1|2|3} matchRatio - Match ratio (1, 2, or 3)
-   * @param {number} annualCap - Maximum XLM matched per employee per year
-   * @returns {{employerId: string, name: string, matchRatio: number, annualCap: number}}
-   */
-  addEmployer(employerId, name, matchRatio, annualCap) {
+  async addEmployer(employerId, name, matchRatio, annualCap) {
     if (!employerId || !name) throw new Error('employerId and name are required');
     if (![1, 2, 3].includes(matchRatio)) throw new Error('matchRatio must be 1, 2, or 3');
     if (!annualCap || annualCap <= 0) throw new Error('annualCap must be a positive number');
 
-    const employer = { name, matchRatio, annualCap, addedAt: new Date().toISOString() };
-    this.employers.set(employerId, employer);
-    return { employerId, ...employer };
+    const addedAt = new Date().toISOString();
+    await db.run(
+      `INSERT INTO corporate_employers (id, name, matchRatio, annualCap, addedAt)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET name=excluded.name, matchRatio=excluded.matchRatio,
+         annualCap=excluded.annualCap`,
+      [employerId, name, matchRatio, annualCap, addedAt]
+    );
+    return { employerId, name, matchRatio, annualCap, addedAt };
   }
 
-  /**
-   * Get all employers in the allowlist.
-   * @returns {Array}
-   */
-  listEmployers() {
-    return Array.from(this.employers.entries()).map(([employerId, e]) => ({ employerId, ...e }));
+  async listEmployers() {
+    const rows = await db.all('SELECT * FROM corporate_employers');
+    return rows.map(r => ({ employerId: r.id, name: r.name, matchRatio: r.matchRatio, annualCap: r.annualCap, addedAt: r.addedAt }));
   }
 
-  /**
-   * Check if an employer is in the allowlist.
-   * @param {string} employerId
-   * @returns {boolean}
-   */
-  isEmployerAllowed(employerId) {
-    return this.employers.has(employerId);
+  async isEmployerAllowed(employerId) {
+    const row = await db.get('SELECT id FROM corporate_employers WHERE id = ?', [employerId]);
+    return Boolean(row);
   }
 
   // ─── Annual Cap Tracking ─────────────────────────────────────────────────────
 
-  /**
-   * Calculate total matched amount for a donor+employer pair in the current calendar year.
-   * @param {string} donorId
-   * @param {string} employerId
-   * @returns {number}
-   */
-  getYearlyMatchedAmount(donorId, employerId) {
+  async getYearlyMatchedAmount(donorId, employerId) {
     const year = new Date().getFullYear();
-    let total = 0;
-    for (const claim of this.claims.values()) {
-      if (
-        claim.donorId === donorId &&
-        claim.employerId === employerId &&
-        claim.status === 'approved' &&
-        new Date(claim.createdAt).getFullYear() === year
-      ) {
-        total += claim.matchAmount;
-      }
-    }
-    return total;
+    const yearStart = `${year}-01-01T00:00:00.000Z`;
+    const yearEnd = `${year + 1}-01-01T00:00:00.000Z`;
+    const row = await db.get(
+      `SELECT COALESCE(SUM(matchAmount), 0) as total FROM corporate_claims
+       WHERE donorId = ? AND employerId = ? AND status = 'approved'
+         AND createdAt >= ? AND createdAt < ?`,
+      [donorId, employerId, yearStart, yearEnd]
+    );
+    return row ? row.total : 0;
   }
 
   // ─── Claim Workflow ──────────────────────────────────────────────────────────
 
-  /**
-   * Submit a match claim for a donation.
-   * @param {string} donorId - Donor identifier
-   * @param {string} employerId - Employer identifier (must be in allowlist)
-   * @param {number} donationAmount - Original donation amount in XLM
-   * @returns {Object} Created claim
-   */
-  submitClaim(donorId, employerId, donationAmount) {
+  async submitClaim(donorId, employerId, donationAmount) {
     if (!donorId) throw new Error('donorId is required');
-    if (!this.isEmployerAllowed(employerId)) throw new Error(`Employer '${employerId}' is not in the allowlist`);
+    if (!(await this.isEmployerAllowed(employerId))) throw new Error(`Employer '${employerId}' is not in the allowlist`);
     if (!donationAmount || donationAmount <= 0) throw new Error('donationAmount must be a positive number');
 
-    const employer = this.employers.get(employerId);
+    const employer = await db.get('SELECT * FROM corporate_employers WHERE id = ?', [employerId]);
     const matchAmount = donationAmount * employer.matchRatio;
 
-    // Check annual cap
-    const alreadyMatched = this.getYearlyMatchedAmount(donorId, employerId);
+    const alreadyMatched = await this.getYearlyMatchedAmount(donorId, employerId);
     const remaining = employer.annualCap - alreadyMatched;
     if (remaining <= 0) {
       throw new Error(`Annual cap of ${employer.annualCap} XLM reached for employer '${employerId}'`);
@@ -103,86 +73,65 @@ class CorporateMatchingService {
 
     const effectiveMatch = Math.min(matchAmount, remaining);
     const id = crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex');
+    const createdAt = new Date().toISOString();
 
-    const claim = {
-      id,
-      donorId,
-      employerId,
-      donationAmount,
-      matchAmount: effectiveMatch,
-      status: 'pending',
-      createdAt: new Date().toISOString(),
-    };
-
-    this.claims.set(id, claim);
-    return { ...claim };
+    await db.run(
+      `INSERT INTO corporate_claims (id, donorId, employerId, donationAmount, matchAmount, status, createdAt)
+       VALUES (?, ?, ?, ?, ?, 'pending', ?)`,
+      [id, donorId, employerId, donationAmount, effectiveMatch, createdAt]
+    );
+    return { id, donorId, employerId, donationAmount, matchAmount: effectiveMatch, status: 'pending', createdAt };
   }
 
-  /**
-   * List claims, optionally filtered by status.
-   * @param {string} [status] - Filter by status ('pending', 'approved', 'rejected')
-   * @returns {Array}
-   */
-  listClaims(status) {
-    const all = Array.from(this.claims.values());
-    return status ? all.filter(c => c.status === status) : all;
+  async listClaims(status) {
+    const rows = status
+      ? await db.all('SELECT * FROM corporate_claims WHERE status = ?', [status])
+      : await db.all('SELECT * FROM corporate_claims');
+    return rows;
   }
 
-  /**
-   * Approve a claim and execute the matching donation on-chain.
-   * @param {string} claimId
-   * @param {string} sourcePublicKey - Employer's Stellar public key for the match payment
-   * @param {string} donorPublicKey - Donor's Stellar public key to receive the match
-   * @returns {Promise<Object>} Updated claim with txId
-   */
   async approveClaim(claimId, sourcePublicKey, donorPublicKey) {
-    const claim = this.claims.get(claimId);
+    const claim = await db.get('SELECT * FROM corporate_claims WHERE id = ?', [claimId]);
     if (!claim) throw new Error(`Claim '${claimId}' not found`);
     if (claim.status !== 'pending') throw new Error(`Claim is already ${claim.status}`);
 
-    // Re-check annual cap at approval time (guard against race conditions)
-    const employer = this.employers.get(claim.employerId);
-    const alreadyMatched = this.getYearlyMatchedAmount(claim.donorId, claim.employerId);
+    const employer = await db.get('SELECT * FROM corporate_employers WHERE id = ?', [claim.employerId]);
+    const alreadyMatched = await this.getYearlyMatchedAmount(claim.donorId, claim.employerId);
     if (alreadyMatched + claim.matchAmount > employer.annualCap) {
-      claim.status = 'rejected';
-      claim.reviewedAt = new Date().toISOString();
-      claim.rejectReason = 'Annual cap exceeded at approval time';
-      return { ...claim };
+      await db.run(
+        `UPDATE corporate_claims SET status='rejected', reviewedAt=?, rejectReason=? WHERE id=?`,
+        [new Date().toISOString(), 'Annual cap exceeded at approval time', claimId]
+      );
+      return await db.get('SELECT * FROM corporate_claims WHERE id = ?', [claimId]);
     }
 
-    // Execute on-chain
     let txId = null;
     if (this.stellarService) {
       const result = await this.stellarService.sendPayment(
-        sourcePublicKey,
-        donorPublicKey,
-        claim.matchAmount,
+        sourcePublicKey, donorPublicKey, claim.matchAmount,
         `Corporate match for donation by ${claim.donorId}`
       );
       txId = result.hash || result.transactionId;
     }
 
-    claim.status = 'approved';
-    claim.reviewedAt = new Date().toISOString();
-    claim.txId = txId;
-    return { ...claim };
+    const reviewedAt = new Date().toISOString();
+    await db.run(
+      `UPDATE corporate_claims SET status='approved', reviewedAt=?, txId=? WHERE id=?`,
+      [reviewedAt, txId, claimId]
+    );
+    return await db.get('SELECT * FROM corporate_claims WHERE id = ?', [claimId]);
   }
 
-  /**
-   * Reject a claim.
-   * @param {string} claimId
-   * @param {string} [reason]
-   * @returns {Object} Updated claim
-   */
-  rejectClaim(claimId, reason) {
-    const claim = this.claims.get(claimId);
+  async rejectClaim(claimId, reason) {
+    const claim = await db.get('SELECT * FROM corporate_claims WHERE id = ?', [claimId]);
     if (!claim) throw new Error(`Claim '${claimId}' not found`);
     if (claim.status !== 'pending') throw new Error(`Claim is already ${claim.status}`);
 
-    claim.status = 'rejected';
-    claim.reviewedAt = new Date().toISOString();
-    if (reason) claim.rejectReason = reason;
-    return { ...claim };
+    await db.run(
+      `UPDATE corporate_claims SET status='rejected', reviewedAt=?, rejectReason=? WHERE id=?`,
+      [new Date().toISOString(), reason || null, claimId]
+    );
+    return await db.get('SELECT * FROM corporate_claims WHERE id = ?', [claimId]);
   }
 }
 

--- a/src/services/SEP10Service.js
+++ b/src/services/SEP10Service.js
@@ -15,11 +15,11 @@ const StellarSdk = require('stellar-sdk');
 const { issueAccessToken } = require('./JwtService');
 const log = require('../utils/log');
 const { ValidationError, ERROR_CODES } = require('../utils/errors');
+const db = require('../utils/database');
 
 class SEP10Service {
   constructor(stellarService, config = {}) {
     this.stellarService = stellarService;
-    this.challengeStore = new Map();
     this.challengePrefix = config.challengePrefix || 'web_auth_';
     this.config = {
       challengeExpiresIn: config.challengeExpiresIn || 15 * 60 * 1000, // default 15 minutes
@@ -50,7 +50,7 @@ class SEP10Service {
         );
       }
 
-      this._cleanupExpiredChallenges();
+      await this._cleanupExpiredChallenges();
 
       const serverKeypair = StellarSdk.Keypair.fromSecret(this.config.serverSigningKey);
       const serverAccount = await this.stellarService.loadAccount(serverKeypair.publicKey());
@@ -75,7 +75,7 @@ class SEP10Service {
 
       transaction.sign(serverKeypair);
 
-      this._registerChallenge(challengeId, clientAccount, expiresAtMs);
+      await this._registerChallenge(challengeId, clientAccount, expiresAtMs);
 
       log.info('SEP10', 'Challenge transaction generated', {
         clientAccount: this._maskPublicKey(clientAccount),
@@ -117,8 +117,8 @@ class SEP10Service {
       this._verifyServerSignature(transaction);
       this._verifyTransactionSignatures(transaction, clientAccount);
 
-      this._getChallengeEntry(memoPayload.challengeId, clientAccount);
-      this._markChallengeUsed(memoPayload.challengeId);
+      await this._getChallengeEntry(memoPayload.challengeId, clientAccount);
+      await this._markChallengeUsed(memoPayload.challengeId);
 
       log.info('SEP10', 'Challenge verification successful', {
         account: this._maskPublicKey(clientAccount)
@@ -159,39 +159,36 @@ class SEP10Service {
   }
 
   /**
-   * Register issued challenge for replay detection and TTL enforcement
+   * Register issued challenge in the database for replay detection and TTL enforcement
    * @private
    */
-  _registerChallenge(challengeId, clientAccount, expiresAt) {
-    this.challengeStore.set(challengeId, {
-      account: clientAccount,
-      expiresAt,
-      issuedAt: Date.now(),
-      used: false,
-    });
+  async _registerChallenge(challengeId, clientAccount, expiresAt) {
+    await db.run(
+      `INSERT INTO sep10_challenges (challengeId, account, expiresAt, issuedAt, used)
+       VALUES (?, ?, ?, ?, 0)`,
+      [challengeId, clientAccount, expiresAt, Date.now()]
+    );
   }
 
   /**
-   * Clean up expired challenges from the in-memory store
+   * Delete expired challenges from the database
    * @private
    */
-  _cleanupExpiredChallenges() {
-    const now = Date.now();
-    for (const [key, entry] of this.challengeStore.entries()) {
-      if (entry.expiresAt <= now) {
-        this.challengeStore.delete(key);
-      }
-    }
+  async _cleanupExpiredChallenges() {
+    await db.run('DELETE FROM sep10_challenges WHERE expiresAt <= ?', [Date.now()]);
   }
 
   /**
    * Fetch a challenge entry and assert it is still valid for the given account
    * @private
    */
-  _getChallengeEntry(challengeId, clientAccount) {
-    this._cleanupExpiredChallenges();
+  async _getChallengeEntry(challengeId, clientAccount) {
+    await this._cleanupExpiredChallenges();
 
-    const entry = this.challengeStore.get(challengeId);
+    const entry = await db.get(
+      'SELECT * FROM sep10_challenges WHERE challengeId = ?',
+      [challengeId]
+    );
     if (!entry) {
       throw new ValidationError(
         'Challenge transaction has expired or was not issued by this server',
@@ -223,12 +220,11 @@ class SEP10Service {
    * Mark a challenge as consumed to prevent replay
    * @private
    */
-  _markChallengeUsed(challengeId) {
-    const entry = this.challengeStore.get(challengeId);
-    if (entry) {
-      entry.used = true;
-      entry.usedAt = Date.now();
-    }
+  async _markChallengeUsed(challengeId) {
+    await db.run(
+      'UPDATE sep10_challenges SET used = 1, usedAt = ? WHERE challengeId = ?',
+      [Date.now(), challengeId]
+    );
   }
 
   /**


### PR DESCRIPTION
- #1134: CorporateMatchingService now persists employers and claims to DB (corporate_employers, corporate_claims tables via migration 024)
- #1135: SEP10Service challenge store backed by DB with TTL/expiry instead of in-memory Map; challenges verifiable across instances
- #1132: errorHandler strips details and debug fields in production; stack trace logged server-side only; removed duplicate log call
- #1133: AuditLogService already writes directly to DB on every call; removed dead in-memory _pendingBuffer and broken flush() logic; flush()/startAutoFlush()/stopAutoFlush() kept as no-ops for shutdown API
- ## Checklist
- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed

Closes #1133 
Closes #1132 
Closes #1134 
Closes #1135 
