### PR TITLE
test: contract, property, webhook E2E, and load-gate suites (#1164–#1167)

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -1,6 +1,12 @@
 name: Load Tests
 
+# Runs on every PR and push to the main branches so a performance regression
+# blocks the merge (issue #1167), and nightly for trend tracking.
 on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
   schedule:
     # Run nightly at 02:00 UTC
     - cron: '0 2 * * *'
@@ -10,6 +16,15 @@ jobs:
   load-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    env:
+      # Performance gate thresholds live in tests/load/PerformanceBaselines.js.
+      # Shared GitHub runners are noisier/slower than a dev box, so we widen the
+      # tolerances here (not the targets) to keep the gate meaningful without
+      # being flaky. See docs/LOAD_TESTING.md.
+      LOAD_TEST_LATENCY_MARGIN: '2.0'     # tolerate up to 2x the target latency
+      LOAD_TEST_THROUGHPUT_MARGIN: '0.5'  # tolerate down to 50% of target throughput
+      LOAD_TEST_ERROR_RATE_MARGIN: '1.0'  # error-rate ceilings are not relaxed
 
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +38,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run load tests
+      - name: Run load tests (gates the merge on SLO thresholds)
         env:
           MOCK_STELLAR: 'true'
           NODE_ENV: test
           API_KEYS: 'test-load-key,test-key-1,test-key-2'
-        run: npm run test:load -- --output ./reports/load --concurrency 10 --iterations 50
+          ENCRYPTION_KEY: test_encryption_key_fixed_32bytes_hex_value_here_00
+        # Warm-up requests absorb cold-start variance before measurement. The
+        # script exits non-zero when any threshold is exceeded, failing the job.
+        run: npm run test:load -- --output ./reports/load --concurrency 10 --iterations 50 --warmup 10
 
       - name: Upload load test report
         if: always()

--- a/docs/LOAD_TESTING.md
+++ b/docs/LOAD_TESTING.md
@@ -1,0 +1,59 @@
+# Load Testing & Performance Gate
+
+The load-test suite drives the Express app (in mock-Stellar mode) with
+concurrent virtual users, measures latency / throughput / error rate per
+scenario, and **fails CI when results regress beyond defined thresholds**
+(issue #1167). Because the `.github/workflows/load-tests.yml` job runs on every
+pull request and push to `main`/`master`, a regression blocks the merge.
+
+## Running locally
+
+```bash
+npm run test:load -- --concurrency 10 --iterations 50 --warmup 10
+```
+
+| Flag            | Default | Meaning                                            |
+|-----------------|---------|----------------------------------------------------|
+| `--concurrency` | 10      | Concurrent virtual users                           |
+| `--iterations`  | 50      | Measured requests per scenario                     |
+| `--warmup`      | 5       | Discarded warm-up requests per scenario (see below)|
+| `--output`      | reports/load | Directory for the JSON/HTML reports           |
+
+The runner exits non-zero if any scenario breaches its threshold, prints a
+per-scenario pass/fail summary, and writes JSON + HTML reports. In GitHub
+Actions it also appends a metrics table to the job summary so reviewers see the
+numbers even on a pass.
+
+## Thresholds (SLOs)
+
+Targets are defined per scenario in
+[`tests/load/PerformanceBaselines.js`](../tests/load/PerformanceBaselines.js):
+`p50` / `p95` / `p99` latency ceilings (ms), a minimum throughput (req/s), and a
+maximum error rate. To change a *target*, edit that file. Current defaults:
+
+| Scenario            | Route                      | p50 | p95 | p99  | min req/s | max error rate |
+|---------------------|----------------------------|-----|-----|------|-----------|----------------|
+| `liveness`          | `GET /health/live`         | 50  | 150 | 300  | 20        | 1%             |
+| `list-donations`    | `GET /api/v1/donations`    | 100 | 300 | 600  | 10        | 2%             |
+| `donation-creation` | `POST /api/v1/donations`   | 200 | 500 | 1000 | 5         | 5%             |
+
+## Handling runner variance
+
+Shared CI runners are noisy, so absolute latency varies run-to-run. Two
+mechanisms keep the gate meaningful without being flaky:
+
+1. **Warm-up** — `--warmup N` runs `N` discarded requests per scenario before
+   measurement, so cold-start cost (JIT, lazy `require`s, first DB connection)
+   doesn't pollute the steady-state numbers.
+2. **Margins** — three environment variables widen the *tolerance* (not the
+   targets), applied by `resolveBaselines()`:
+
+   | Env var                       | Default | Effect                                  |
+   |-------------------------------|---------|-----------------------------------------|
+   | `LOAD_TEST_LATENCY_MARGIN`    | 1.0     | Multiplies every latency ceiling        |
+   | `LOAD_TEST_THROUGHPUT_MARGIN` | 1.0     | Multiplies every min-throughput floor   |
+   | `LOAD_TEST_ERROR_RATE_MARGIN` | 1.0     | Multiplies every max-error-rate ceiling |
+
+   The CI workflow sets `LOAD_TEST_LATENCY_MARGIN=2.0` and
+   `LOAD_TEST_THROUGHPUT_MARGIN=0.5` to absorb shared-runner slowness; locally
+   the defaults (no margin) apply.

--- a/src/middleware/perKeyRateLimit.js
+++ b/src/middleware/perKeyRateLimit.js
@@ -45,6 +45,35 @@ const perKeyRateLimit = async (req, res, next) => {
   return next();
 };
 
+/**
+ * Synchronous per-key rate-limit check used by the legacy-API-key path in
+ * rbac.js, which consumes the result inline (no await). Delegates to the
+ * configured store and normalises the shape to include `limit`.
+ *
+ * The default in-memory store returns synchronously. If an async store (e.g.
+ * Redis) is configured, this synchronous entry point cannot block on it, so it
+ * fails open (allows the request) rather than throwing in the auth path — the
+ * async `perKeyRateLimit` middleware still enforces limits for DB-backed keys.
+ *
+ * @param {string} key
+ * @param {number} [limit] request ceiling; defaults to the module constant
+ * @param {number} [windowSeconds] window length in seconds; defaults to the module constant
+ * @returns {{ allowed: boolean, limit: number, remaining: number, resetAt: number }}
+ */
+function checkRateLimit(key, limit = DEFAULT_RATE_LIMIT, windowSeconds = DEFAULT_WINDOW_SECONDS) {
+  const result = getStore().incrementAndCheck(key, limit, windowSeconds);
+  if (result && typeof result.then === 'function') {
+    // Async store: cannot resolve synchronously here — fail open.
+    return { allowed: true, limit, remaining: limit, resetAt: Date.now() + windowSeconds * 1000 };
+  }
+  return {
+    allowed: result.allowed,
+    limit,
+    remaining: result.remaining,
+    resetAt: result.resetAt,
+  };
+}
+
 function clearStore() {
   const s = getStore();
   if (typeof s.clear === 'function') s.clear();
@@ -54,6 +83,7 @@ function _setStore(store) { _store = store; }
 
 module.exports = perKeyRateLimit;
 module.exports.buildRateLimitHeaders = buildRateLimitHeaders;
+module.exports.checkRateLimit = checkRateLimit;
 module.exports.clearStore = clearStore;
 module.exports._setStore = _setStore;
 module.exports.DEFAULT_RATE_LIMIT = DEFAULT_RATE_LIMIT;

--- a/src/services/StellarService.js
+++ b/src/services/StellarService.js
@@ -198,16 +198,16 @@ class StellarService extends StellarServiceInterface {
 
     // Retry policy — centralised and configurable (applies to all Horizon calls)
     this.retryPolicy = {
-      maxAttempts: config.maxRetryAttempts ?? parseInt(process.env.HORIZON_MAX_RETRY_ATTEMPTS, 10) || 3,
-      baseDelayMs:  config.retryBaseDelayMs  ?? parseInt(process.env.HORIZON_RETRY_BASE_DELAY_MS, 10) || 200,
-      maxDelayMs:   config.retryMaxDelayMs   ?? parseInt(process.env.HORIZON_RETRY_MAX_DELAY_MS, 10) || 2_000,
+      maxAttempts: config.maxRetryAttempts ?? (parseInt(process.env.HORIZON_MAX_RETRY_ATTEMPTS, 10) || 3),
+      baseDelayMs:  config.retryBaseDelayMs  ?? (parseInt(process.env.HORIZON_RETRY_BASE_DELAY_MS, 10) || 200),
+      maxDelayMs:   config.retryMaxDelayMs   ?? (parseInt(process.env.HORIZON_RETRY_MAX_DELAY_MS, 10) || 2_000),
     };
 
     // Circuit breaker — protects all Horizon API calls
     this.circuitBreaker = new CircuitBreaker({
-      failureThreshold: config.circuitBreakerThreshold ?? parseInt(process.env.HORIZON_CB_FAILURE_THRESHOLD, 10) || 5,
-      windowMs:  config.circuitBreakerWindowMs  ?? parseInt(process.env.HORIZON_CB_WINDOW_MS, 10) || 60_000,
-      cooldownMs: config.circuitBreakerCooldownMs ?? parseInt(process.env.HORIZON_CB_COOLDOWN_MS, 10) || 30_000,
+      failureThreshold: config.circuitBreakerThreshold ?? (parseInt(process.env.HORIZON_CB_FAILURE_THRESHOLD, 10) || 5),
+      windowMs:  config.circuitBreakerWindowMs  ?? (parseInt(process.env.HORIZON_CB_WINDOW_MS, 10) || 60_000),
+      cooldownMs: config.circuitBreakerCooldownMs ?? (parseInt(process.env.HORIZON_CB_COOLDOWN_MS, 10) || 30_000),
       name: 'horizon',
     });
   }
@@ -996,6 +996,7 @@ class StellarService extends StellarServiceInterface {
       if (timeoutTimer) {
         clearTimeout(timeoutTimer);
       }
+      // eslint-disable-next-line local/no-bare-timers -- per-stream idle timeout, cleared on every message and on stream close below
       timeoutTimer = setTimeout(() => {
         const elapsed = Date.now() - lastMessageTime;
         log.error('STELLAR_SERVICE', 'Transaction stream timeout', {

--- a/src/services/WebhookService.js
+++ b/src/services/WebhookService.js
@@ -552,7 +552,7 @@ class WebhookService {
     for (const webhook of interested) {
       withAsyncContext('webhook_delivery', async () => {
         try {
-          await this._deliverWithRetry(webhook, event, payload, 0);
+          await WebhookService._deliverWithRetry(webhook, event, payload, 0);
         } catch (err) {
           await WebhookService.scheduleRetry({
             webhookId: webhook.id,
@@ -574,7 +574,7 @@ class WebhookService {
    * Attempt delivery with exponential backoff retry.
    * @private
    */
-  async _deliverWithRetry(webhook, event, payload, attempt) {
+  static async _deliverWithRetry(webhook, event, payload, attempt) {
     const correlationHeaders = generateCorrelationHeaders();
     const timestamp = new Date().toISOString();
     const body = JSON.stringify({
@@ -593,8 +593,14 @@ class WebhookService {
     const signature = WebhookService._sign(body, plaintextSecret, timestamp);
 
     try {
-      const result = await WebhookService._httpPost(webhook.url, body, signature, correlationHeaders, !!webhook.tls_skip_verify, webhook.id);
-      
+      const result = await WebhookService._httpPost(webhook.url, body, signature, correlationHeaders, !!webhook.tls_skip_verify, webhook.id, timestamp);
+
+      // A non-2xx response is a delivery failure: it must drive the retry /
+      // dead-letter path rather than being recorded as success.
+      if (!result.delivered) {
+        throw new Error(`Webhook endpoint responded with HTTP ${result.statusCode}`);
+      }
+
       // Log successful delivery
       const Database = require('../utils/database');
       await Database.run(
@@ -655,7 +661,7 @@ class WebhookService {
    * Validates the URL against SSRF rules before every request (DNS rebinding protection).
    * @private
    */
-  static _httpPost(url, body, signature, correlationHeaders = {}, tlsSkipVerify = false, webhookId = null) {
+  static _httpPost(url, body, signature, correlationHeaders = {}, tlsSkipVerify = false, webhookId = null, timestamp = null) {
     const isProduction = process.env.NODE_ENV === 'production';
     const breakGlass = process.env.WEBHOOK_ALLOW_TLS_SKIP_VERIFY === 'break-glass';
 

--- a/tests/contracts/stellarService.contract.test.js
+++ b/tests/contracts/stellarService.contract.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/**
+ * Contract / parity tests between MockStellarService and StellarService.
+ * Issue #1164.
+ *
+ * One shared contract (see ./stellarServiceContract.js) is executed against
+ * BOTH the mock and the real implementation. On top of that, a direct
+ * mock-vs-real parity matrix asserts the two never drift in method surface or
+ * signature beyond the explicitly documented divergences. Any undocumented
+ * drift — a new interface method left unimplemented, a changed arity, a method
+ * that appears on one side but not the other — fails CI.
+ */
+
+const StellarServiceInterface = require('../../src/services/interfaces/StellarServiceInterface');
+const MockStellarService = require('../../src/services/MockStellarService');
+const StellarService = require('../../src/services/StellarService');
+const {
+  runStellarServiceContract,
+  CONTRACT_METHODS,
+  KNOWN_DIVERGENCES,
+  overridesMethod,
+} = require('./stellarServiceContract');
+
+// ── The shared contract, run against each implementation ─────────────────────
+
+runStellarServiceContract({
+  name: 'MockStellarService',
+  impl: 'mock',
+  createService: () => new MockStellarService({ network: 'testnet' }),
+  capabilities: { offlineWallets: true },
+});
+
+runStellarServiceContract({
+  name: 'StellarService (real)',
+  impl: 'real',
+  createService: () => new StellarService({ network: 'testnet' }),
+  capabilities: { offlineWallets: false },
+});
+
+// ── Direct mock-vs-real parity matrix ────────────────────────────────────────
+
+describe('MockStellarService ⇄ StellarService parity', () => {
+  const mock = new MockStellarService({ network: 'testnet' });
+  const real = new StellarService({ network: 'testnet' });
+
+  test('both implementations extend StellarServiceInterface', () => {
+    expect(mock).toBeInstanceOf(StellarServiceInterface);
+    expect(real).toBeInstanceOf(StellarServiceInterface);
+  });
+
+  test('the contract covers every method declared on the interface', () => {
+    const ifaceMethods = Object.getOwnPropertyNames(StellarServiceInterface.prototype)
+      .filter((n) => n !== 'constructor');
+    expect(CONTRACT_METHODS.map((m) => m.name).sort()).toEqual(ifaceMethods.sort());
+  });
+
+  describe('per-method signature parity', () => {
+    test.each(CONTRACT_METHODS.map((m) => [m.name, m]))(
+      '%s() — mock and real agree (within documented divergences)',
+      (methodName) => {
+        const mockOverrides = overridesMethod(mock, methodName);
+        const realOverrides = overridesMethod(real, methodName);
+        const divergence = KNOWN_DIVERGENCES[methodName] || {};
+
+        // Both must expose the method as callable (presence via inheritance).
+        expect(typeof mock[methodName]).toBe('function');
+        expect(typeof real[methodName]).toBe('function');
+
+        // Whether each side OVERRIDES the interface stub is fixed by the
+        // documented divergence map; an undocumented inherited-vs-overridden
+        // mismatch is real drift and fails here.
+        expect(mockOverrides).toBe(divergence.mock !== 'inherited');
+        expect(realOverrides).toBe(divergence.real !== 'inherited');
+
+        // When BOTH override, their declared arity must match unless a
+        // divergence is documented for that side.
+        if (mockOverrides && realOverrides) {
+          const mockArity = mock[methodName].length;
+          const realArity = real[methodName].length;
+          const mockDoc = typeof divergence.mock === 'string' && divergence.mock.startsWith('arity:');
+          const realDoc = typeof divergence.real === 'string' && divergence.real.startsWith('arity:');
+          if (!mockDoc && !realDoc) {
+            expect(mockArity).toBe(realArity);
+          }
+        }
+      }
+    );
+  });
+
+  test('offline-pure conversions agree between mock and a reference impl', () => {
+    // stroops/XLM conversion is part of the contract but only the mock
+    // implements it as a class method. Guard that the mock honours the
+    // canonical 1 XLM = 10,000,000 stroops relationship the real service's
+    // SDK-backed math also obeys.
+    expect(mock.xlmToStroops('1')).toBe('10000000');
+    expect(mock.stroopsToXlm('10000000')).toBe('1.0000000');
+    expect(mock.stroopsToXlm(mock.xlmToStroops('7.5'))).toBe('7.5000000');
+  });
+});

--- a/tests/contracts/stellarServiceContract.js
+++ b/tests/contracts/stellarServiceContract.js
@@ -1,0 +1,303 @@
+'use strict';
+
+/**
+ * Shared Stellar service contract (issue #1164)
+ * ─────────────────────────────────────────────
+ * StellarServiceInterface is the formal contract that BOTH the in-memory
+ * MockStellarService (tests/dev) and the real StellarService (production)
+ * promise to honour. If the two drift apart in signature, return shape, or
+ * error behaviour, the test suite passes against the mock while production
+ * behaves differently — the worst kind of false confidence for a payments
+ * system.
+ *
+ * This module exports a SINGLE contract that `stellarService.contract.test.js`
+ * runs against both implementations, so a divergence from the interface or
+ * from the shared behavioural expectations fails CI.
+ *
+ * The contract has two layers:
+ *   1. Structural conformance — every interface method is present, both
+ *      classes are instances of the interface, and the arity of each method
+ *      matches the contract (a changed signature is drift).
+ *   2. Behavioural conformance — for methods that are deterministic offline
+ *      (no live Horizon required) we assert the actual return shapes and
+ *      error contracts, not merely that the method exists.
+ *
+ * Methods whose behaviour can only be exercised against a live/sandbox
+ * Horizon are gated behind capability flags so the same suite runs cleanly
+ * against the mock (full behaviour) and the real service (structure + the
+ * offline-deterministic subset).
+ */
+
+const StellarServiceInterface = require('../../src/services/interfaces/StellarServiceInterface');
+
+/**
+ * The canonical method surface of the contract, derived from the interface.
+ * `arity` is the declared parameter count of the interface method and is the
+ * single source of truth a signature change is measured against.
+ *
+ * `offlinePure` marks methods that return deterministically without any
+ * network access — these are exercised behaviourally against every
+ * implementation that overrides them.
+ */
+const OFFLINE_PURE = new Set([
+  'isValidAddress',
+  'stroopsToXlm',
+  'xlmToStroops',
+  'getNetwork',
+  'getHorizonUrl',
+]);
+
+const CONTRACT_METHODS = (() => {
+  const proto = StellarServiceInterface.prototype;
+  return Object.getOwnPropertyNames(proto)
+    .filter((name) => name !== 'constructor' && typeof proto[name] === 'function')
+    .map((name) => ({
+      name,
+      arity: proto[name].length,
+      offlinePure: OFFLINE_PURE.has(name),
+    }));
+})();
+
+/**
+ * Documented divergences from the interface that exist in the codebase TODAY.
+ * Each entry is an explicit, reviewed exception — NOT a licence to drift. The
+ * structural contract treats anything NOT listed here as a failure, so:
+ *   - adding a new interface method without implementing it,
+ *   - changing the arity of a conformant method, or
+ *   - introducing a brand-new mock/real mismatch
+ * all fail CI. Closing one of these gaps (good!) also fails CI, prompting the
+ * entry to be removed — keeping this list honest over time.
+ *
+ * shape: { method: { mock?: <verdict>, real?: <verdict> } } where <verdict> is
+ *   - 'inherited' : the implementation does not override the interface method
+ *                   (it inherits the throwing stub).
+ *   - 'arity:N'   : the implementation overrides the method but with declared
+ *                   arity N instead of the interface's arity.
+ */
+const KNOWN_DIVERGENCES = {
+  // Real service delegates raw account/transaction access to the Stellar SDK
+  // `server` object and does not expose these as its own methods offline.
+  loadAccount: { real: 'inherited' },
+  submitTransaction: { real: 'inherited' },
+  buildPaymentTransaction: { real: 'inherited' },
+  getAccountSequence: { real: 'inherited' },
+  buildTransaction: { real: 'inherited' },
+  signTransaction: { real: 'inherited' },
+  getTransaction: { real: 'inherited' },
+  // Pure helpers implemented on the mock; the real service relies on the
+  // shared validation/util layer rather than class methods.
+  isValidAddress: { real: 'inherited' },
+  stroopsToXlm: { real: 'inherited' },
+  xlmToStroops: { real: 'inherited' },
+  getTrustlines: { real: 'inherited' },
+  // deleteAccountData is implemented on the real service but not the mock.
+  deleteAccountData: { mock: 'inherited' },
+  // setOptions: both override with a default-valued options param (arity 1).
+  setOptions: { mock: 'arity:1', real: 'arity:1' },
+  // Trustline management drifted to a richer signature on both implementations
+  // (accountSecret, assetCode, issuerPublic, [limit]); the interface still
+  // documents the older (publicKey, asset) shape.
+  addTrustline: { mock: 'arity:3', real: 'arity:3' },
+  // removeTrustline: only the real service adopted the richer signature.
+  removeTrustline: { real: 'arity:3' },
+};
+
+/** Walk the prototype chain to find the prototype object that owns `method`. */
+function findOwningProto(instance, method) {
+  let proto = Object.getPrototypeOf(instance);
+  while (proto) {
+    if (Object.prototype.hasOwnProperty.call(proto, method)) return proto;
+    proto = Object.getPrototypeOf(proto);
+  }
+  return null;
+}
+
+/** Does this implementation override (vs inherit) the interface method? */
+function overridesMethod(instance, method) {
+  const owner = findOwningProto(instance, method);
+  return owner !== null && owner !== StellarServiceInterface.prototype;
+}
+
+/**
+ * Resolve the contractually expected verdict for a method on one
+ * implementation, taking the documented divergences into account.
+ * @returns {{ kind: 'inherited' } | { kind: 'arity', arity: number }}
+ */
+function expectedVerdict(methodName, impl /* 'mock' | 'real' */, canonicalArity) {
+  const divergence = (KNOWN_DIVERGENCES[methodName] || {})[impl];
+  if (divergence === 'inherited') {
+    return { kind: 'inherited' };
+  }
+  if (typeof divergence === 'string' && divergence.startsWith('arity:')) {
+    return { kind: 'arity', arity: parseInt(divergence.slice('arity:'.length), 10) };
+  }
+  return { kind: 'arity', arity: canonicalArity };
+}
+
+/**
+ * Run the shared contract against one implementation.
+ *
+ * @param {Object} opts
+ * @param {string} opts.name           - Human label, e.g. "MockStellarService"
+ * @param {'mock'|'real'} opts.impl    - Which side of the divergence map applies
+ * @param {() => Object} opts.createService - Factory returning a fresh instance
+ * @param {Object} [opts.capabilities] - Behavioural capability flags
+ * @param {boolean} [opts.capabilities.offlineWallets] - In-memory wallet
+ *        behaviour is available (full behavioural contract).
+ */
+function runStellarServiceContract({ name, impl, createService, capabilities = {} }) {
+  const { offlineWallets = false } = capabilities;
+
+  describe(`StellarServiceInterface contract — ${name}`, () => {
+    let service;
+    beforeEach(() => {
+      service = createService();
+    });
+
+    describe('structural conformance', () => {
+      test('is an instance of StellarServiceInterface', () => {
+        expect(service).toBeInstanceOf(StellarServiceInterface);
+      });
+
+      test.each(CONTRACT_METHODS.map((m) => [m.name]))(
+        'exposes %s() as a callable',
+        (methodName) => {
+          expect(typeof service[methodName]).toBe('function');
+        }
+      );
+
+      test.each(CONTRACT_METHODS.map((m) => [m.name, m]))(
+        'method %s() conforms to the contract signature/presence',
+        (methodName, meta) => {
+          const verdict = expectedVerdict(methodName, impl, meta.arity);
+
+          if (verdict.kind === 'inherited') {
+            // Documented gap: the implementation inherits the throwing stub.
+            expect(overridesMethod(service, methodName)).toBe(false);
+            return;
+          }
+
+          // Implementation must override the interface method...
+          expect(overridesMethod(service, methodName)).toBe(true);
+          // ...with the contractually expected arity.
+          expect(service[methodName].length).toBe(verdict.arity);
+        }
+      );
+    });
+
+    describe('behavioural conformance — offline-pure methods', () => {
+      const offline = CONTRACT_METHODS.filter((m) => m.offlinePure);
+
+      for (const meta of offline) {
+        const supported = overridesMethod(createService(), meta.name);
+        const maybe = supported ? describe : describe.skip;
+
+        maybe(`${meta.name}()`, () => {
+          if (meta.name === 'getNetwork') {
+            test('returns a non-empty network identifier string', () => {
+              expect(typeof service.getNetwork()).toBe('string');
+              expect(service.getNetwork().length).toBeGreaterThan(0);
+            });
+          }
+
+          if (meta.name === 'getHorizonUrl') {
+            test('returns a parseable Horizon URL', () => {
+              const url = service.getHorizonUrl();
+              expect(typeof url).toBe('string');
+              expect(() => new URL(url)).not.toThrow();
+            });
+          }
+
+          if (meta.name === 'isValidAddress') {
+            test('accepts a well-formed public key and rejects malformed input', () => {
+              const valid = 'G' + 'A'.repeat(55);
+              expect(service.isValidAddress(valid)).toBe(true);
+              expect(service.isValidAddress('not-a-key')).toBe(false);
+              expect(service.isValidAddress('')).toBe(false);
+              expect(service.isValidAddress(null)).toBe(false);
+            });
+          }
+
+          if (meta.name === 'stroopsToXlm') {
+            test('converts integer stroops to a 7-dp XLM string', () => {
+              expect(service.stroopsToXlm(10_000_000)).toBe('1.0000000');
+              expect(service.stroopsToXlm(1)).toBe('0.0000001');
+              expect(service.stroopsToXlm(0)).toBe('0.0000000');
+            });
+            test('rejects non-numeric input with an error', () => {
+              expect(() => service.stroopsToXlm('not-a-number')).toThrow();
+            });
+          }
+
+          if (meta.name === 'xlmToStroops') {
+            test('converts an XLM amount to an integer stroop string', () => {
+              expect(service.xlmToStroops('1')).toBe('10000000');
+              expect(service.xlmToStroops('0.0000001')).toBe('1');
+            });
+            test('rejects non-numeric input with an error', () => {
+              expect(() => service.xlmToStroops('not-a-number')).toThrow();
+            });
+            test('round-trips with stroopsToXlm', () => {
+              const xlm = '12.3456789';
+              expect(service.stroopsToXlm(service.xlmToStroops(xlm))).toBe('12.3456789');
+            });
+          }
+        });
+      }
+    });
+
+    // The full behavioural contract (return shapes + error contracts for
+    // wallet/transaction operations) is only deterministic offline against the
+    // in-memory implementation. The real service exercises these paths in its
+    // own integration suites against a sandbox/recorded Horizon.
+    const walletSuite = offlineWallets ? describe : describe.skip;
+    walletSuite('behavioural conformance — wallet/transaction operations', () => {
+      const validAddr = 'G' + 'A'.repeat(55);
+
+      test('loadAccount() rejects an invalid address with an error', async () => {
+        await expect(service.loadAccount('bad')).rejects.toThrow();
+      });
+
+      test('loadAccount() returns the documented account shape for a known wallet', async () => {
+        service.wallets.set(validAddr, { sequence: '42', balance: '100.0000000' });
+        const account = await service.loadAccount(validAddr);
+        expect(typeof account.accountId).toBe('function');
+        expect(account.accountId()).toBe(validAddr);
+        expect(typeof account.sequenceNumber).toBe('function');
+        expect(Array.isArray(account.balances)).toBe(true);
+      });
+
+      test('getAccountSequence() rejects an invalid address', async () => {
+        await expect(service.getAccountSequence('bad')).rejects.toThrow();
+      });
+
+      test('submitSignedTransaction() returns {transactionId, hash, ledger}', async () => {
+        const result = await service.submitSignedTransaction('AAAA-fake-xdr');
+        expect(result).toEqual(
+          expect.objectContaining({
+            transactionId: expect.any(String),
+            hash: expect.any(String),
+            ledger: expect.any(Number),
+          })
+        );
+      });
+
+      test('submitSignedTransaction() rejects empty input with an error', async () => {
+        await expect(service.submitSignedTransaction('')).rejects.toThrow();
+      });
+
+      test('buildPaymentTransaction() rejects an invalid source key', async () => {
+        await expect(
+          service.buildPaymentTransaction('bad', validAddr, '10')
+        ).rejects.toThrow();
+      });
+    });
+  });
+}
+
+module.exports = {
+  runStellarServiceContract,
+  CONTRACT_METHODS,
+  KNOWN_DIVERGENCES,
+  overridesMethod,
+};

--- a/tests/helpers/propertyTest.js
+++ b/tests/helpers/propertyTest.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Minimal property-based testing helper (issue #1165).
+ *
+ * Example-based unit tests only check the inputs the author thought of.
+ * Money/fee/conversion math is precision-sensitive and full of boundary
+ * conditions, so we generate a large spread of inputs and assert invariants
+ * that must hold for ALL of them.
+ *
+ * This is a tiny, dependency-free harness (rather than pulling in fast-check)
+ * so the property tests stay self-contained and the lockfile is untouched. It
+ * provides:
+ *   - a deterministic, seeded PRNG so any failure is reproducible,
+ *   - generators for the value ranges that matter for Stellar money math,
+ *   - `forAll`, which runs a property `runs` times and, on the first failing
+ *     input, throws an error embedding the counterexample.
+ */
+
+/** Deterministic PRNG (mulberry32) — same seed ⇒ same sequence. */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Run `property` for each value produced by `generator`. On the first failure
+ * the thrown error names the seed and the offending value so the case can be
+ * reproduced and frozen as a regression test.
+ *
+ * @param {(rng: () => number) => any} generator - produces one input value
+ * @param {(value: any) => void} property - asserts the invariant; throws on violation
+ * @param {Object} [opts]
+ * @param {number} [opts.runs=500]
+ * @param {number} [opts.seed=0xC0FFEE]
+ */
+function forAll(generator, property, opts = {}) {
+  const { runs = 500, seed = 0xc0ffee } = opts;
+  const rng = mulberry32(seed);
+  for (let i = 0; i < runs; i++) {
+    const value = generator(rng);
+    try {
+      property(value);
+    } catch (err) {
+      const printable = (() => {
+        try { return JSON.stringify(value); } catch { return String(value); }
+      })();
+      err.message =
+        `Property failed on run ${i + 1}/${runs} (seed=${seed}) ` +
+        `for input ${printable}:\n${err.message}`;
+      throw err;
+    }
+  }
+}
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+/** Uniform float in [min, max], rounded to `decimals` places. */
+function floatInRange(min, max, decimals = 7) {
+  return (rng) => {
+    const raw = min + rng() * (max - min);
+    return parseFloat(raw.toFixed(decimals));
+  };
+}
+
+/** Uniform integer in [min, max] (inclusive). */
+function intInRange(min, max) {
+  return (rng) => min + Math.floor(rng() * (max - min + 1));
+}
+
+/**
+ * A realistic XLM amount as a fixed-point string with up to 7 decimal places,
+ * spanning sub-stroop boundaries up to large balances. Never produces
+ * scientific notation, matching the input-boundary validator.
+ */
+function xlmAmountString(min = 0.0000001, max = 1_000_000) {
+  const f = floatInRange(min, max, 7);
+  return (rng) => {
+    const v = f(rng);
+    // Guarantee strictly positive after rounding.
+    const safe = v <= 0 ? 0.0000001 : v;
+    return safe.toFixed(7).replace(/\.?0+$/, '') || '0';
+  };
+}
+
+/** Pick one element from `choices`. */
+function oneOf(choices) {
+  return (rng) => choices[Math.floor(rng() * choices.length)];
+}
+
+module.exports = {
+  mulberry32,
+  forAll,
+  floatInRange,
+  intInRange,
+  xlmAmountString,
+  oneOf,
+};

--- a/tests/integration/webhook-delivery-e2e.test.js
+++ b/tests/integration/webhook-delivery-e2e.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+/**
+ * End-to-end webhook delivery integration tests (issue #1166).
+ *
+ * Webhook delivery is a multi-part subsystem — payload construction, signing,
+ * transport, retry/backoff, and dead-lettering. Unit tests can't prove the
+ * parts work together, and bugs here are consumer-facing and hard to notice
+ * from the inside. These tests stand up a real local HTTP sink, point the
+ * webhook subsystem at it, and assert the full delivery contract:
+ *
+ *   1. the delivered payload matches the documented schema and carries a
+ *      signature that verifies with the documented HMAC-SHA256 algorithm/secret;
+ *   2. transient failures (5xx) trigger retries with exponential backoff up to
+ *      the capped attempt count;
+ *   3. a permanent failure lands in the dead-letter queue with full context,
+ *      and replaying it re-delivers successfully once the sink is healthy.
+ */
+
+const http = require('http');
+const crypto = require('crypto');
+
+const webhookService = require('../../src/services/WebhookService');
+const { WebhookService } = webhookService;
+const Database = require('../../src/utils/database');
+
+// Mirrors the constants in WebhookService (not exported there).
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1000;
+const RETRY_MAX_ATTEMPTS = 5;
+
+/**
+ * A minimal local HTTP server that records every delivery it receives and
+ * replies with a configurable status code (or per-request status function).
+ */
+class WebhookSink {
+  constructor() {
+    this.requests = [];
+    this.status = 200; // number, or (requestIndex) => number
+    this.server = null;
+  }
+
+  start() {
+    return new Promise((resolve) => {
+      this.server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (chunk) => { body += chunk; });
+        req.on('end', () => {
+          this.requests.push({
+            method: req.method,
+            headers: req.headers,
+            body,
+            at: Date.now(),
+          });
+          const code = typeof this.status === 'function'
+            ? this.status(this.requests.length)
+            : this.status;
+          res.statusCode = code;
+          res.end(code >= 200 && code < 300 ? 'ok' : 'error');
+        });
+      });
+      this.server.listen(0, '127.0.0.1', () => resolve());
+    });
+  }
+
+  get port() { return this.server.address().port; }
+  url(path = '/hook') { return `http://127.0.0.1:${this.port}${path}`; }
+  bodies() { return this.requests.map((r) => JSON.parse(r.body)); }
+
+  stop() {
+    return new Promise((resolve) => {
+      if (!this.server) return resolve();
+      this.server.close(() => resolve());
+    });
+  }
+}
+
+/** Recompute the documented signature: HMAC-SHA256 over `${timestamp}.${body}`. */
+function expectedSignature(secret, timestamp, rawBody) {
+  return crypto.createHmac('sha256', secret).update(`${timestamp}.${rawBody}`).digest('hex');
+}
+
+describe('Webhook delivery — end-to-end', () => {
+  let sink;
+
+  beforeAll(async () => {
+    await WebhookService.initTable();
+    // The tls_skip_verify column is added by migration 020; the bare test
+    // schema may not have it. Add it defensively so register() can insert.
+    try {
+      await Database.run('ALTER TABLE webhooks ADD COLUMN tls_skip_verify INTEGER NOT NULL DEFAULT 0');
+    } catch (_) { /* column already exists */ }
+  });
+
+  beforeEach(async () => {
+    // Isolate each test from the others.
+    await Database.run('DELETE FROM webhooks');
+    await Database.run('DELETE FROM webhook_retries');
+    await Database.run('DELETE FROM webhook_dead_letters');
+    await Database.run('DELETE FROM webhook_delivery_history');
+    sink = new WebhookSink();
+    await sink.start();
+  });
+
+  afterEach(async () => {
+    await sink.stop();
+  });
+
+  async function registerWebhook(events) {
+    const reg = await webhookService.register({ url: sink.url(), events });
+    const row = await Database.get('SELECT * FROM webhooks WHERE id = ?', [reg.id]);
+    return { reg, row };
+  }
+
+  test('delivers a well-formed, correctly-signed payload', async () => {
+    sink.status = 200;
+    const { reg, row } = await registerWebhook(['donation.created']);
+
+    const payload = {
+      donationId: 'd_123',
+      amount: '10.5000000',
+      currency: 'XLM',
+      recipient: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRST2345',
+    };
+
+    await WebhookService._deliverWithRetry(row, 'donation.created', payload, 0);
+
+    expect(sink.requests).toHaveLength(1);
+    const req = sink.requests[0];
+
+    // Transport contract
+    expect(req.method).toBe('POST');
+    expect(req.headers['content-type']).toBe('application/json');
+
+    // Documented payload schema
+    const parsed = JSON.parse(req.body);
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        event: 'donation.created',
+        data: payload,
+        timestamp: expect.any(String),
+        correlationContext: expect.any(Object),
+      })
+    );
+    expect(() => new Date(parsed.timestamp).toISOString()).not.toThrow();
+
+    // Signature verifies with the documented algorithm/secret
+    const ts = req.headers['x-webhook-timestamp'];
+    expect(ts).toBe(parsed.timestamp);
+    const sig = expectedSignature(reg.secret, ts, req.body);
+    expect(req.headers['x-webhook-signature']).toBe(`sha256=${sig}`);
+    expect(req.headers['x-signature']).toBe(`sha256=${sig}`);
+
+    // A wrong secret must NOT verify (guards against an empty/static secret).
+    const wrong = expectedSignature('not-the-secret', ts, req.body);
+    expect(req.headers['x-webhook-signature']).not.toBe(`sha256=${wrong}`);
+  });
+
+  test('retries transient 5xx failures with exponential backoff up to the capped attempt count', async () => {
+    sink.status = 500; // permanently failing endpoint
+    const { row } = await registerWebhook(['evt.retry']);
+
+    await expect(
+      WebhookService._deliverWithRetry(row, 'evt.retry', { n: 1 }, 0)
+    ).rejects.toBeDefined();
+
+    // Capped at MAX_RETRIES total attempts.
+    expect(sink.requests).toHaveLength(MAX_RETRIES);
+
+    // Backoff increases between attempts (1s, then 2s) — assert with margin.
+    const gap1 = sink.requests[1].at - sink.requests[0].at;
+    const gap2 = sink.requests[2].at - sink.requests[1].at;
+    expect(gap1).toBeGreaterThanOrEqual(BASE_BACKOFF_MS * 0.8);
+    expect(gap2).toBeGreaterThanOrEqual(BASE_BACKOFF_MS * 2 * 0.8);
+    expect(gap2).toBeGreaterThan(gap1);
+  }, 20000);
+
+  test('promotes a permanently failed delivery to the dead-letter queue with full context', async () => {
+    const { reg } = await registerWebhook(['evt.dlq']);
+    const payload = { orderId: 'o_99', note: 'permanent failure' };
+
+    // Drive the queue to its final attempt — scheduleRetry promotes to DLQ
+    // once RETRY_MAX_ATTEMPTS is reached.
+    await WebhookService.scheduleRetry({
+      webhookId: reg.id,
+      event: 'evt.dlq',
+      payload,
+      attempt: RETRY_MAX_ATTEMPTS,
+      lastError: 'HTTP 500 (permanent)',
+    });
+
+    const deadLetters = await WebhookService.listDeadLetters({ limit: 50 });
+    const entry = deadLetters.find((e) => e.webhookId === reg.id && e.event === 'evt.dlq');
+
+    expect(entry).toBeDefined();
+    expect(entry.payload).toEqual(payload); // full context preserved
+    expect(entry.attempts).toBe(RETRY_MAX_ATTEMPTS);
+    expect(entry.lastError).toBe('HTTP 500 (permanent)');
+  });
+
+  test('replaying a dead-letter re-delivers successfully once the sink is healthy', async () => {
+    const { reg } = await registerWebhook(['evt.replay']);
+    const payload = { invoiceId: 'inv_7', amount: '3.2500000' };
+
+    // Land it in the DLQ first.
+    await WebhookService.scheduleRetry({
+      webhookId: reg.id,
+      event: 'evt.replay',
+      payload,
+      attempt: RETRY_MAX_ATTEMPTS,
+      lastError: 'gone',
+    });
+    const before = await WebhookService.listDeadLetters({ limit: 50 });
+    const entry = before.find((e) => e.event === 'evt.replay');
+    expect(entry).toBeDefined();
+
+    // Sink is now healthy; replay re-queues the delivery.
+    sink.status = 200;
+    await WebhookService.replayDeadLetter(entry.id);
+
+    // Replay schedules a fresh retry due in the future; simulate the delay
+    // elapsing so the scheduler would pick it up now.
+    await Database.run(
+      'UPDATE webhook_retries SET next_retry_at = ? WHERE webhook_id = ?',
+      [new Date(Date.now() - 1000).toISOString(), reg.id]
+    );
+
+    const result = await WebhookService.processRetryQueue();
+    expect(result.succeeded).toBeGreaterThanOrEqual(1);
+
+    // The replayed payload reached the healthy sink...
+    const delivered = sink.bodies().find((b) => b.event === 'evt.replay');
+    expect(delivered).toBeDefined();
+    expect(delivered.data).toEqual(payload);
+
+    // ...and the dead-letter entry is consumed.
+    const after = await WebhookService.listDeadLetters({ limit: 50 });
+    expect(after.find((e) => e.id === entry.id)).toBeUndefined();
+  }, 20000);
+});

--- a/tests/load/LoadTestRunner.js
+++ b/tests/load/LoadTestRunner.js
@@ -16,6 +16,9 @@ class LoadTestRunner {
    * @param {number} [options.concurrency=10] - Concurrent virtual users
    * @param {number} [options.iterations=50] - Total requests per scenario
    * @param {number} [options.thinkTimeMs=50] - Delay between requests per VU (ms)
+   * @param {number} [options.warmupIterations=0] - Discarded requests run before
+   *        measurement to absorb cold-start cost (JIT, lazy requires, first DB
+   *        connection) so the gate measures steady-state, not startup variance.
    */
   constructor(app, options = {}) {
     this.app = app;
@@ -23,6 +26,19 @@ class LoadTestRunner {
     this.iterations = options.iterations || 50;
     // Use explicit undefined check so thinkTimeMs: 0 is respected (0 is falsy)
     this.thinkTimeMs = options.thinkTimeMs !== undefined ? options.thinkTimeMs : 50;
+    this.warmupIterations = options.warmupIterations || 0;
+  }
+
+  /**
+   * Run a handful of discarded requests so the measured run reflects
+   * steady-state performance rather than one-off cold-start cost.
+   * @param {object} scenario
+   * @returns {Promise<void>}
+   */
+  async _warmup(scenario) {
+    for (let i = 0; i < this.warmupIterations; i++) {
+      await this._executeRequest(scenario.requestFn);
+    }
   }
 
   /**
@@ -69,6 +85,8 @@ class LoadTestRunner {
    * @returns {Promise<ScenarioResult>}
    */
   async runScenario(scenario) {
+    await this._warmup(scenario);
+
     const results = [];
     const startTime = Date.now();
 

--- a/tests/load/PerformanceBaselines.js
+++ b/tests/load/PerformanceBaselines.js
@@ -1,16 +1,35 @@
 /**
  * PerformanceBaselines - Defines and validates performance thresholds
  *
- * Performance baselines for the Stellar Micro-Donation API.
- * CI load tests will fail if any threshold is exceeded.
+ * Performance baselines (SLOs) for the Stellar Micro-Donation API. The CI
+ * load-test job fails (and therefore blocks the merge) if any threshold is
+ * exceeded — see .github/workflows/load-tests.yml and docs/LOAD_TESTING.md.
  *
- * Baselines are defined per scenario with p50, p95, p99 latency (ms),
- * minimum throughput (req/s), and maximum error rate (0–1).
+ * Baselines are defined per scenario with p50, p95, p99 latency (ms), minimum
+ * throughput (req/s), and maximum error rate (0–1).
+ *
+ * ── Configurability & runner variance ───────────────────────────────────────
+ * Shared CI runners are noisy, so absolute latency numbers vary run-to-run.
+ * Rather than hand-pick loose ceilings, the defaults below describe the target
+ * behaviour and three environment variables apply a margin so the gate stays
+ * meaningful without being flaky:
+ *
+ *   LOAD_TEST_LATENCY_MARGIN     multiply every latency ceiling (default 1.0).
+ *                                e.g. 1.5 tolerates 50% slower runners.
+ *   LOAD_TEST_THROUGHPUT_MARGIN  multiply every min-throughput floor
+ *                                (default 1.0). e.g. 0.7 tolerates 30% lower
+ *                                throughput on a slow runner.
+ *   LOAD_TEST_ERROR_RATE_MARGIN  multiply every max-error-rate ceiling
+ *                                (default 1.0).
+ *
+ * The CI workflow sets conservative margins; locally the defaults apply. To
+ * change a target itself (not just tolerance), edit BASELINES below.
  */
 'use strict';
 
 /** @type {Object.<string, ScenarioBaseline>} */
 const BASELINES = {
+  // Write path: auth + validation + idempotency + mock submit.
   'donation-creation': {
     p50LatencyMs: 200,
     p95LatencyMs: 500,
@@ -18,21 +37,16 @@ const BASELINES = {
     minThroughputRps: 5,
     maxErrorRate: 0.05,
   },
-  'balance-queries': {
+  // Read path: auth + DB read + pagination + serialization.
+  'list-donations': {
     p50LatencyMs: 100,
     p95LatencyMs: 300,
     p99LatencyMs: 600,
     minThroughputRps: 10,
     maxErrorRate: 0.02,
   },
-  'stats': {
-    p50LatencyMs: 150,
-    p95LatencyMs: 400,
-    p99LatencyMs: 800,
-    minThroughputRps: 8,
-    maxErrorRate: 0.02,
-  },
-  'health-check': {
+  // Liveness: HTTP stack only, no auth/DB — the cheapest endpoint.
+  'liveness': {
     p50LatencyMs: 50,
     p95LatencyMs: 150,
     p99LatencyMs: 300,
@@ -42,12 +56,53 @@ const BASELINES = {
 };
 
 /**
+ * Read the configured margins from the environment (see file header).
+ * @param {Object} [env=process.env]
+ * @returns {{ latency: number, throughput: number, errorRate: number }}
+ */
+function getMargins(env = process.env) {
+  const num = (v, def) => {
+    const n = parseFloat(v);
+    return Number.isFinite(n) && n > 0 ? n : def;
+  };
+  return {
+    latency: num(env.LOAD_TEST_LATENCY_MARGIN, 1),
+    throughput: num(env.LOAD_TEST_THROUGHPUT_MARGIN, 1),
+    errorRate: num(env.LOAD_TEST_ERROR_RATE_MARGIN, 1),
+  };
+}
+
+/**
+ * Apply the configured margins to the baseline map, producing the effective
+ * thresholds the gate enforces. Pure function of (baselines, env).
+ * @param {Object.<string, ScenarioBaseline>} [baselines=BASELINES]
+ * @param {Object} [env=process.env]
+ * @returns {Object.<string, ScenarioBaseline>}
+ */
+function resolveBaselines(baselines = BASELINES, env = process.env) {
+  const m = getMargins(env);
+  const resolved = {};
+  for (const [name, b] of Object.entries(baselines)) {
+    resolved[name] = {
+      p50LatencyMs: b.p50LatencyMs * m.latency,
+      p95LatencyMs: b.p95LatencyMs * m.latency,
+      p99LatencyMs: b.p99LatencyMs * m.latency,
+      minThroughputRps: b.minThroughputRps * m.throughput,
+      maxErrorRate: b.maxErrorRate * m.errorRate,
+    };
+  }
+  return resolved;
+}
+
+/**
  * Validate a scenario result against its baseline
  * @param {ScenarioResult} result - Result from LoadTestRunner.runScenario
+ * @param {Object.<string, ScenarioBaseline>} [baselines] - Effective thresholds
+ *        (defaults to margin-resolved BASELINES).
  * @returns {{ passed: boolean, violations: string[] }}
  */
-function validateAgainstBaseline(result) {
-  const baseline = BASELINES[result.scenario];
+function validateAgainstBaseline(result, baselines = resolveBaselines()) {
+  const baseline = baselines[result.scenario];
   if (!baseline) {
     return { passed: true, violations: [], note: `No baseline defined for scenario "${result.scenario}"` };
   }
@@ -79,9 +134,10 @@ function validateAgainstBaseline(result) {
  * @returns {{ allPassed: boolean, results: Array<{ scenario: string, passed: boolean, violations: string[] }> }}
  */
 function validateReport(report) {
+  const baselines = resolveBaselines();
   const results = report.scenarios.map(scenarioResult => ({
     scenario: scenarioResult.scenario,
-    ...validateAgainstBaseline(scenarioResult),
+    ...validateAgainstBaseline(scenarioResult, baselines),
   }));
 
   return {
@@ -90,4 +146,10 @@ function validateReport(report) {
   };
 }
 
-module.exports = { BASELINES, validateAgainstBaseline, validateReport };
+module.exports = {
+  BASELINES,
+  getMargins,
+  resolveBaselines,
+  validateAgainstBaseline,
+  validateReport,
+};

--- a/tests/load/run-load-tests.js
+++ b/tests/load/run-load-tests.js
@@ -17,10 +17,69 @@
 process.env.MOCK_STELLAR = 'true';
 process.env.NODE_ENV = 'test';
 
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const crypto = require('crypto');
+
+// Point the database layer at a private temp DB and build its schema BEFORE the
+// app is required — otherwise every request hits an empty/missing database and
+// /health reports "degraded" (503), making the load gate measure a broken app
+// rather than real performance. Mirrors tests/globalSetup.js.
+if (!process.env.DB_PATH) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'load-test-db-'));
+  process.env.DB_PATH = path.join(dir, 'load-test.db');
+}
 const LoadTestRunner = require('./LoadTestRunner');
-const { validateReport } = require('./PerformanceBaselines');
+const { validateReport, resolveBaselines, getMargins } = require('./PerformanceBaselines');
 const { generateJsonReport, generateHtmlReport } = require('./ReportGenerator');
+
+/**
+ * Publish the metrics + pass/fail verdict to the GitHub Actions job summary so
+ * reviewers can see the numbers on the PR even when the gate passes.
+ * No-op outside Actions (GITHUB_STEP_SUMMARY unset).
+ */
+function writeStepSummary(report, validation) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const baselines = resolveBaselines();
+  const margins = getMargins();
+  const lines = [];
+  lines.push('## Load test results');
+  lines.push('');
+  lines.push(`Verdict: ${validation.allPassed ? '✅ **PASS**' : '❌ **FAIL** — performance regressed beyond thresholds'}`);
+  lines.push('');
+  lines.push(`Margins applied — latency ×${margins.latency}, throughput ×${margins.throughput}, error-rate ×${margins.errorRate}`);
+  lines.push('');
+  lines.push('| Scenario | p50 (ms) | p95 (ms) | p99 (ms) | Throughput (req/s) | Error rate | Threshold |');
+  lines.push('|---|---|---|---|---|---|---|');
+  for (const s of report.scenarios) {
+    const b = baselines[s.scenario];
+    const v = validation.results.find(r => r.scenario === s.scenario);
+    const status = v && v.passed ? '✅' : (v && v.violations && v.violations.length ? '❌' : '➖');
+    const ceiling = b ? `p95≤${Math.round(b.p95LatencyMs)}ms, err≤${(b.maxErrorRate * 100).toFixed(1)}%` : 'no baseline';
+    lines.push(
+      `| ${s.scenario} | ${s.latency.p50} | ${s.latency.p95} | ${s.latency.p99} | ` +
+      `${s.throughput.toFixed(1)} | ${(s.errorRate * 100).toFixed(1)}% | ${status} ${ceiling} |`
+    );
+  }
+  if (!validation.allPassed) {
+    lines.push('');
+    lines.push('### Violations');
+    for (const r of validation.results) {
+      if (!r.passed && r.violations && r.violations.length) {
+        lines.push(`- **${r.scenario}**: ${r.violations.join('; ')}`);
+      }
+    }
+  }
+  lines.push('');
+  try {
+    fs.appendFileSync(summaryPath, lines.join('\n') + '\n');
+  } catch (err) {
+    console.warn('Could not write job summary:', err.message);
+  }
+}
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -32,37 +91,53 @@ const getArg = (flag, def) => {
 const outputDir = getArg('--output', path.join(__dirname, '../../reports/load'));
 const concurrency = parseInt(getArg('--concurrency', '10'), 10);
 const iterations = parseInt(getArg('--iterations', '50'), 10);
+// Discarded warm-up requests per scenario absorb cold-start variance (issue #1167).
+const warmup = parseInt(getArg('--warmup', '5'), 10);
 
 async function main() {
   console.log('\n=== Stellar Micro-Donation API — Load Tests ===');
   console.log(`Concurrency: ${concurrency} VUs | Iterations: ${iterations} per scenario\n`);
 
+  // Build the database schema before the app starts handling requests.
+  try {
+    const Database = require('../../src/utils/database');
+    const createTestTables = require('../helpers/dbBootstrap');
+    await createTestTables(Database);
+  } catch (err) {
+    console.warn('Could not bootstrap load-test database schema:', err.message);
+  }
+
   // Load the Express app in mock mode
   const app = require('../../src/app');
 
-  const runner = new LoadTestRunner(app, { concurrency, iterations, thinkTimeMs: 10 });
+  const runner = new LoadTestRunner(app, { concurrency, iterations, thinkTimeMs: 10, warmupIterations: warmup });
+
+  // Representative read/write mix against the real, versioned API routes.
+  // Donor/recipient are valid Stellar public keys so the write path passes
+  // validation; each create uses a unique Idempotency-Key so the requests are
+  // genuinely processed rather than served from the idempotency cache.
+  const StellarSdk = require('stellar-sdk');
+  const donor = StellarSdk.Keypair.random().publicKey();
+  const recipient = StellarSdk.Keypair.random().publicKey();
 
   const scenarios = [
     {
-      name: 'health-check',
-      requestFn: (req) => req.get('/health'),
+      name: 'liveness',
+      requestFn: (req) => req.get('/health/live'),
     },
     {
-      name: 'balance-queries',
-      requestFn: (req) => req.get('/wallets').set('X-API-Key', 'test-load-key'),
-    },
-    {
-      name: 'stats',
-      requestFn: (req) => req.get('/stats/daily').set('X-API-Key', 'test-load-key'),
+      name: 'list-donations',
+      requestFn: (req) => req.get('/api/v1/donations').set('X-API-Key', 'test-load-key'),
     },
     {
       name: 'donation-creation',
-      requestFn: (req) => req.post('/donations')
+      requestFn: (req) => req.post('/api/v1/donations')
         .set('X-API-Key', 'test-load-key')
+        .set('Idempotency-Key', crypto.randomUUID())
         .send({
           amount: '10.00',
-          recipient: 'GBXXXXRECIPIENT1234567890XXXXXXXXXXXXXXXXXXXXXXXXXX',
-          donor: 'GBXXXXDONOR1234567890XXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          recipient,
+          donor,
           currency: 'XLM',
         }),
     },
@@ -91,6 +166,9 @@ async function main() {
   generateJsonReport(report, path.join(outputDir, 'load-test-report.json'));
   generateHtmlReport(report, path.join(outputDir, 'load-test-report.html'));
   console.log(`\nReports written to: ${outputDir}`);
+
+  // Publish metrics to the PR/job summary (visible even on a pass).
+  writeStepSummary(report, validation);
 
   if (!validation.allPassed) {
     console.error('\n[FAIL] Performance baselines violated — see violations above');

--- a/tests/performance/load-testing-suite.test.js
+++ b/tests/performance/load-testing-suite.test.js
@@ -289,18 +289,14 @@ describe('PerformanceBaselines', () => {
       expect(BASELINES['donation-creation'].minThroughputRps).toBeGreaterThan(0);
     });
 
-    test('defines baseline for balance-queries', () => {
-      expect(BASELINES['balance-queries']).toBeDefined();
-      expect(BASELINES['balance-queries'].p95LatencyMs).toBeLessThan(BASELINES['donation-creation'].p95LatencyMs);
+    test('defines baseline for list-donations', () => {
+      expect(BASELINES['list-donations']).toBeDefined();
+      expect(BASELINES['list-donations'].p95LatencyMs).toBeLessThan(BASELINES['donation-creation'].p95LatencyMs);
     });
 
-    test('defines baseline for stats', () => {
-      expect(BASELINES['stats']).toBeDefined();
-    });
-
-    test('defines baseline for health-check', () => {
-      expect(BASELINES['health-check']).toBeDefined();
-      expect(BASELINES['health-check'].p95LatencyMs).toBeLessThan(BASELINES['donation-creation'].p95LatencyMs);
+    test('defines baseline for liveness', () => {
+      expect(BASELINES['liveness']).toBeDefined();
+      expect(BASELINES['liveness'].p95LatencyMs).toBeLessThan(BASELINES['donation-creation'].p95LatencyMs);
     });
 
     test('all baselines have required fields', () => {
@@ -605,12 +601,12 @@ describe('Integration: load test scenarios against test app', () => {
   test('report passes validation for well-behaved test app', async () => {
     const runner = new LoadTestRunner(testApp, { concurrency: 2, iterations: 6, thinkTimeMs: 0 });
     const report = await runner.runAll([
-      { name: 'health-check', requestFn: req => req.get('/health') },
+      { name: 'liveness', requestFn: req => req.get('/health') },
     ]);
     const jsonReport = generateJsonReport(report);
-    expect(jsonReport.scenarios[0].scenario).toBe('health-check');
+    expect(jsonReport.scenarios[0].scenario).toBe('liveness');
     // The test app is fast so no p95 violations expected
-    expect(report.scenarios[0].latency.p95).toBeLessThan(BASELINES['health-check'].p95LatencyMs);
+    expect(report.scenarios[0].latency.p95).toBeLessThan(BASELINES['liveness'].p95LatencyMs);
   }, 20000);
 });
 
@@ -620,14 +616,14 @@ describe('Integration: load test scenarios against test app', () => {
 
 describe('CI integration', () => {
   test('Artillery config files exist for all three scenarios', () => {
-    const artilleryDir = path.join(__dirname, 'load', 'artillery');
+    const artilleryDir = path.join(__dirname, '..', 'load', 'artillery');
     expect(fs.existsSync(path.join(artilleryDir, 'donation-creation.yml'))).toBe(true);
     expect(fs.existsSync(path.join(artilleryDir, 'balance-queries.yml'))).toBe(true);
     expect(fs.existsSync(path.join(artilleryDir, 'stats.yml'))).toBe(true);
   });
 
   test('run-load-tests.js entry point exists', () => {
-    expect(fs.existsSync(path.join(__dirname, 'load', 'run-load-tests.js'))).toBe(true);
+    expect(fs.existsSync(path.join(__dirname, '..', 'load', 'run-load-tests.js'))).toBe(true);
   });
 
   test('PerformanceBaselines.js exports BASELINES, validateAgainstBaseline, validateReport', () => {
@@ -648,7 +644,7 @@ describe('CI integration', () => {
   });
 
   test('GitHub Actions workflow file for load tests exists', () => {
-    const workflowPath = path.join(__dirname, '..', '.github', 'workflows', 'load-tests.yml');
+    const workflowPath = path.join(__dirname, '..', '..', '.github', 'workflows', 'load-tests.yml');
     expect(fs.existsSync(workflowPath)).toBe(true);
   });
 });

--- a/tests/property/moneyMath.property.test.js
+++ b/tests/property/moneyMath.property.test.js
@@ -1,0 +1,213 @@
+'use strict';
+
+/**
+ * Property-based tests for money / fee / conversion math (issue #1165).
+ *
+ * Rounding and precision bugs hide in inputs nobody hand-picks — odd stroop
+ * values, rates that round at the boundary, very large or very small amounts.
+ * Each test below encodes an invariant that must hold for ALL valid inputs and
+ * checks it across a generated spread (including boundaries), so a regression
+ * in the precision-sensitive helpers fails CI automatically.
+ */
+
+const {
+  forAll,
+  floatInRange,
+  intInRange,
+  xlmAmountString,
+} = require('../helpers/propertyTest');
+
+const {
+  calculateAnalyticsFee,
+  MIN_FEE,
+  MAX_FEE_PERCENTAGE,
+} = require('../../src/utils/feeCalculator');
+
+const {
+  roundHalfEven,
+  convertToXLMWithMeta,
+  STROOPS_PER_XLM,
+} = require('../../src/utils/currencyConversion');
+
+const { validateXLMAmount } = require('../../src/utils/validationHelpers');
+
+// Documented conversion tolerance: one stroop in XLM terms.
+const ONE_STROOP_XLM = 1 / STROOPS_PER_XLM;
+
+describe('feeCalculator.calculateAnalyticsFee — invariants', () => {
+  // Generate {amount, feePercentage} across the realistic range.
+  const genAmountAndPct = (rng) => ({
+    amount: floatInRange(MIN_FEE, 100_000, 2)(rng),
+    feePercentage: floatInRange(0, MAX_FEE_PERCENTAGE, 4)(rng),
+  });
+
+  test('fee is always ≥ 0', () => {
+    forAll(genAmountAndPct, ({ amount, feePercentage }) => {
+      const { fee } = calculateAnalyticsFee(amount, feePercentage);
+      expect(fee).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  test('fee is always ≥ the configured minimum fee', () => {
+    forAll(genAmountAndPct, ({ amount, feePercentage }) => {
+      const { fee } = calculateAnalyticsFee(amount, feePercentage);
+      // The implementation floors every fee at MIN_FEE.
+      expect(fee).toBeGreaterThanOrEqual(MIN_FEE - 1e-9);
+    });
+  });
+
+  test('fee never exceeds the donation amount (for amounts ≥ MIN_FEE)', () => {
+    // Below MIN_FEE the flat-minimum fee legitimately exceeds the donation;
+    // for any donation at or above the minimum the fee must not exceed it.
+    forAll(genAmountAndPct, ({ amount, feePercentage }) => {
+      const { fee } = calculateAnalyticsFee(amount, feePercentage);
+      expect(fee).toBeLessThanOrEqual(amount + 1e-9);
+    });
+  });
+
+  test('totalWithFee equals amount + fee (to cent precision)', () => {
+    forAll(genAmountAndPct, ({ amount, feePercentage }) => {
+      const { fee, totalWithFee, originalAmount } = calculateAnalyticsFee(amount, feePercentage);
+      expect(originalAmount).toBe(amount);
+      expect(totalWithFee).toBeCloseTo(amount + fee, 2);
+    });
+  });
+
+  test('a higher fee percentage never produces a smaller fee (monotonic)', () => {
+    forAll(
+      (rng) => floatInRange(MIN_FEE, 100_000, 2)(rng),
+      (amount) => {
+        const low = calculateAnalyticsFee(amount, 0.01).fee;
+        const high = calculateAnalyticsFee(amount, MAX_FEE_PERCENTAGE).fee;
+        expect(high).toBeGreaterThanOrEqual(low - 1e-9);
+      }
+    );
+  });
+
+  test('rejects non-positive amounts and out-of-range percentages', () => {
+    expect(() => calculateAnalyticsFee(0)).toThrow();
+    expect(() => calculateAnalyticsFee(-5)).toThrow();
+    expect(() => calculateAnalyticsFee(10, MAX_FEE_PERCENTAGE + 0.01)).toThrow();
+    expect(() => calculateAnalyticsFee(10, -0.01)).toThrow();
+  });
+});
+
+describe('currencyConversion.roundHalfEven — invariants', () => {
+  test('result is always rounded to ≤ 7 decimal places', () => {
+    forAll(floatInRange(-1_000_000, 1_000_000, 9), (value) => {
+      const rounded = roundHalfEven(value, 7);
+      // Re-rounding to 7dp must be a fixed point.
+      expect(roundHalfEven(rounded, 7)).toBeCloseTo(rounded, 10);
+      const decimals = (rounded.toString().split('.')[1] || '').length;
+      expect(decimals).toBeLessThanOrEqual(7);
+    });
+  });
+
+  test('rounding error is at most half a stroop', () => {
+    forAll(floatInRange(-1_000, 1_000, 9), (value) => {
+      const rounded = roundHalfEven(value, 7);
+      expect(Math.abs(rounded - value)).toBeLessThanOrEqual(ONE_STROOP_XLM / 2 + 1e-12);
+    });
+  });
+
+  test('rounding an already-7dp value is the identity', () => {
+    forAll(floatInRange(-10_000, 10_000, 7), (value) => {
+      expect(roundHalfEven(value, 7)).toBeCloseTo(value, 10);
+    });
+  });
+});
+
+describe('currencyConversion.convertToXLMWithMeta — invariants', () => {
+  const genConversion = (rng) => ({
+    sourceAmount: floatInRange(0, 100_000, 2)(rng),
+    rate: floatInRange(0.0001, 1000, 6)(rng),
+  });
+
+  test('converted XLM is non-negative and reproducible from stored inputs', () => {
+    forAll(genConversion, ({ sourceAmount, rate }) => {
+      const meta = convertToXLMWithMeta(sourceAmount, 'USD', rate);
+      expect(meta.xlm).toBeGreaterThanOrEqual(0);
+      // Reproducibility guarantee documented in the module.
+      expect(meta.xlm).toBeCloseTo(roundHalfEven(sourceAmount * rate, 7), 10);
+    });
+  });
+
+  test('stroops is an integer equal to round(xlm * STROOPS_PER_XLM)', () => {
+    forAll(genConversion, ({ sourceAmount, rate }) => {
+      const meta = convertToXLMWithMeta(sourceAmount, 'USD', rate);
+      expect(Number.isInteger(meta.stroops)).toBe(true);
+      expect(meta.stroops).toBe(Math.round(meta.xlm * STROOPS_PER_XLM));
+    });
+  });
+
+  test('converting and converting back round-trips within one stroop', () => {
+    forAll(genConversion, ({ sourceAmount, rate }) => {
+      const { xlm } = convertToXLMWithMeta(sourceAmount, 'USD', rate);
+      const backToSource = xlm / rate;
+      // Tolerance scales with the rate: rounding to a stroop in XLM is at most
+      // one stroop / rate in source-currency terms.
+      const tolerance = ONE_STROOP_XLM / rate + 1e-9;
+      expect(Math.abs(backToSource - sourceAmount)).toBeLessThanOrEqual(tolerance);
+    });
+  });
+
+  test('rejects negative amounts and non-positive rates', () => {
+    expect(() => convertToXLMWithMeta(-1, 'USD', 10)).toThrow();
+    expect(() => convertToXLMWithMeta(10, 'USD', 0)).toThrow();
+    expect(() => convertToXLMWithMeta(10, 'USD', -5)).toThrow();
+  });
+});
+
+describe('stroop arithmetic — round-trip, associativity, commutativity', () => {
+  const toStroops = (xlmStr) => {
+    const res = validateXLMAmount(xlmStr, { allowZero: true });
+    if (!res.valid) throw new Error(`generator produced invalid amount: ${xlmStr} (${res.error})`);
+    return res.stroops;
+  };
+  const fromStroops = (stroops) => stroops / STROOPS_PER_XLM;
+
+  test('fromStroops(toStroops(x)) === x for all valid display amounts', () => {
+    forAll(xlmAmountString(0.0000001, 1_000_000), (xlmStr) => {
+      const round = fromStroops(toStroops(xlmStr));
+      expect(round).toBeCloseTo(parseFloat(xlmStr), 7);
+    });
+  });
+
+  test('summation in stroops is commutative (order-independent)', () => {
+    const genTriple = (rng) => [
+      xlmAmountString(0, 10_000)(rng),
+      xlmAmountString(0, 10_000)(rng),
+      xlmAmountString(0, 10_000)(rng),
+    ];
+    forAll(genTriple, ([a, b, c]) => {
+      const sa = toStroops(a), sb = toStroops(b), sc = toStroops(c);
+      expect(sa + sb + sc).toBe(sc + sb + sa);
+    });
+  });
+
+  test('summation in stroops is associative', () => {
+    const genTriple = (rng) => [
+      xlmAmountString(0, 10_000)(rng),
+      xlmAmountString(0, 10_000)(rng),
+      xlmAmountString(0, 10_000)(rng),
+    ];
+    forAll(genTriple, ([a, b, c]) => {
+      const sa = toStroops(a), sb = toStroops(b), sc = toStroops(c);
+      expect((sa + sb) + sc).toBe(sa + (sb + sc));
+    });
+  });
+
+  test('stroop totals are exact integers regardless of summation order', () => {
+    const genList = (rng) => {
+      const n = intInRange(2, 25)(rng);
+      return Array.from({ length: n }, () => xlmAmountString(0, 1_000)(rng));
+    };
+    forAll(genList, (amounts) => {
+      const stroops = amounts.map(toStroops);
+      const forward = stroops.reduce((acc, s) => acc + s, 0);
+      const reverse = [...stroops].reverse().reduce((acc, s) => acc + s, 0);
+      expect(Number.isInteger(forward)).toBe(true);
+      expect(forward).toBe(reverse);
+    });
+  });
+});


### PR DESCRIPTION
Implements four testing initiatives in a single PR. Each suite is run against **real** code, which surfaced several pre-existing bugs that were silently breaking the production paths under test — those are fixed here so the new suites are meaningful and green.

## #1164 — Contract / parity tests (Mock vs real StellarService)
- `tests/contracts/stellarServiceContract.js` — one shared contract derived from `StellarServiceInterface`, run against **both** implementations. Asserts `instanceof`, full method presence, per-method **arity**, and behavioural **return shapes / error contracts** for offline-deterministic methods (not just presence).
- A direct mock⇄real parity matrix documents today's interface divergences in an explicit allow-list, so any **new** drift — or a closed gap — fails CI.
- **Bug fixed:** `StellarService.js` could not be parsed at all (`??` mixed with `||` without parens, lines 201–210), so `require`-ing the real service — including via `serviceContainer` at app startup — threw a `SyntaxError`. Added parentheses.

## #1165 — Property-based tests for money / fee / conversion math
- `tests/helpers/propertyTest.js` — tiny, dependency-free **seeded** property harness (no lockfile churn).
- `tests/property/moneyMath.property.test.js` — invariants for fees (≥0, ≥min, ≤amount above the minimum, monotonic), banker's rounding (≤7dp, ≤½-stroop error), conversion (non-negative, reproducible, integer stroops, round-trip within one stroop), and stroop arithmetic (round-trip, commutativity, associativity, integer totals).

## #1166 — End-to-end webhook delivery tests (retries, signatures, DLQ)
- `tests/integration/webhook-delivery-e2e.test.js` — a local HTTP sink verifies the payload schema + HMAC-SHA256 signature, exponential-backoff retries up to the capped attempt count on 5xx, dead-lettering with full context, and successful replay once the sink is healthy.
- **Bugs fixed (all silently broke delivery):** `_httpPost` referenced an undefined `timestamp` (`ReferenceError` on every send); `_deliverWithRetry` was an instance method but called statically by `processRetryQueue`/`flushPending`/its own retry recursion (`TypeError`, so retries & queue re-delivery never ran); and a non-2xx response was recorded as success instead of triggering retry/DLQ.

## #1167 — Gate CI on load-test performance thresholds
- `load-tests.yml` now runs on `pull_request`/`push` so a regression **blocks the merge**, with documented, env-configurable variance margins, and publishes a metrics table to the job summary (visible even on a pass).
- `PerformanceBaselines.js` — env-driven margins (`LOAD_TEST_*_MARGIN`) + resolver; `LoadTestRunner.js` — warm-up iterations to absorb cold-start variance; `run-load-tests.js` — bootstraps a private DB so the app is healthy, uses the real versioned routes with valid keypairs + idempotency keys.
- `docs/LOAD_TESTING.md` documents thresholds, margins, and the gate.
- **Bug fixed:** `rbac.js` imported a non-existent `checkRateLimit` from `perKeyRateLimit`, breaking all legacy-API-key auth; implemented and exported it.

### Notes
- The repo's full suite has pre-existing failures (e.g. tracing init, degraded `/health` in test mode) unrelated to this work; the parse-error fix lets several previously-unloadable suites run again. The four new suites pass in isolation, and lint is clean for the touched source files.

closes #1164
closes #1165
closes #1166
closes #1167