### PR TITLE
fix: cache eviction, migration locking, reconciliation drift detection, startup verification

### DIFF
--- a/src/bootstrap/routes.js
+++ b/src/bootstrap/routes.js
@@ -235,6 +235,13 @@ function mountRoutes(app, services = {}) {
     if (state.isShuttingDown) {
       return res.status(503).json({ status: 'not_ready', reason: 'server is shutting down' });
     }
+    if (!state.isInitialized) {
+      const initErr = state.initializationError;
+      return res.status(503).json({
+        status: 'not_ready',
+        reason: initErr ? `initialization failed: ${initErr}` : 'server still initializing',
+      });
+    }
     try {
       const readiness = await HealthCheckService.getReadiness(
         stellarService, networkStatusService, recurringDonationScheduler

--- a/src/bootstrap/server.js
+++ b/src/bootstrap/server.js
@@ -143,6 +143,33 @@ async function startServer(app, overrideServices = {}) {
         await DonationExportService.initialize();
         AuditLogService.startAutoFlush();
 
+        // Verify Horizon connectivity before marking as ready
+        // This ensures the service doesn't accept traffic that depends on Horizon
+        const isMockStellar = process.env.USE_MOCK_STELLAR === 'true' || process.env.MOCK_STELLAR === 'true';
+        if (!isMockStellar && stellarService.server && typeof stellarService.server.root === 'function') {
+          try {
+            await Promise.race([
+              stellarService.server.root(),
+              new Promise((_, reject) =>
+                setTimeout(() => reject(new Error('Horizon root endpoint timed out')), 15000)
+              ),
+            ]);
+            log.info('STARTUP', 'Horizon connectivity verified');
+          } catch (horizonErr) {
+            log.error('STARTUP', 'Horizon connectivity check failed', { error: horizonErr.message });
+            state.initializationError = `Horizon unreachable: ${horizonErr.message}`;
+            process.exit(1);
+          }
+        }
+
+        // Start background cache cleanup timers
+        const Cache = require('../utils/cache');
+        Cache.startCleanup();
+        const { startMemCacheCleanup } = require('../middleware/deduplication');
+        startMemCacheCleanup();
+        const { startCacheCleanup: startFedCacheCleanup } = require('../utils/federation');
+        startFedCacheCleanup();
+
         if (process.env.NODE_ENV !== 'test') {
           const stopQuotaResetJob = startQuotaResetJob();
           server.stopQuotaResetJob = stopQuotaResetJob;
@@ -186,6 +213,8 @@ async function startServer(app, overrideServices = {}) {
           log.error('APP', 'Failed to initialize LeaderboardSSE', { error: err.message });
         }
 
+        // Mark as fully initialized — readiness checks will now return healthy
+        state.isInitialized = true;
         log.info('APP', 'API ready', {
           port: PORT,
           network: config.network,
@@ -202,6 +231,7 @@ async function startServer(app, overrideServices = {}) {
           });
         }
       } catch (initErr) {
+        state.initializationError = initErr.message;
         log.error('APP', 'Background initialization failed', { error: initErr.message });
         process.exit(1);
       }

--- a/src/bootstrap/state.js
+++ b/src/bootstrap/state.js
@@ -6,4 +6,6 @@
 module.exports = {
   isShuttingDown: false,
   inFlightRequests: 0,
+  isInitialized: false,
+  initializationError: null,
 };

--- a/src/middleware/deduplication.js
+++ b/src/middleware/deduplication.js
@@ -24,6 +24,9 @@ const DEFAULT_OPTIONS = {
 
 // In-memory fallback used when the dedup_cache table does not exist yet
 const _memCache = new Map();
+const MEM_CACHE_MAX_SIZE = parseInt(process.env.DEDUP_MEM_CACHE_MAX_SIZE, 10) || 5000;
+const MEM_CACHE_CLEANUP_INTERVAL_MS = parseInt(process.env.DEDUP_MEM_CACHE_CLEANUP_INTERVAL_MS, 10) || 60000;
+let _memCleanupTimer = null;
 
 function _memGet(key) {
   const item = _memCache.get(key);
@@ -34,6 +37,45 @@ function _memGet(key) {
 
 function _memSet(key, value, ttlMs) {
   _memCache.set(key, { value, expiresAt: Date.now() + ttlMs });
+  if (_memCache.size > MEM_CACHE_MAX_SIZE) {
+    const oldest = _memCache.keys().next().value;
+    if (oldest) _memCache.delete(oldest);
+  }
+}
+
+/**
+ * Remove expired entries from the in-memory dedup fallback cache.
+ * @returns {number} Number of entries removed
+ */
+function _memCleanup() {
+  const now = Date.now();
+  let removed = 0;
+  for (const [key, item] of _memCache) {
+    if (now > item.expiresAt) {
+      _memCache.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Start periodic background cleanup for the in-memory dedup fallback cache.
+ */
+function startMemCacheCleanup() {
+  if (_memCleanupTimer) return;
+  _memCleanupTimer = setInterval(_memCleanup, MEM_CACHE_CLEANUP_INTERVAL_MS);
+  if (_memCleanupTimer.unref) _memCleanupTimer.unref();
+}
+
+/**
+ * Stop the background dedup memory cache cleanup timer.
+ */
+function stopMemCacheCleanup() {
+  if (_memCleanupTimer) {
+    clearInterval(_memCleanupTimer);
+    _memCleanupTimer = null;
+  }
 }
 
 /**
@@ -164,4 +206,4 @@ function createDeduplicationMiddleware(options = {}) {
   };
 }
 
-module.exports = { createDeduplicationMiddleware, computeFingerprint };
+module.exports = { createDeduplicationMiddleware, computeFingerprint, startMemCacheCleanup, stopMemCacheCleanup };

--- a/src/services/SequenceCacheService.js
+++ b/src/services/SequenceCacheService.js
@@ -31,6 +31,8 @@ class SequenceCacheService {
     this.stellarService = stellarService;
     this.cacheStalenessThresholdMs = config.cacheStalenessThresholdMs || 300000; // 5 minutes
     this.maxRetryCount = config.maxRetryCount || 3;
+    this.maxCacheSize = config.maxCacheSize || 10000;
+    this.cleanupIntervalMs = config.cleanupIntervalMs || 300000;
 
     // Cache structure: { accountAddress: { sequence, lastFamilyCount, fetchedAt, optimisticDeltas: [] } }
     this.cache = new Map();
@@ -48,9 +50,15 @@ class SequenceCacheService {
     // Lock management for preventing concurrent fetches
     this.fetchLocks = new Map();
 
+    // Background cleanup of stale entries
+    this._cleanupTimer = null;
+    this._startCleanup();
+
     log.info('SEQ_CACHE', 'SequenceCacheService initialized', {
       cacheStalenessThresholdMs: this.cacheStalenessThresholdMs,
       maxRetryCount: this.maxRetryCount,
+      maxCacheSize: this.maxCacheSize,
+      cleanupIntervalMs: this.cleanupIntervalMs,
     });
   }
 
@@ -274,6 +282,62 @@ class SequenceCacheService {
       errorCount: this.metrics.totalErrors,
       message: isHealthy ? 'Sequence cache operational' : 'Sequence cache degraded',
     };
+  }
+
+  /**
+   * Remove stale cache entries and enforce max cache size.
+   * @returns {{ removed: number }} Number of entries removed
+   */
+  cleanupStaleEntries() {
+    const now = Date.now();
+    let removed = 0;
+
+    for (const [address, entry] of this.cache) {
+      if (now - entry.fetchedAt > this.cacheStalenessThresholdMs * 2) {
+        this.cache.delete(address);
+        this.fetchLocks.delete(address);
+        removed++;
+      }
+    }
+
+    while (this.cache.size > this.maxCacheSize) {
+      const oldest = this.cache.keys().next().value;
+      if (!oldest) break;
+      this.cache.delete(oldest);
+      this.fetchLocks.delete(oldest);
+      removed++;
+    }
+
+    if (removed > 0) {
+      log.debug('SEQ_CACHE', 'Cleanup removed stale entries', { removed });
+    }
+
+    return { removed };
+  }
+
+  /**
+   * Start background cleanup timer.
+   * @private
+   */
+  _startCleanup() {
+    if (this._cleanupTimer) return;
+    const timerRegistry = require('../utils/timerRegistry');
+    this._cleanupTimer = timerRegistry.createInterval(
+      () => this.cleanupStaleEntries(),
+      this.cleanupIntervalMs,
+      'seq-cache-cleanup'
+    );
+    if (this._cleanupTimer.unref) this._cleanupTimer.unref();
+  }
+
+  /**
+   * Stop background cleanup timer.
+   */
+  stopCleanup() {
+    if (this._cleanupTimer) {
+      clearInterval(this._cleanupTimer);
+      this._cleanupTimer = null;
+    }
   }
 
   /**

--- a/src/services/TransactionReconciliationService.js
+++ b/src/services/TransactionReconciliationService.js
@@ -175,54 +175,59 @@ class TransactionReconciliationService {
     try {
       const result = await this.stellarService.verifyTransaction(tx.stellarTxId);
 
-      if (result.verified && tx.status !== TRANSACTION_STATES.CONFIRMED) {
-        // Try to auto-confirm; if the state machine rejects the transition, flag for manual review
-        try {
-          Transaction.updateStatus(tx.id, TRANSACTION_STATES.CONFIRMED, {
-            transactionId: tx.stellarTxId,
-            ledger: result.transaction && result.transaction.ledger,
-            confirmedAt: new Date().toISOString(),
-          });
+      if (result.verified) {
+        // Check for amount/memo drift against the on-chain record
+        this._checkFieldDrift(tx, result);
 
-          // Invalidate caching for wallets involved in this transaction
-          const Cache = require('../utils/cache');
-          const Database = require('../utils/database');
+        if (tx.status !== TRANSACTION_STATES.CONFIRMED) {
+          // Try to auto-confirm; if the state machine rejects the transition, flag for manual review
           try {
-            if (tx.senderId) {
-              const sender = await Database.get('SELECT publicKey FROM users WHERE id = ?', [tx.senderId]);
-              if (sender) Cache.delete(`wallet_balance_${sender.publicKey}`);
+            Transaction.updateStatus(tx.id, TRANSACTION_STATES.CONFIRMED, {
+              transactionId: tx.stellarTxId,
+              ledger: result.transaction && result.transaction.ledger,
+              confirmedAt: new Date().toISOString(),
+            });
+
+            // Invalidate caching for wallets involved in this transaction
+            const Cache = require('../utils/cache');
+            const Database = require('../utils/database');
+            try {
+              if (tx.senderId) {
+                const sender = await Database.get('SELECT publicKey FROM users WHERE id = ?', [tx.senderId]);
+                if (sender) Cache.delete(`wallet_balance_${sender.publicKey}`);
+              }
+              if (tx.receiverId) {
+                const receiver = await Database.get('SELECT publicKey FROM users WHERE id = ?', [tx.receiverId]);
+                if (receiver) Cache.delete(`wallet_balance_${receiver.publicKey}`);
+              }
+            } catch (cacheErr) {
+              log.warn('RECONCILIATION', 'Failed to clear cache for confirmed transaction', { error: cacheErr.message });
             }
-            if (tx.receiverId) {
-              const receiver = await Database.get('SELECT publicKey FROM users WHERE id = ?', [tx.receiverId]);
-              if (receiver) Cache.delete(`wallet_balance_${receiver.publicKey}`);
-            }
-          } catch (cacheErr) {
-            log.warn('RECONCILIATION', 'Failed to clear cache for confirmed transaction', { error: cacheErr.message });
+
+            log.info('RECONCILIATION', 'Transaction corrected to confirmed', {
+              id: tx.id,
+              stellarTxId: tx.stellarTxId,
+              previousStatus: tx.status,
+            });
+
+            WebhookService.deliver('transaction.confirmed', {
+              id: tx.id,
+              stellarTxId: tx.stellarTxId,
+              previousStatus: tx.status,
+              status: TRANSACTION_STATES.CONFIRMED,
+              ledger: result.transaction && result.transaction.ledger,
+              confirmedAt: new Date().toISOString(),
+            }).catch(err => log.warn('RECONCILIATION', 'Webhook delivery error', { error: err.message }));
+          } catch (stateErr) {
+            // State machine rejected the transition — flag for manual resolution
+            this.flagDiscrepancy(
+              tx.id,
+              `Confirmed on-chain (${tx.stellarTxId}) but DB status is '${tx.status}': ${stateErr.message}`
+            );
           }
 
-          log.info('RECONCILIATION', 'Transaction corrected to confirmed', {
-            id: tx.id,
-            stellarTxId: tx.stellarTxId,
-            previousStatus: tx.status,
-          });
-
-          WebhookService.deliver('transaction.confirmed', {
-            id: tx.id,
-            stellarTxId: tx.stellarTxId,
-            previousStatus: tx.status,
-            status: TRANSACTION_STATES.CONFIRMED,
-            ledger: result.transaction && result.transaction.ledger,
-            confirmedAt: new Date().toISOString(),
-          }).catch(err => log.warn('RECONCILIATION', 'Webhook delivery error', { error: err.message }));
-        } catch (stateErr) {
-          // State machine rejected the transition — flag for manual resolution
-          this.flagDiscrepancy(
-            tx.id,
-            `Confirmed on-chain (${tx.stellarTxId}) but DB status is '${tx.status}': ${stateErr.message}`
-          );
+          return true;
         }
-
-        return true;
       }
 
       return false;
@@ -243,6 +248,53 @@ class TransactionReconciliationService {
 
       throw error;
     }
+  }
+
+  /**
+   * Check for amount or memo drift between the local record and the
+   * on-chain transaction. Flags a discrepancy if they differ.
+   * @param {object} tx - Local transaction record
+   * @param {object} result - On-chain verification result
+   * @private
+   */
+  _checkFieldDrift(tx, result) {
+    const onChainTx = result.transaction;
+    if (!onChainTx) return;
+
+    const onChainAmount = parseFloat(
+      (onChainTx.operations && onChainTx.operations[0] && onChainTx.operations[0].amount) || '0'
+    );
+    const localAmount = parseFloat(tx.amount || '0');
+
+    if (onChainAmount > 0 && localAmount > 0 && Math.abs(onChainAmount - localAmount) > 0.0000001) {
+      this._emitDriftAlert(tx, 'amount', localAmount, onChainAmount);
+    }
+
+    if (tx.memo && onChainTx.memo && tx.memo !== onChainTx.memo) {
+      this._emitDriftAlert(tx, 'memo', tx.memo, onChainTx.memo);
+    }
+  }
+
+  /**
+   * Emit an alert when on-chain data differs from the local record.
+   * @param {object} tx
+   * @param {string} field
+   * @param {*} localValue
+   * @param {*} onChainValue
+   * @private
+   */
+  _emitDriftAlert(tx, field, localValue, onChainValue) {
+    log.error('RECONCILIATION', 'ALERT: Local/on-chain field mismatch detected', {
+      transactionId: tx.id,
+      stellarTxId: tx.stellarTxId || 'unknown',
+      field,
+      localValue,
+      onChainValue,
+    });
+    this.flagDiscrepancy(
+      tx.id,
+      `Field '${field}' mismatch: local=${JSON.stringify(localValue)}, on-chain=${JSON.stringify(onChainValue)}`
+    );
   }
 
   // ─── Orphan detection & compensation ─────────────────────────────────────
@@ -275,7 +327,36 @@ class TransactionReconciliationService {
     // Collect all Stellar transactions from the mock/real service
     const stellarTxs = this._getAllStellarTransactions();
 
-    const orphans = stellarTxs.filter(tx => !knownStellarIds.has(tx.transactionId));
+    // Also fetch Horizon transactions for known wallet addresses
+    let horizonTxs = [];
+    try {
+      const wallets = await Database.query(
+        'SELECT DISTINCT publicKey FROM users WHERE publicKey IS NOT NULL',
+        []
+      );
+      const walletKeys = wallets.map(w => w.publicKey).filter(Boolean);
+      const horizonResults = await Promise.allSettled(
+        walletKeys.map(key => this._fetchHorizonTransactions(key, 20))
+      );
+      const seen = new Set();
+      for (const result of horizonResults) {
+        if (result.status === 'fulfilled') {
+          for (const tx of result.value) {
+            if (!seen.has(tx.transactionId)) {
+              seen.add(tx.transactionId);
+              horizonTxs.push(tx);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      log.warn('RECONCILIATION', 'Failed to fetch Horizon transactions for orphan detection', {
+        error: err.message,
+      });
+    }
+
+    const allKnown = [...stellarTxs, ...horizonTxs];
+    const orphans = allKnown.filter(tx => !knownStellarIds.has(tx.transactionId));
 
     if (orphans.length === 0) {
       return { detected: 0, compensated: 0, orphans: [] };
@@ -380,7 +461,7 @@ class TransactionReconciliationService {
 
   /**
    * Collect all transactions from the Stellar service's in-memory store.
-   * Works with MockStellarService; real implementations would query Horizon.
+   * Works with MockStellarService; falls back to Horizon query for real service.
    *
    * @returns {Array} Flat, deduplicated list of Stellar transaction objects
    * @private
@@ -406,6 +487,42 @@ class TransactionReconciliationService {
       return all;
     }
     return [];
+  }
+
+  /**
+   * Fetch recent transactions for known wallets from Horizon for orphan detection.
+   * Only works with a real StellarService (not mock).
+   * @param {string} publicKey - Stellar public key to query
+   * @param {number} [limit=50] - Max transactions to fetch
+   * @returns {Promise<Array>} List of transaction-like objects
+   * @private
+   */
+  async _fetchHorizonTransactions(publicKey, limit = 50) {
+    if (!this.stellarService || !this.stellarService.server) return [];
+    try {
+      const server = this.stellarService.server;
+      const response = await server.transactions()
+        .forAccount(publicKey)
+        .limit(limit)
+        .order('desc')
+        .call();
+      return (response.records || []).map(tx => ({
+        transactionId: tx.id,
+        hash: tx.hash,
+        source: tx.source_account,
+        destination: (tx.operations && tx.operations[0] && tx.operations[0].to) || tx.source_account,
+        amount: (tx.operations && tx.operations[0] && tx.operations[0].amount) || '0',
+        memo: tx.memo || null,
+        timestamp: tx.created_at,
+      }));
+    } catch (error) {
+      if (error.response && error.response.status === 404) return [];
+      log.warn('RECONCILIATION', 'Failed to fetch Horizon transactions for orphan detection', {
+        publicKey,
+        error: error.message,
+      });
+      return [];
+    }
   }
 
   // ─── Discrepancy management ───────────────────────────────────────────────

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -4,6 +4,11 @@
 
 const CACHE = new Map();
 
+const DEFAULT_MAX_SIZE = parseInt(process.env.CACHE_MAX_SIZE, 10) || 10000;
+const CLEANUP_INTERVAL_MS = parseInt(process.env.CACHE_CLEANUP_INTERVAL_MS, 10) || 60000;
+
+let _cleanupTimer = null;
+
 class Cache {
   /**
    * Set a value in the cache with a specific TTL
@@ -14,6 +19,11 @@ class Cache {
   static set(key, value, ttlMs) {
     const expiresAt = Date.now() + ttlMs;
     CACHE.set(key, { value, expiresAt });
+
+    if (CACHE.size > DEFAULT_MAX_SIZE) {
+      const oldest = CACHE.keys().next().value;
+      CACHE.delete(oldest);
+    }
   }
 
   /**
@@ -58,6 +68,50 @@ class Cache {
    */
   static clear() {
     CACHE.clear();
+  }
+
+  /**
+   * Remove all expired entries from the cache.
+   * @returns {number} Number of entries removed
+   */
+  static cleanup() {
+    const now = Date.now();
+    let removed = 0;
+    for (const [key, item] of CACHE) {
+      if (now > item.expiresAt) {
+        CACHE.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
+   * Start periodic background cleanup of expired entries.
+   * Safe to call multiple times — only one timer runs.
+   */
+  static startCleanup() {
+    if (_cleanupTimer) return;
+    _cleanupTimer = setInterval(() => Cache.cleanup(), CLEANUP_INTERVAL_MS);
+    if (_cleanupTimer.unref) _cleanupTimer.unref();
+  }
+
+  /**
+   * Stop the background cleanup timer.
+   */
+  static stopCleanup() {
+    if (_cleanupTimer) {
+      clearInterval(_cleanupTimer);
+      _cleanupTimer = null;
+    }
+  }
+
+  /**
+   * Return the current cache size.
+   * @returns {number}
+   */
+  static getSize() {
+    return CACHE.size;
   }
 }
 

--- a/src/utils/federation.js
+++ b/src/utils/federation.js
@@ -29,6 +29,15 @@ const _cache = new Map();
 /** Cache TTL in ms (1 hour) */
 const CACHE_TTL_MS = 60 * 60 * 1000;
 
+/** Maximum number of entries in the federation cache before eviction starts */
+const MAX_CACHE_SIZE = parseInt(process.env.FEDERATION_CACHE_MAX_SIZE, 10) || 5000;
+
+/** How often (ms) to sweep expired entries from the cache */
+const CLEANUP_INTERVAL_MS = parseInt(process.env.FEDERATION_CACHE_CLEANUP_INTERVAL_MS, 10) || 300000;
+
+/** Background cleanup timer handle */
+let _cleanupTimer = null;
+
 /**
  * Check whether a string looks like a federation address.
  * @param {string} value
@@ -78,6 +87,11 @@ async function resolveAddress(address, { _resolverFn } = {}) {
     }
 
     _cache.set(address, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+    // Enforce max cache size — evict oldest entry if over limit
+    if (_cache.size > MAX_CACHE_SIZE) {
+      const oldest = _cache.keys().next().value;
+      if (oldest) _cache.delete(oldest);
+    }
     log.debug('FEDERATION', 'Resolved federation address', { address, account_id: result.account_id });
     return result;
   } catch (error) {
@@ -119,4 +133,40 @@ function getCacheSize() {
   return _cache.size;
 }
 
-module.exports = { isFederationAddress, resolveAddress, resolveRecipient, clearCache, getCacheSize };
+/**
+ * Remove all expired entries from the federation cache.
+ * @returns {number} Number of expired entries removed
+ */
+function cleanupCache() {
+  const now = Date.now();
+  let removed = 0;
+  for (const [address, entry] of _cache) {
+    if (now >= entry.expiresAt) {
+      _cache.delete(address);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Start periodic background cleanup of expired federation cache entries.
+ * Safe to call multiple times — only one timer runs.
+ */
+function startCacheCleanup() {
+  if (_cleanupTimer) return;
+  _cleanupTimer = setInterval(cleanupCache, CLEANUP_INTERVAL_MS);
+  if (_cleanupTimer.unref) _cleanupTimer.unref();
+}
+
+/**
+ * Stop the background federation cache cleanup timer.
+ */
+function stopCacheCleanup() {
+  if (_cleanupTimer) {
+    clearInterval(_cleanupTimer);
+    _cleanupTimer = null;
+  }
+}
+
+module.exports = { isFederationAddress, resolveAddress, resolveRecipient, clearCache, getCacheSize, cleanupCache, startCacheCleanup, stopCacheCleanup };

--- a/src/utils/migrationRunner.js
+++ b/src/utils/migrationRunner.js
@@ -11,10 +11,29 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const db = require('./database');
+const log = require('./log');
 
 const MIGRATIONS_DIR = path.join(__dirname, '../migrations');
 
-async function ensureMigrationsTable() {
+/**
+ * Maximum time (ms) to wait for the migration lock before giving up.
+ */
+const LOCK_TIMEOUT_MS = parseInt(process.env.MIGRATION_LOCK_TIMEOUT_MS, 10) || 30000;
+
+/**
+ * How often (ms) to poll when waiting for the migration lock.
+ */
+const LOCK_POLL_INTERVAL_MS = parseInt(process.env.MIGRATION_LOCK_POLL_INTERVAL_MS, 10) || 500;
+
+/**
+ * A unique instance identifier so we can tell who holds the lock.
+ */
+const INSTANCE_ID = `${require('os').hostname()}-${process.pid}`;
+
+/**
+ * Ensure the schema_migrations and migration_lock tables exist.
+ */
+async function ensureTables() {
   await db.run(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -27,6 +46,57 @@ async function ensureMigrationsTable() {
   try {
     await db.run(`ALTER TABLE schema_migrations ADD COLUMN checksum TEXT NOT NULL DEFAULT ''`);
   } catch (_) { /* column already exists */ }
+
+  // Migration lock table for preventing concurrent migrations across instances
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS migration_lock (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      instance_id TEXT NOT NULL,
+      acquired_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+}
+
+/**
+ * Attempt to acquire the exclusive migration lock.
+ * @returns {Promise<boolean>} true if the lock was acquired
+ */
+async function acquireLock() {
+  try {
+    await db.run(
+      `INSERT OR FAIL INTO migration_lock (id, instance_id, acquired_at)
+       VALUES (1, ?, datetime('now'))`,
+      [INSTANCE_ID]
+    );
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Release the migration lock if we hold it.
+ */
+async function releaseLock() {
+  try {
+    await db.run(
+      'DELETE FROM migration_lock WHERE id = 1 AND instance_id = ?',
+      [INSTANCE_ID]
+    );
+  } catch (_) { /* non-critical */ }
+}
+
+/**
+ * Busy-wait for the migration lock with a timeout.
+ * @returns {Promise<boolean>} true if the lock was acquired within the timeout
+ */
+async function waitForLock() {
+  const start = Date.now();
+  while (Date.now() - start < LOCK_TIMEOUT_MS) {
+    if (await acquireLock()) return true;
+    await new Promise(resolve => setTimeout(resolve, LOCK_POLL_INTERVAL_MS));
+  }
+  return false;
 }
 
 function fileChecksum(filePath) {
@@ -66,76 +136,101 @@ async function getApplied() {
 
 async function runMigrations() {
   await db.initialize();
-  await ensureMigrationsTable();
+  await ensureTables();
 
-  const applied = await getApplied();
-  const files = loadMigrationFiles();
+  const acquired = await waitForLock();
+  if (!acquired) {
+    throw new Error(
+      `Could not acquire migration lock within ${LOCK_TIMEOUT_MS}ms. ` +
+      'Another instance may be holding it. If no other instance is running, ' +
+      'delete the row from the migration_lock table manually.'
+    );
+  }
 
-  // Warn on modified migrations
-  for (const { migration, checksum } of files) {
-    const storedChecksum = applied.get(migration.name);
-    if (storedChecksum && storedChecksum !== '' && storedChecksum !== checksum) {
-      console.warn(`⚠ WARNING: Migration "${migration.name}" has been modified after being applied (checksum mismatch).`);
+  try {
+    const applied = await getApplied();
+    const files = loadMigrationFiles();
+
+    // Warn on modified migrations
+    for (const { migration, checksum } of files) {
+      const storedChecksum = applied.get(migration.name);
+      if (storedChecksum && storedChecksum !== '' && storedChecksum !== checksum) {
+        log.warn('MIGRATION', `Migration "${migration.name}" has been modified after being applied (checksum mismatch).`);
+      }
     }
-  }
 
-  const pending = files.filter(({ migration }) => !applied.has(migration.name));
+    const pending = files.filter(({ migration }) => !applied.has(migration.name));
 
-  if (pending.length === 0) {
-    return { applied: 0, skipped: files.length };
-  }
-
-  for (const { file, migration, checksum } of pending) {
-    try {
-      await migration.up(db);
-      await db.run(
-        'INSERT INTO schema_migrations (name, checksum) VALUES (?, ?)',
-        [migration.name, checksum]
-      );
-      console.log(`✓ Migration applied: ${migration.name} (${file})`);
-    } catch (err) {
-      throw new Error(`Migration failed [${migration.name}]: ${err.message}`);
+    if (pending.length === 0) {
+      return { applied: 0, skipped: files.length };
     }
-  }
 
-  return { applied: pending.length, skipped: files.length - pending.length };
+    for (const { file, migration, checksum } of pending) {
+      try {
+        await migration.up(db);
+        await db.run(
+          'INSERT INTO schema_migrations (name, checksum) VALUES (?, ?)',
+          [migration.name, checksum]
+        );
+        log.info('MIGRATION', `Migration applied: ${migration.name} (${file})`);
+      } catch (err) {
+        throw new Error(`Migration failed [${migration.name}]: ${err.message}`);
+      }
+    }
+
+    return { applied: pending.length, skipped: files.length - pending.length };
+  } finally {
+    await releaseLock();
+  }
 }
 
 async function rollbackMigration() {
   await db.initialize();
-  await ensureMigrationsTable();
+  await ensureTables();
 
-  const rows = await db.query(
-    'SELECT name FROM schema_migrations ORDER BY id DESC LIMIT 1',
-    []
-  );
-
-  if (rows.length === 0) {
-    console.log('No migrations to roll back.');
-    return { rolledBack: null };
+  const acquired = await waitForLock();
+  if (!acquired) {
+    throw new Error(
+      `Could not acquire migration lock within ${LOCK_TIMEOUT_MS}ms. ` +
+      'Another instance may be holding it.'
+    );
   }
 
-  const { name } = rows[0];
-  const files = loadMigrationFiles();
-  const entry = files.find(({ migration }) => migration.name === name);
+  try {
+    const rows = await db.query(
+      'SELECT name FROM schema_migrations ORDER BY id DESC LIMIT 1',
+      []
+    );
 
-  if (!entry) {
-    throw new Error(`Migration file for "${name}" not found — cannot roll back.`);
+    if (rows.length === 0) {
+      log.info('MIGRATION', 'No migrations to roll back.');
+      return { rolledBack: null };
+    }
+
+    const { name } = rows[0];
+    const files = loadMigrationFiles();
+    const entry = files.find(({ migration }) => migration.name === name);
+
+    if (!entry) {
+      throw new Error(`Migration file for "${name}" not found — cannot roll back.`);
+    }
+
+    if (typeof entry.migration.down !== 'function') {
+      throw new Error(`Migration "${name}" does not export a down() function.`);
+    }
+
+    await entry.migration.down(db);
+    await db.run('DELETE FROM schema_migrations WHERE name = ?', [name]);
+    log.info('MIGRATION', `Rolled back: ${name}`);
+    return { rolledBack: name };
+  } finally {
+    await releaseLock();
   }
-
-  if (typeof entry.migration.down !== 'function') {
-    throw new Error(`Migration "${name}" does not export a down() function.`);
-  }
-
-  await entry.migration.down(db);
-  await db.run('DELETE FROM schema_migrations WHERE name = ?', [name]);
-  console.log(`✓ Rolled back: ${name}`);
-  return { rolledBack: name };
 }
 
 async function migrationStatus() {
   await db.initialize();
-  await ensureMigrationsTable();
+  await ensureTables();
 
   const applied = await getApplied();
   const files = loadMigrationFiles();


### PR DESCRIPTION
Closes #1148 
Closes #1149 
Closes #1150 
Closes #1151 

## Summary

Four related fixes addressing in-process cache growth, concurrent migration races, local/on-chain state drift detection, and undefined startup behavior when Horizon is unreachable.

## Commits

### 1. Cache eviction and size bounding
**`feat: add background eviction and size bounding to in-process caches`**

Adds periodic cleanup timers and max-size enforcement to the generic cache, sequence-number cache, federation cache, and request-dedup in-memory fallback to prevent unbounded growth under traffic load.

- **src/utils/cache.js** — background cleanup every 60s, max 10k entries, `startCleanup()`/`stopCleanup()` lifecycle
- **src/services/SequenceCacheService.js** — stale-entry sweep every 5min, max 10k entries, uses timerRegistry
- **src/utils/federation.js** — expired-entry sweep every 5min, max 5k entries, `startCacheCleanup()`/`stopCacheCleanup()`
- **src/middleware/deduplication.js** — expired sweep every 60s, max 5k entries for in-memory fallback

### 2. Migration locking
**`feat: add distributed locking to migration runner to prevent concurrent migration races`**

Adds a `migration_lock` table with a single-row constraint (`CHECK (id = 1)`) so only one instance can apply or roll back migrations at a time. The second caller busy-polls with configurable timeout (30s) and interval (500ms) instead of silently racing or producing lock errors mid-migration.

- `acquireLock()` — `INSERT OR FAIL` into `migration_lock`
- `releaseLock()` — `DELETE` from `migration_lock` by instance_id
- `waitForLock()` — polls with `LOCK_POLL_INTERVAL_MS` until `LOCK_TIMEOUT_MS` expires
- Lock wraps both `runMigrations()` and `rollbackMigration()` in `try/finally`

### 3. Reconciliation drift detection
**`feat: enhance transaction reconciliation with drift detection and Horizon orphan scan`**

Extends the existing reconciliation service to catch silent data divergence between local state and the Stellar network.

- `_checkFieldDrift()` — compares local amount/memo against on-chain data after every `verifyTransaction` call; flags discrepancies via ERROR-level log and `flagDiscrepancy()`
- `_fetchHorizonTransactions()` — queries real Horizon for recent transactions by wallet public key
- `detectAndCompensateOrphans()` now queries Horizon for all known wallet addresses alongside the mock store, enabling orphan detection in production mode

### 4. Startup verification
**`fix: verify Horizon connectivity and block readiness until init completes`**

Prevents the service from accepting traffic before it is fully operational.

- **src/bootstrap/state.js** — added `isInitialized` and `initializationError` fields
- **src/bootstrap/server.js** — verifies Horizon root endpoint (15s timeout) after migrations; exits with code 1 if Horizon is unreachable; wires cache cleanup timers; sets `isInitialized=true` only after all critical init passes
- **src/bootstrap/routes.js** — `/health/ready` checks `isInitialized` first, returning `not_ready` with the initialization error message if the service hasn't finished booting
