### PR TITLE
feat(security): gate CI on high/critical npm advisories with triage SLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,5 +29,6 @@ npm test
 - [ ] Lint passes (`npm run lint`)
 - [ ] All tests pass (`npm test`)
 - [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
+- [ ] `npm audit --audit-level=high` passes — or vulnerability triaged in `SECURITY.md`
 - [ ] Database migration included if schema changed
 - [ ] Documentation updated if behaviour changed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      security-patches:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +22,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps-actions)"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Do **not** open a public GitHub issue for security vulnerabilities. Instead, email **emmanuelokanandu99@gmail.com** with:
+
+- A description of the vulnerability and affected component
+- Steps to reproduce
+- Potential impact
+
+You will receive an acknowledgement within **48 hours** and a status update within **7 days**.
+
+---
+
+## Dependency Vulnerability Triage
+
+`npm audit --audit-level=high` runs on every PR and push to `main` via [CI](.github/workflows/ci.yml) and the dedicated [Security Scan](.github/workflows/security-scan.yml). The build **fails** on any advisory rated `high` or `critical`.
+
+Dependabot opens weekly PRs for both npm packages and GitHub Actions. Security-only patches are grouped in a single PR labelled `dependencies`.
+
+### SLA
+
+| Severity | Remediation target |
+|----------|--------------------|
+| Critical | 24 hours           |
+| High     | 7 days             |
+| Medium   | 30 days            |
+| Low      | 90 days            |
+
+### Triage process
+
+1. **Evaluate exploitability** — determine whether the vulnerable code path is reachable in this project's deployment context.
+2. **Remediate or accept risk**:
+   - If a patched version is available, merge the Dependabot PR (or run `npm update <pkg>`).
+   - If no fix exists and the vulnerability is not exploitable in context, document the decision below in [Accepted risks](#accepted-risks) and re-evaluate when a fix ships.
+3. **Verify** — confirm `npm audit --audit-level=high` exits 0 before merging.
+
+### Suppressing a false positive
+
+If a finding is a confirmed false positive or the vulnerable code path is unreachable, add an override to `.npmrc`:
+
+```
+# Example: audit suppression is not natively supported by npm audit.
+# Use `npm audit --json | node scripts/filter-audit.js` with a local
+# allowlist file, or upgrade to a version where the advisory is resolved.
+```
+
+Alternatively, pin the dependency to a safe version in `package.json` and add a comment explaining why.
+
+---
+
+## Required branch protection
+
+To enforce the security gate, configure the following in **Settings → Branches → Branch protection rules** for `main`:
+
+- Enable **Require status checks to pass before merging**
+- Add `security-scan` and `test` as required checks
+- Enable **Dismiss stale pull request approvals when new commits are pushed**
+
+---
+
+## Accepted risks
+
+Document any accepted/deferred advisories here. Remove entries when they are resolved.
+
+| Advisory | Package | Reason not fixed | Review date |
+|----------|---------|-----------------|-------------|
+| _(none)_ | | | |


### PR DESCRIPTION
- Fix broken action versions in security-scan.yml (checkout@v6 and setup-node@v6 do not exist; updated to @v4 so the workflow actually runs)
- Add SECURITY.md with vulnerability reporting process, triage SLA (Critical 24h / High 7d / Medium 30d / Low 90d), accepted-risks table, false-positive suppression guidance, and branch protection setup instructions
- Extend dependabot.yml with dependency labels, a security-patches group that batches all security-only npm updates into a single PR, and a github-actions label for Actions update PRs
- Add npm audit checklist item to the PR template so contributors must confirm the gate passes (or document an accepted risk) before merge

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed

closes #1127 