### PR TITLE
feat: use integer BigInt stroop math for all monetary calculations (#1152/#1153/#1154)

### DIFF
--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -361,7 +361,7 @@ class DonationService {
     // Record in JSON with state transitions
     const transaction = Transaction.create({
       id: dbResult.id.toString(),
-      amount: parseFloat(amount),
+      amount: amount,
       donor: sender.publicKey,
       recipient: receiver.publicKey,
       status: TRANSACTION_STATES.PENDING,

--- a/src/services/StatsService.js
+++ b/src/services/StatsService.js
@@ -11,6 +11,7 @@
 
 const Transaction = require('../models/transaction');
 const { generatePseudonymousId, isPseudonymousId } = require('../utils/anonymization');
+const { toStroops, fromStroops, addStroops } = require('../utils/money');
 
 class StatsService {
   /**
@@ -55,14 +56,14 @@ class StatsService {
       if (!dailyMap.has(dateKey)) {
         dailyMap.set(dateKey, {
           date: dateKey,
-          totalVolume: 0,
+          _totalVolumeStroops: 0n,
           transactionCount: 0,
           transactions: []
         });
       }
 
       const dayStats = dailyMap.get(dateKey);
-      dayStats.totalVolume += parseFloat(tx.amount) || 0;
+      dayStats._totalVolumeStroops = addStroops(dayStats._totalVolumeStroops, toStroops(tx.amount || 0));
       dayStats.transactionCount += 1;
       dayStats.transactions.push({
         id: tx.id,
@@ -73,9 +74,12 @@ class StatsService {
       });
     });
 
-    return Array.from(dailyMap.values()).sort((a, b) => 
-      new Date(a.date) - new Date(b.date)
-    );
+    return Array.from(dailyMap.values())
+      .sort((a, b) => new Date(a.date) - new Date(b.date))
+      .map(d => {
+        const { _totalVolumeStroops, ...rest } = d;
+        return { ...rest, totalVolume: fromStroops(_totalVolumeStroops) };
+      });
   }
 
   /**
@@ -100,14 +104,14 @@ class StatsService {
           year: weekKey.year,
           weekStart: weekKey.weekStart,
           weekEnd: weekKey.weekEnd,
-          totalVolume: 0,
+          _totalVolumeStroops: 0n,
           transactionCount: 0,
           transactions: []
         });
       }
 
       const weekStats = weeklyMap.get(mapKey);
-      weekStats.totalVolume += parseFloat(tx.amount) || 0;
+      weekStats._totalVolumeStroops = addStroops(weekStats._totalVolumeStroops, toStroops(tx.amount || 0));
       weekStats.transactionCount += 1;
       weekStats.transactions.push({
         id: tx.id,
@@ -118,10 +122,15 @@ class StatsService {
       });
     });
 
-    return Array.from(weeklyMap.values()).sort((a, b) => {
-      if (a.year !== b.year) return a.year - b.year;
-      return a.week - b.week;
-    });
+    return Array.from(weeklyMap.values())
+      .sort((a, b) => {
+        if (a.year !== b.year) return a.year - b.year;
+        return a.week - b.week;
+      })
+      .map(w => {
+        const { _totalVolumeStroops, ...rest } = w;
+        return { ...rest, totalVolume: fromStroops(_totalVolumeStroops) };
+      });
   }
 
   /**
@@ -134,11 +143,11 @@ class StatsService {
     const transactions = Transaction.getByDateRange(startDate, endDate);
     
     const summary = {
-      totalVolume: 0,
+      totalVolume: '0.0000000',
       totalTransactions: transactions.length,
-      averageTransactionAmount: 0,
-      maxTransactionAmount: 0,
-      minTransactionAmount: Infinity,
+      averageTransactionAmount: '0.0000000',
+      maxTransactionAmount: '0.0000000',
+      minTransactionAmount: '0.0000000',
       dateRange: {
         start: startDate.toISOString(),
         end: endDate.toISOString()
@@ -146,18 +155,25 @@ class StatsService {
     };
 
     if (transactions.length === 0) {
-      summary.minTransactionAmount = 0;
       return summary;
     }
 
+    let totalStroops = 0n;
+    let maxStroops = 0n;
+    let minStroops = null;
+
     transactions.forEach(tx => {
-      const amount = parseFloat(tx.amount) || 0;
-      summary.totalVolume += amount;
-      summary.maxTransactionAmount = Math.max(summary.maxTransactionAmount, amount);
-      summary.minTransactionAmount = Math.min(summary.minTransactionAmount, amount);
+      const s = toStroops(tx.amount || 0);
+      totalStroops += s;
+      if (s > maxStroops) maxStroops = s;
+      if (minStroops === null || s < minStroops) minStroops = s;
     });
 
-    summary.averageTransactionAmount = summary.totalVolume / transactions.length;
+    summary.totalVolume = fromStroops(totalStroops);
+    summary.maxTransactionAmount = fromStroops(maxStroops);
+    summary.minTransactionAmount = fromStroops(minStroops ?? 0n);
+    // average: integer division (floor)
+    summary.averageTransactionAmount = fromStroops(totalStroops / BigInt(transactions.length));
 
     return summary;
   }
@@ -182,14 +198,14 @@ class StatsService {
       if (!donorMap.has(donor)) {
         donorMap.set(donor, {
           donor,
-          totalDonated: 0,
+          _totalDonatedStroops: 0n,
           donationCount: 0,
           donations: []
         });
       }
 
       const donorStats = donorMap.get(donor);
-      donorStats.totalDonated += parseFloat(tx.amount) || 0;
+      donorStats._totalDonatedStroops = addStroops(donorStats._totalDonatedStroops, toStroops(tx.amount || 0));
       donorStats.donationCount += 1;
       donorStats.donations.push({
         id: tx.id,
@@ -199,9 +215,17 @@ class StatsService {
       });
     });
 
-    return Array.from(donorMap.values()).sort((a, b) => 
-      b.totalDonated - a.totalDonated
-    );
+    return Array.from(donorMap.values())
+      .map(d => {
+        const { _totalDonatedStroops, ...rest } = d;
+        return { ...rest, totalDonated: fromStroops(_totalDonatedStroops) };
+      })
+      .sort((a, b) => {
+        // sort descending by stroop value (compare as strings of equal-length wouldn't work; re-parse)
+        const aS = toStroops(a.totalDonated);
+        const bS = toStroops(b.totalDonated);
+        return bS > aS ? 1 : bS < aS ? -1 : 0;
+      });
   }
 
   /**
@@ -221,14 +245,14 @@ class StatsService {
       if (!recipientMap.has(recipient)) {
         recipientMap.set(recipient, {
           recipient,
-          totalReceived: 0,
+          _totalReceivedStroops: 0n,
           donationCount: 0,
           donations: []
         });
       }
 
       const recipientStats = recipientMap.get(recipient);
-      recipientStats.totalReceived += parseFloat(tx.amount) || 0;
+      recipientStats._totalReceivedStroops = addStroops(recipientStats._totalReceivedStroops, toStroops(tx.amount || 0));
       recipientStats.donationCount += 1;
       recipientStats.donations.push({
         id: tx.id,
@@ -238,9 +262,16 @@ class StatsService {
       });
     });
 
-    return Array.from(recipientMap.values()).sort((a, b) => 
-      b.totalReceived - a.totalReceived
-    );
+    return Array.from(recipientMap.values())
+      .map(r => {
+        const { _totalReceivedStroops, ...rest } = r;
+        return { ...rest, totalReceived: fromStroops(_totalReceivedStroops) };
+      })
+      .sort((a, b) => {
+        const aS = toStroops(a.totalReceived);
+        const bS = toStroops(b.totalReceived);
+        return bS > aS ? 1 : bS < aS ? -1 : 0;
+      });
   }
 
   /**
@@ -336,42 +367,54 @@ class StatsService {
    */
   static getAnalyticsFeeStats(startDate, endDate) {
     const transactions = Transaction.getByDateRange(startDate, endDate);
-
     const byAsset = {};
+
+    let totalFeeStroops = 0n;
+    let totalVolumeStroops = 0n;
 
     transactions.forEach(tx => {
       const asset = tx.asset || tx.assetCode || 'XLM';
-      const amount = parseFloat(tx.amount) || 0;
-      const fee = parseFloat(tx.analyticsFee) || 0;
+      const amountStroops = toStroops(tx.amount || 0);
+      const feeStroops = toStroops(tx.analyticsFee || 0);
       const xlmRate = parseFloat(tx.xlmRate) || (asset === 'XLM' ? 1 : 0);
 
       if (!byAsset[asset]) {
         byAsset[asset] = {
           asset,
-          totalFees: 0,
-          totalVolume: 0,
+          _totalFeesStroops: 0n,
+          _totalVolumeStroops: 0n,
+          _totalFeesInXLMStroops: 0n,
           transactionCount: 0,
-          totalFeesInXLM: 0,
         };
       }
 
-      byAsset[asset].totalFees += fee;
-      byAsset[asset].totalVolume += amount;
+      byAsset[asset]._totalFeesStroops += feeStroops;
+      byAsset[asset]._totalVolumeStroops += amountStroops;
       byAsset[asset].transactionCount += 1;
-      byAsset[asset].totalFeesInXLM += asset === 'XLM' ? fee : fee * xlmRate;
+      // For non-XLM, convert fee to XLM stroops using stored rate
+      const feeInXLMStroops = asset === 'XLM' ? feeStroops : BigInt(Math.floor(Number(feeStroops) * xlmRate));
+      byAsset[asset]._totalFeesInXLMStroops += feeInXLMStroops;
+
+      totalFeeStroops += feeInXLMStroops;
+      totalVolumeStroops += asset === 'XLM' ? amountStroops : 0n;
     });
 
-    const feesByAsset = Object.values(byAsset).map(a => ({
-      ...a,
-      totalFees: +a.totalFees.toFixed(7),
-      totalVolume: +a.totalVolume.toFixed(7),
-      totalFeesInXLM: +a.totalFeesInXLM.toFixed(7),
-      effectiveFeePercentage: a.totalVolume > 0
-        ? +((a.totalFees / a.totalVolume) * 100).toFixed(4)
-        : 0,
-    }));
+    const feesByAsset = Object.values(byAsset).map(a => {
+      const { _totalFeesStroops, _totalVolumeStroops, _totalFeesInXLMStroops, ...rest } = a;
+      const volStroops = _totalVolumeStroops;
+      return {
+        ...rest,
+        totalFees: fromStroops(_totalFeesStroops),
+        totalVolume: fromStroops(_totalVolumeStroops),
+        totalFeesInXLM: fromStroops(_totalFeesInXLMStroops),
+        effectiveFeePercentage: volStroops > 0n
+          ? Number(_totalFeesStroops * 10000n / volStroops) / 100
+          : 0,
+      };
+    });
 
-    const totalInXLM = +feesByAsset.reduce((s, a) => s + a.totalFeesInXLM, 0).toFixed(7);
+    const totalInXLMStroops = feesByAsset.reduce((s, a) => s + toStroops(a.totalFeesInXLM), 0n);
+    const totalInXLM = fromStroops(totalInXLMStroops);
     const totalTransactions = transactions.length;
     const _totalFeesXLM = feesByAsset.find(a => a.asset === 'XLM');
 
@@ -380,8 +423,8 @@ class StatsService {
       totalInXLM,
       transactionCount: totalTransactions,
       averageFeePerTransactionXLM: totalTransactions > 0
-        ? +(totalInXLM / totalTransactions).toFixed(7)
-        : 0,
+        ? fromStroops(totalInXLMStroops / BigInt(totalTransactions))
+        : '0.0000000',
       dateRange: {
         start: startDate.toISOString(),
         end: endDate.toISOString(),
@@ -408,8 +451,8 @@ class StatsService {
 
     const analytics = {
       walletAddress,
-      totalSent: 0,
-      totalReceived: 0,
+      totalSent: '0.0000000',
+      totalReceived: '0.0000000',
       donationCount: 0,
       sentCount: 0,
       receivedCount: 0,
@@ -426,12 +469,14 @@ class StatsService {
       analytics.dateRange = 'lifetime';
     }
 
-    transactions.forEach(tx => {
-      const amount = parseFloat(tx.amount) || 0;
+    let sentStroops = 0n;
+    let receivedStroops = 0n;
 
-      // Check if wallet is the donor (sender)
+    transactions.forEach(tx => {
+      const s = toStroops(tx.amount || 0);
+
       if (tx.donor === walletAddress) {
-        analytics.totalSent += amount;
+        sentStroops += s;
         analytics.sentCount += 1;
         analytics.sentTransactions.push({
           id: tx.id,
@@ -442,9 +487,8 @@ class StatsService {
         });
       }
 
-      // Check if wallet is the recipient (receiver)
       if (tx.recipient === walletAddress) {
-        analytics.totalReceived += amount;
+        receivedStroops += s;
         analytics.receivedCount += 1;
         analytics.receivedTransactions.push({
           id: tx.id,
@@ -456,7 +500,8 @@ class StatsService {
       }
     });
 
-    // Total donation count is the sum of sent and received
+    analytics.totalSent = fromStroops(sentStroops);
+    analytics.totalReceived = fromStroops(receivedStroops);
     analytics.donationCount = analytics.sentCount + analytics.receivedCount;
 
     return analytics;

--- a/src/utils/feeCalculator.js
+++ b/src/utils/feeCalculator.js
@@ -1,42 +1,66 @@
 /**
  * Fee Calculator Utility
- * Calculates optional analytics fees for donations
- * Note: Fees are calculated but NOT deducted on-chain
+ *
+ * All arithmetic is done in integer stroops via the money utility.
+ * Rounding: floor (BigInt division truncates toward zero) — platform's favor.
+ *
+ * Fee rates are in basis points (1 bps = 0.01%).
+ *   DEFAULT_FEE_BPS  = 200  → 2 %
+ *   MAX_FEE_BPS      = 500  → 5 %
+ *   MIN_FEE_STROOPS  = 100_000  → 0.01 XLM
  */
 
-const DEFAULT_FEE_PERCENTAGE = 0.02; // 2% default fee
-const MIN_FEE = 0.01; // Minimum fee amount
-const MAX_FEE_PERCENTAGE = 0.05; // Maximum 5% fee cap
+const { toStroops, fromStroops, calcFee } = require('./money');
+
+const DEFAULT_FEE_BPS = 200n;   // 2 %
+const MAX_FEE_BPS = 500n;        // 5 %
+const MIN_FEE_STROOPS = 100_000n; // 0.01 XLM
 
 /**
- * Calculate analytics fee for a donation
- * @param {number} amount - The donation amount
- * @param {number} feePercentage - Optional custom fee percentage (default: 2%)
- * @returns {Object} Fee calculation details
+ * Calculate analytics fee for a donation.
+ * Accepts an XLM string or number; returns amounts as XLM display strings plus
+ * the raw BigInt stroop values for internal use.
+ *
+ * @param {string|number} amount - Donation amount in XLM
+ * @param {bigint|number} [feeBps=DEFAULT_FEE_BPS] - Fee rate in basis points
+ * @returns {{
+ *   fee: string,
+ *   feeStroops: bigint,
+ *   feePercentage: number,
+ *   originalAmount: string,
+ *   totalWithFee: string
+ * }}
  */
-function calculateAnalyticsFee(amount, feePercentage = DEFAULT_FEE_PERCENTAGE) {
-  if (typeof amount !== 'number' || amount <= 0) {
-    throw new Error('Amount must be a positive number');
+function calculateAnalyticsFee(amount, feeBps = DEFAULT_FEE_BPS) {
+  const bps = BigInt(feeBps);
+  if (bps < 0n || bps > MAX_FEE_BPS) {
+    throw new Error(`Fee bps must be between 0 and ${MAX_FEE_BPS} (${Number(MAX_FEE_BPS) / 100}%)`);
   }
 
-  if (feePercentage < 0 || feePercentage > MAX_FEE_PERCENTAGE) {
-    throw new Error(`Fee percentage must be between 0 and ${MAX_FEE_PERCENTAGE * 100}%`);
+  const amountStroops = toStroops(amount);
+  if (amountStroops <= 0n) {
+    throw new Error('Amount must be a positive value');
   }
 
-  const calculatedFee = amount * feePercentage;
-  const fee = Math.max(calculatedFee, MIN_FEE);
+  const feeStroops = calcFee(amountStroops, bps, { minFeeStroops: MIN_FEE_STROOPS });
+  const totalStroops = amountStroops + feeStroops;
 
   return {
-    fee: parseFloat(fee.toFixed(2)),
-    feePercentage: feePercentage,
-    originalAmount: amount,
-    totalWithFee: parseFloat((amount + fee).toFixed(2))
+    fee: fromStroops(feeStroops),
+    feeStroops,
+    feePercentage: Number(bps) / 100,
+    originalAmount: fromStroops(amountStroops),
+    totalWithFee: fromStroops(totalStroops),
   };
 }
 
 module.exports = {
   calculateAnalyticsFee,
-  DEFAULT_FEE_PERCENTAGE,
-  MIN_FEE,
-  MAX_FEE_PERCENTAGE
+  DEFAULT_FEE_BPS,
+  MIN_FEE_STROOPS,
+  MAX_FEE_BPS,
+  // Legacy float-equivalent constants for callers that only need the numeric value
+  DEFAULT_FEE_PERCENTAGE: Number(DEFAULT_FEE_BPS) / 10000,
+  MIN_FEE: Number(MIN_FEE_STROOPS) / 10_000_000,
+  MAX_FEE_PERCENTAGE: Number(MAX_FEE_BPS) / 10000,
 };

--- a/src/utils/money.js
+++ b/src/utils/money.js
@@ -1,0 +1,116 @@
+/**
+ * Money Utility - Integer Stroop Arithmetic
+ *
+ * All monetary values are represented as BigInt stroops (1 XLM = 10,000,000 stroops).
+ * Fee rates are expressed in basis points (1 bps = 0.01%). Integer division always
+ * floors (truncates toward zero), rounding in the platform's favor for fees.
+ *
+ * Rounding rule: floor (BigInt division truncates). This is documented and consistent —
+ * a fee is never rounded up against the donor.
+ */
+
+const STROOPS_PER_XLM = 10_000_000n;
+const BPS_DIVISOR = 10_000n;
+
+/**
+ * Convert an XLM string or number to BigInt stroops.
+ * Accepts: "1.234567", 1.234567, "5", 5
+ * Throws for non-finite or negative input.
+ * @param {string|number} xlm
+ * @returns {bigint}
+ */
+function toStroops(xlm) {
+  // Normalise to string for exact decimal handling
+  const str = String(xlm).trim();
+  if (!/^-?\d+(\.\d+)?$/.test(str)) {
+    throw new Error(`Invalid XLM amount: ${xlm}`);
+  }
+  const [whole, frac = ''] = str.split('.');
+  // Pad / truncate fractional part to exactly 7 digits
+  const fracPadded = frac.padEnd(7, '0').slice(0, 7);
+  const stroops = BigInt(whole) * STROOPS_PER_XLM + BigInt(fracPadded);
+  if (stroops < 0n) {
+    throw new Error(`Amount must be non-negative: ${xlm}`);
+  }
+  return stroops;
+}
+
+/**
+ * Convert BigInt stroops to a 7-decimal XLM display string.
+ * @param {bigint} stroops
+ * @returns {string}  e.g. "1.2345670"
+ */
+function fromStroops(stroops) {
+  if (typeof stroops !== 'bigint') {
+    throw new Error('fromStroops expects a BigInt');
+  }
+  const abs = stroops < 0n ? -stroops : stroops;
+  const sign = stroops < 0n ? '-' : '';
+  const whole = abs / STROOPS_PER_XLM;
+  const frac = abs % STROOPS_PER_XLM;
+  return `${sign}${whole}.${String(frac).padStart(7, '0')}`;
+}
+
+/**
+ * Calculate a fee in stroops using basis points (integer math, floors in platform's favor).
+ * feeStroops = floor(amountStroops * bps / 10000)
+ *
+ * @param {bigint} amountStroops
+ * @param {bigint|number} bps  - fee rate in basis points (e.g. 200 = 2%)
+ * @param {object} [opts]
+ * @param {bigint} [opts.minFeeStroops]  - minimum fee clamp (default 0n)
+ * @param {bigint} [opts.maxFeeStroops]  - maximum fee clamp (default unbounded)
+ * @param {bigint|number} [opts.surgeMultiplierBps]  - surge multiplier in bps (e.g. 15000 = 1.5×)
+ * @returns {bigint}
+ */
+function calcFee(amountStroops, bps, opts = {}) {
+  if (typeof amountStroops !== 'bigint') {
+    throw new Error('calcFee: amountStroops must be BigInt');
+  }
+  const bpsBig = BigInt(bps);
+  if (bpsBig < 0n) {
+    throw new Error('calcFee: bps must be non-negative');
+  }
+
+  let effectiveBps = bpsBig;
+
+  // Apply surge multiplier if provided (surge is also in bps; e.g. 15000n = 1.5×)
+  if (opts.surgeMultiplierBps !== undefined) {
+    const surgeBps = BigInt(opts.surgeMultiplierBps);
+    // effectiveBps = floor(bps * surgeMultiplierBps / 10000)
+    effectiveBps = bpsBig * surgeBps / BPS_DIVISOR;
+  }
+
+  // floor division (BigInt division truncates toward zero, which equals floor for positives)
+  let fee = amountStroops * effectiveBps / BPS_DIVISOR;
+
+  const minFee = opts.minFeeStroops !== undefined ? BigInt(opts.minFeeStroops) : 0n;
+  if (fee < minFee) fee = minFee;
+
+  if (opts.maxFeeStroops !== undefined) {
+    const maxFee = BigInt(opts.maxFeeStroops);
+    if (fee > maxFee) fee = maxFee;
+  }
+
+  return fee;
+}
+
+/** Add two BigInt stroop values. */
+function addStroops(a, b) {
+  return BigInt(a) + BigInt(b);
+}
+
+/** Subtract two BigInt stroop values. */
+function subtractStroops(a, b) {
+  return BigInt(a) - BigInt(b);
+}
+
+module.exports = {
+  STROOPS_PER_XLM,
+  BPS_DIVISOR,
+  toStroops,
+  fromStroops,
+  calcFee,
+  addStroops,
+  subtractStroops,
+};

--- a/tests/money.test.js
+++ b/tests/money.test.js
@@ -1,0 +1,252 @@
+'use strict';
+/**
+ * tests/money.test.js
+ *
+ * Unit tests for src/utils/money.js
+ * Covers:
+ *  - toStroops / fromStroops round-trip precision
+ *  - Floating-point values that IEEE-754 gets wrong
+ *  - calcFee: basic bps math, min clamp, max clamp, surge multiplier
+ *  - Impact-report reconciliation: per-SDG subtotals sum exactly to grand total
+ */
+
+const {
+  toStroops,
+  fromStroops,
+  calcFee,
+  addStroops,
+  subtractStroops,
+  STROOPS_PER_XLM,
+} = require('../src/utils/money');
+
+// ─── toStroops ────────────────────────────────────────────────────────────────
+
+describe('toStroops', () => {
+  test('converts integer XLM string', () => {
+    expect(toStroops('1')).toBe(10_000_000n);
+    expect(toStroops('10')).toBe(100_000_000n);
+  });
+
+  test('converts 7-decimal XLM string exactly', () => {
+    expect(toStroops('1.0000001')).toBe(10_000_001n);
+    expect(toStroops('0.0000001')).toBe(1n);
+  });
+
+  test('truncates beyond 7 decimal places', () => {
+    // "0.10000005" — 8th decimal is truncated, not rounded
+    expect(toStroops('0.10000005')).toBe(toStroops('0.1000000'));
+  });
+
+  test('handles float input with known IEEE-754 representation issues', () => {
+    // 0.1 + 0.2 in float = 0.30000000000000004, but as a string "0.1" is exact
+    const a = toStroops('0.1');   // 1_000_000n
+    const b = toStroops('0.2');   // 2_000_000n
+    expect(a + b).toBe(toStroops('0.3'));  // 3_000_000n — no drift
+  });
+
+  test('rejects negative value', () => {
+    expect(() => toStroops('-1')).toThrow();
+  });
+
+  test('rejects non-numeric string', () => {
+    expect(() => toStroops('abc')).toThrow();
+  });
+
+  test('accepts numeric input (number type)', () => {
+    expect(toStroops(1)).toBe(10_000_000n);
+    expect(toStroops(0.5)).toBe(5_000_000n);
+  });
+});
+
+// ─── fromStroops ──────────────────────────────────────────────────────────────
+
+describe('fromStroops', () => {
+  test('converts to 7-decimal string', () => {
+    expect(fromStroops(10_000_000n)).toBe('1.0000000');
+    expect(fromStroops(1n)).toBe('0.0000001');
+    expect(fromStroops(0n)).toBe('0.0000000');
+  });
+
+  test('round-trips with toStroops', () => {
+    const amounts = ['0.0000001', '1.2345678', '999.9999999', '0.1000000'];
+    for (const amt of amounts) {
+      expect(fromStroops(toStroops(amt))).toBe(amt);
+    }
+  });
+
+  test('throws for non-bigint input', () => {
+    expect(() => fromStroops(1000000)).toThrow();
+    expect(() => fromStroops('1000000')).toThrow();
+  });
+});
+
+// ─── addStroops / subtractStroops ─────────────────────────────────────────────
+
+describe('addStroops / subtractStroops', () => {
+  test('adds two stroop values', () => {
+    expect(addStroops(1n, 2n)).toBe(3n);
+    expect(addStroops(0n, 10_000_000n)).toBe(10_000_000n);
+  });
+
+  test('subtracts stroop values', () => {
+    expect(subtractStroops(10_000_000n, 1n)).toBe(9_999_999n);
+  });
+
+  test('accumulates large number of small amounts without drift', () => {
+    // 10,000,000 × 0.0000001 XLM = 1 XLM exactly
+    const ONE_STROOP = 1n;
+    let total = 0n;
+    for (let i = 0; i < 10_000_000; i++) {
+      total = addStroops(total, ONE_STROOP);
+    }
+    expect(total).toBe(STROOPS_PER_XLM);
+    expect(fromStroops(total)).toBe('1.0000000');
+  });
+});
+
+// ─── calcFee ─────────────────────────────────────────────────────────────────
+
+describe('calcFee', () => {
+  // 200 bps = 2 %
+  const BPS_2PCT = 200n;
+
+  test('basic 2% fee on 1 XLM = 0.02 XLM = 200_000 stroops', () => {
+    const fee = calcFee(toStroops('1'), BPS_2PCT);
+    expect(fee).toBe(200_000n);
+    expect(fromStroops(fee)).toBe('0.0200000');
+  });
+
+  test('floors fractional stroop (platform favor)', () => {
+    // 1 stroop × 200 bps / 10000 = 0.02 stroops → floor = 0
+    expect(calcFee(1n, BPS_2PCT)).toBe(0n);
+
+    // 5001 stroops × 200 / 10000 = 100.02 → floor = 100
+    expect(calcFee(5001n, BPS_2PCT)).toBe(100n);
+  });
+
+  // ── minimum-fee clamp ────────────────────────────────────────────────────
+
+  test('clamps to minFeeStroops when calculated fee is below minimum', () => {
+    // Very small donation: 0.0000001 XLM = 1 stroop
+    // 2% of 1 stroop = 0 (floor) → clamp to min = 100_000 stroops = 0.01 XLM
+    const fee = calcFee(1n, BPS_2PCT, { minFeeStroops: 100_000n });
+    expect(fee).toBe(100_000n);
+  });
+
+  test('does NOT clamp when fee exceeds minimum', () => {
+    // 1 XLM donation, 2% = 200_000 stroops > 100_000 min
+    const fee = calcFee(toStroops('1'), BPS_2PCT, { minFeeStroops: 100_000n });
+    expect(fee).toBe(200_000n);
+  });
+
+  // ── maximum-fee clamp ────────────────────────────────────────────────────
+
+  test('clamps to maxFeeStroops when calculated fee exceeds maximum', () => {
+    // 1000 XLM × 2% = 20 XLM = 200_000_000 stroops → cap at 10 XLM = 100_000_000
+    const fee = calcFee(toStroops('1000'), BPS_2PCT, { maxFeeStroops: 100_000_000n });
+    expect(fee).toBe(100_000_000n);
+  });
+
+  test('does NOT clamp when fee is below maximum', () => {
+    const fee = calcFee(toStroops('1'), BPS_2PCT, { maxFeeStroops: 100_000_000n });
+    expect(fee).toBe(200_000n);
+  });
+
+  // ── min AND max both active ───────────────────────────────────────────────
+
+  test('min and max clamp together without interference', () => {
+    // fee = 50_000 stroops; min=100_000 → result 100_000 (still under max=200_000)
+    const fee = calcFee(2_500_000n, BPS_2PCT, {
+      minFeeStroops: 100_000n,
+      maxFeeStroops: 200_000n,
+    });
+    expect(fee).toBe(100_000n);
+  });
+
+  // ── surge multiplier ─────────────────────────────────────────────────────
+
+  test('surge multiplier 1.5× (15000 bps) doubles fee correctly', () => {
+    // base bps = 200, surge = 15000 → effective = floor(200 * 15000 / 10000) = floor(300) = 300 bps
+    // fee on 1 XLM = floor(10_000_000 * 300 / 10000) = 300_000
+    const fee = calcFee(toStroops('1'), BPS_2PCT, { surgeMultiplierBps: 15000n });
+    expect(fee).toBe(300_000n);
+    expect(fromStroops(fee)).toBe('0.0300000');
+  });
+
+  test('surge multiplier 2× (20000 bps)', () => {
+    // effective bps = floor(200 * 20000 / 10000) = 400 bps = 4%
+    const fee = calcFee(toStroops('1'), BPS_2PCT, { surgeMultiplierBps: 20000n });
+    expect(fee).toBe(400_000n);
+  });
+
+  test('surge multiplier with min clamp', () => {
+    // 1 stroop, surge 2×, effective bps=400, fee=0 → clamp to min=100_000
+    const fee = calcFee(1n, BPS_2PCT, {
+      surgeMultiplierBps: 20000n,
+      minFeeStroops: 100_000n,
+    });
+    expect(fee).toBe(100_000n);
+  });
+
+  test('throws for negative bps', () => {
+    expect(() => calcFee(toStroops('1'), -1n)).toThrow();
+  });
+
+  test('throws for non-BigInt amountStroops', () => {
+    expect(() => calcFee(1000000, 200n)).toThrow();
+  });
+});
+
+// ─── Impact-report reconciliation ────────────────────────────────────────────
+
+describe('impact report reconciliation', () => {
+  /**
+   * Simulate an SDG-breakdown scenario:
+   *   - 3 SDG buckets, each receiving a set of donations
+   *   - Grand total must equal the exact sum of per-SDG subtotals
+   */
+  test('per-SDG subtotals sum exactly to grand total (no drift)', () => {
+    const sdgDonations = {
+      sdg1: ['0.1', '0.2', '0.3'],           // = 0.6 XLM
+      sdg2: ['0.0000001', '0.9999999'],       // = 1.0000000 XLM
+      sdg3: ['100.1234567', '0.0000001'],     // = 100.1234568 XLM
+    };
+
+    const sdgTotals = {};
+    let grandTotalStroops = 0n;
+
+    for (const [sdg, amounts] of Object.entries(sdgDonations)) {
+      let subtotalStroops = 0n;
+      for (const amt of amounts) {
+        subtotalStroops += toStroops(amt);
+      }
+      sdgTotals[sdg] = subtotalStroops;
+      grandTotalStroops += subtotalStroops;
+    }
+
+    // Sub-totals summed independently must equal the grand total
+    const sumOfSubtotals = Object.values(sdgTotals).reduce((acc, s) => acc + s, 0n);
+    expect(sumOfSubtotals).toBe(grandTotalStroops);
+
+    // Exact values
+    expect(sdgTotals.sdg1).toBe(toStroops('0.6'));
+    expect(sdgTotals.sdg2).toBe(toStroops('1.0000000'));
+    expect(sdgTotals.sdg3).toBe(toStroops('100.1234568'));
+  });
+
+  test('large batch of small donations: no drift vs expected total', () => {
+    // 1,000,000 donations of 0.0000001 XLM = exactly 0.1 XLM
+    const AMOUNT = '0.0000001';
+    const COUNT = 1_000_000;
+    const expectedTotal = toStroops('0.1');
+
+    let total = 0n;
+    const stroop = toStroops(AMOUNT);
+    for (let i = 0; i < COUNT; i++) {
+      total += stroop;
+    }
+
+    expect(total).toBe(expectedTotal);
+    expect(fromStroops(total)).toBe('0.1000000');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses issues #1152, #1153, #1154 — eliminates float-based monetary arithmetic and replaces it with deterministic integer stroop math using BigInt.

## Changes

### New: `src/utils/money.js`
Single shared money utility — the rule lives in one place:
- `toStroops(xlm)` — parses XLM string/number to BigInt stroops at input boundary
- `fromStroops(stroops)` — formats BigInt to 7-decimal XLM string at output boundary only
- `calcFee(amountStroops, bps, opts)` — integer bps fee math with `minFeeStroops`, `maxFeeStroops`, `surgeMultiplierBps`
- `addStroops` / `subtractStroops` helpers

**Rounding rule:** floor (BigInt division truncates toward zero) — platform's favor, documented.

### Refactored
- **`src/utils/feeCalculator.js`** — fee rates in basis points (200 bps = 2%, max 500 bps = 5%), `MIN_FEE_STROOPS = 100_000` (0.01 XLM), all arithmetic via money utility
- **`src/services/StatsService.js`** — all stat methods replace `parseFloat` / `+=` float accumulation with BigInt stroop accumulators; `getAnalyticsFeeStats` keeps upstream's multi-asset `byAsset` structure with stroop math applied
- **`src/services/DonationService.js`** — removed `parseFloat(amount)` in custodial donation path
- **`src/routes/stream.js`** — removed `parseFloat(amount)` on recurring donation INSERT

### Tests: `tests/money.test.js`
27 tests, all passing:
- `toStroops`/`fromStroops` round-trip and IEEE-754 edge cases (0.1 + 0.2 = 0.3 exactly)
- `calcFee`: basic bps, floor rounding, min clamp, max clamp, surge multiplier, combined clamps
- Impact report: per-SDG subtotals sum exactly to grand total; 1M small donations without drift

Closes #1152 
Closes #1153 
Closes #1154 