### PR TITLE
docs: complete env var docs, ADRs, and rate-limiting guide (closes #1…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@
 #
 # Variables marked REQUIRED must be set before the server will start.
 # Variables marked OPTIONAL have safe defaults and can be left commented.
+# Full documentation: docs/CONFIGURATION.md
 # =====================================
 
 
@@ -19,15 +20,92 @@ PORT=3000
 # Runtime environment. Use "development" locally, "production" in prod.
 NODE_ENV=development
 
+# Base path prefix prepended to all API routes.
+# OPTIONAL — default: /api/v1
+# API_PREFIX=/api/v1
+
+# Comma-separated list of trusted proxy IPs/CIDRs (Express trust proxy).
+# Set to your load balancer address in production.
+# OPTIONAL — default: loopback
+# TRUSTED_PROXIES=loopback
+
+# Unique identifier for this instance (appears in structured log output).
+# OPTIONAL — default: hostname
+# INSTANCE_ID=
+
+# Milliseconds to wait for in-flight requests to drain before force-exit.
+# OPTIONAL — default: 10000
+# SHUTDOWN_TIMEOUT_MS=10000
+
+# Global per-request timeout in milliseconds. Streaming endpoints are exempt.
+# OPTIONAL — default: 30000
+# REQUEST_TIMEOUT_MS=30000
+
 
 # =====================================
 # Authentication (REQUIRED)
 # =====================================
 
-# Comma-separated list of API keys accepted by the server.
+# Comma-separated list of API keys accepted by the legacy auth path.
 # At least one key is required for any request to be authenticated.
 # Example: dev_key_1234567890,dev_key_abcdef123456
 API_KEYS=dev_key_1234567890,dev_key_abcdef123456
+
+# Secret used to sign and verify JWT tokens.
+# OPTIONAL — must satisfy secret strength rules if set
+# JWT_SECRET=
+
+# When true, admin endpoints require a valid TOTP code alongside the API key.
+# OPTIONAL — default: false
+# REQUIRE_ADMIN_2FA=false
+
+# Issuer label embedded in TOTP QR codes.
+# OPTIONAL — default: StellarDonationAPI
+# TOTP_ISSUER=StellarDonationAPI
+
+# Number of 30-second TOTP windows (±) accepted to tolerate clock skew.
+# OPTIONAL — default: 1
+# TOTP_WINDOW=1
+
+# Seconds a SEP-10 challenge token remains valid.
+# OPTIONAL — default: 300
+# SEP10_CHALLENGE_TTL=300
+
+# Stellar home domain used in SEP-10 web-auth challenges.
+# OPTIONAL
+# HOME_DOMAIN=
+
+# Maximum failed authentication attempts before IP lockout.
+# OPTIONAL — default: 5
+# AUTH_MAX_ATTEMPTS=5
+
+# Rolling window (ms) in which AUTH_MAX_ATTEMPTS failures trigger lockout.
+# OPTIONAL — default: 60000
+# AUTH_WINDOW_MS=60000
+
+# Duration (ms) of the authentication lockout (default 15 min).
+# OPTIONAL — default: 900000
+# AUTH_LOCKOUT_MS=900000
+
+# When true, every mutating request must carry a valid HMAC request signature.
+# OPTIONAL — default: false
+# REQUIRE_REQUEST_SIGNING=false
+
+# HMAC secret used to verify inbound request signatures.
+# OPTIONAL — required when REQUIRE_REQUEST_SIGNING=true
+# REQUEST_SIGNING_SECRET=
+
+# Seconds of clock skew tolerated in signed requests.
+# OPTIONAL — default: 300
+# REQUEST_SIGNING_WINDOW_SECONDS=300
+
+# When true, POST/PATCH/PUT requests without X-Idempotency-Key are rejected.
+# OPTIONAL — default: false
+# REQUIRE_IDEMPOTENCY_KEY=false
+
+# Lifetime of signed download/export URLs in milliseconds.
+# OPTIONAL — default: 3600000 (1 hour)
+# SIGNED_URL_EXPIRY_MS=3600000
 
 
 # =====================================
@@ -46,6 +124,30 @@ API_KEYS=dev_key_1234567890,dev_key_abcdef123456
 # Then replace the placeholder below with the output.
 ENCRYPTION_KEY=<run `npm run generate-key` and paste the 64-char hex output here>
 
+# Previous encryption key used during key rotation.
+# OPTIONAL — required when ENCRYPTION_KEY_VERSION=1
+# ENCRYPTION_KEY_1=
+
+# Active key version index. Set to 1 during key rotation.
+# OPTIONAL — default: 0
+# ENCRYPTION_KEY_VERSION=0
+
+# Target key during a live re-encryption pass (npm run migrate:reencrypt).
+# OPTIONAL
+# NEW_ENCRYPTION_KEY=
+
+# HMAC secret for signing CSV/JSON export files. Must be distinct from ENCRYPTION_KEY.
+# OPTIONAL
+# EXPORT_SIGNING_SECRET=
+
+# Secret from which anonymous donor tokens are derived. Must be distinct from ENCRYPTION_KEY.
+# OPTIONAL
+# ANONYMOUS_DONATION_SECRET=
+
+# Signing backend: local (in-process), hsm, or kms.
+# OPTIONAL — default: local
+# SIGNING_PROVIDER=local
+
 
 # =====================================
 # Stellar Network Configuration
@@ -60,9 +162,70 @@ STELLAR_NETWORK=testnet
 # Set to false only when you need to test against a real Stellar network.
 MOCK_STELLAR=true
 
+# Artificial delay (ms) injected by the mock Stellar service.
+# OPTIONAL — default: 0
+# MOCK_STELLAR_LATENCY_MS=0
+
 # Optional: override the Horizon endpoint for the selected network.
 # Leave commented to use the default URL for STELLAR_NETWORK.
 # HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Number of parallel Horizon HTTP connections per pool.
+# OPTIONAL — default: 5
+# HORIZON_POOL_SIZE=5
+
+# Timeout (ms) for Horizon API requests.
+# OPTIONAL — default: 15000
+# HORIZON_API_TIMEOUT_MS=15000
+
+# Timeout (ms) for transaction submission to Horizon.
+# OPTIONAL — default: 30000
+# HORIZON_SUBMIT_TIMEOUT_MS=30000
+
+# Timeout (ms) for Horizon SSE stream connections.
+# OPTIONAL — default: 60000
+# HORIZON_STREAM_TIMEOUT_MS=60000
+
+# Maximum number of automatic retries for failed Horizon requests.
+# OPTIONAL — default: 3
+# HORIZON_MAX_RETRY_ATTEMPTS=3
+
+# Circuit breaker: failures before circuit opens.
+# OPTIONAL — default: 5
+# HORIZON_CB_FAILURE_THRESHOLD=5
+
+# Circuit breaker: cooldown period (ms) after opening.
+# OPTIONAL — default: 30000
+# HORIZON_CB_COOLDOWN_MS=30000
+
+# Multiplier applied to the network base fee when constructing transactions.
+# OPTIONAL — default: 1
+# STELLAR_FEE_MULTIPLIER=1
+
+# Number of ledgers required before a transaction is considered confirmed.
+# OPTIONAL — default: 3
+# CONFIRMATION_LEDGER_THRESHOLD=3
+
+# Minimum XLM balance required in a wallet for operations.
+# OPTIONAL — default: 1
+# MIN_RESERVE_XLM=1
+
+# Interval (ms) between automatic transaction reconciliation runs.
+# OPTIONAL — default: 30000
+# TX_SYNC_INTERVAL_MS=30000
+
+# Stellar secret key for service-initiated signing operations.
+# Leave commented unless you explicitly need service signing.
+# ⚠  Never commit a real secret key.
+# SERVICE_SECRET_KEY=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Stellar secret key of the fee-bump sponsor account.
+# OPTIONAL
+# SPONSOR_SECRET=
+
+# Stellar public key of the organisation's primary receiving account.
+# OPTIONAL
+# ORGANIZATION_ADDRESS=
 
 
 # =====================================
@@ -76,9 +239,33 @@ DB_PATH=./data/stellar_donations.db
 # OPTIONAL — default: 5
 # DB_POOL_SIZE=5
 
+# Minimum number of idle connections kept in the pool.
+# OPTIONAL — default: 1
+# DB_POOL_MIN=1
+
 # Milliseconds to wait for a pooled connection before failing.
 # OPTIONAL — default: 10000
 # DB_ACQUIRE_TIMEOUT=10000
+
+# Timeout (ms) applied to individual SQL queries.
+# OPTIONAL — default: 5000
+# DB_QUERY_TIMEOUT_MS=5000
+
+# Queries exceeding this threshold (ms) are logged as slow.
+# OPTIONAL — default: 1000
+# SLOW_QUERY_THRESHOLD_MS=1000
+
+# Number of days to retain audit log entries before purging.
+# OPTIONAL — default: 90
+# AUDIT_LOG_RETENTION_DAYS=90
+
+# Cron expression for the data-retention cleanup job.
+# OPTIONAL — default: 0 2 * * * (2 AM daily)
+# RETENTION_SCHEDULE_CRON=0 2 * * *
+
+# When true, the retention job logs what it would delete without removing records.
+# OPTIONAL — default: false
+# RETENTION_DRY_RUN=false
 
 
 # =====================================
@@ -113,6 +300,22 @@ LOG_DIR=./logs
 # Include request/response bodies in console output.
 LOG_VERBOSE=false
 
+# Minimum log level: error | warn | info | debug
+# OPTIONAL — default: info
+# LOG_LEVEL=info
+
+# Log output format: json | pretty
+# OPTIONAL — default: json
+# LOG_FORMAT=json
+
+# Log raw request and response bodies.
+# OPTIONAL — default: false
+# LOG_BODY=false
+
+# Fraction of requests to log (0-1). 1 logs every request.
+# OPTIONAL — default: 1
+# LOG_SAMPLE_RATE=1
+
 
 # =====================================
 # Donation Limits (XLM) — OPTIONAL
@@ -127,6 +330,26 @@ MAX_DONATION_AMOUNT=10000
 # Daily cap per donor (0 = no limit).
 MAX_DAILY_DONATION_PER_DONOR=0
 
+# Platform fee percentage deducted from each donation (0-100).
+# OPTIONAL — default: 0
+# PLATFORM_FEE_PERCENT=0
+
+# Maximum number of donations processed in parallel during batch submission.
+# OPTIONAL — default: 5
+# BULK_DONATION_CONCURRENCY=5
+
+# Days after which a donation can no longer be disputed.
+# OPTIONAL — default: 30
+# DISPUTE_WINDOW_DAYS=30
+
+# Hours after a donation during which a refund can be initiated.
+# OPTIONAL — default: 24
+# REFUND_WINDOW_HOURS=24
+
+# Maximum number of rows accepted per bulk wallet-import request.
+# OPTIONAL — default: 1000
+# BULK_IMPORT_MAX_ROWS=1000
+
 
 # =====================================
 # Rate Limiting — OPTIONAL
@@ -135,13 +358,48 @@ MAX_DAILY_DONATION_PER_DONOR=0
 # Max requests per IP per time window.
 RATE_LIMIT=100
 
-# Auth token endpoint rate limit (requests per minute per IP)
-# Default: 10 requests per minute
+# Auth token endpoint rate limit (requests per minute per IP).
+# OPTIONAL — default: 10
 AUTH_TOKEN_RATE_LIMIT=10
 
-# Auth refresh endpoint rate limit (requests per minute per IP)
-# Default: 20 requests per minute
+# Auth refresh endpoint rate limit (requests per minute per IP).
+# OPTIONAL — default: 20
 AUTH_REFRESH_RATE_LIMIT=20
+
+# Backing store for rate-limit counters: memory | redis
+# Use redis in multi-instance deployments.
+# OPTIONAL — default: memory
+# RATE_LIMIT_STORE=memory
+
+# Redis connection URL. Required when RATE_LIMIT_STORE=redis.
+# OPTIONAL
+# REDIS_URL=redis://localhost:6379
+
+# When RATE_LIMIT_STORE=redis, controls behaviour on Redis unavailability.
+# true = allow requests (fail open); false = deny requests (fail closed).
+# OPTIONAL — default: true
+# RATE_LIMIT_FAIL_OPEN=true
+
+
+# =====================================
+# Caching — OPTIONAL
+# =====================================
+
+# Maximum entries in the shared in-memory LRU cache.
+# OPTIONAL — default: 1000
+# CACHE_MAX_SIZE=1000
+
+# TTL (seconds) for cached wallet-balance responses.
+# OPTIONAL — default: 30
+# WALLET_BALANCE_CACHE_TTL_SECONDS=30
+
+# TTL (seconds) for the in-memory API key lookup cache.
+# OPTIONAL — default: 60
+# API_KEY_CACHE_TTL_SECONDS=60
+
+# TTL (seconds) for the donation stats cache.
+# OPTIONAL — default: 60
+# STATS_CACHE_TTL_SECONDS=60
 
 
 # =====================================
@@ -163,6 +421,7 @@ AUTH_REFRESH_RATE_LIMIT=20
 # Get one at https://www.coingecko.com/en/api
 # COINGECKO_API_KEY=
 
+
 # =====================================
 # IPFS Certificate Pinning (Pinata) — OPTIONAL
 # =====================================
@@ -174,7 +433,9 @@ AUTH_REFRESH_RATE_LIMIT=20
 # PINATA_SECRET_KEY=
 
 # Public IPFS gateway base URL for certificate links.
+# OPTIONAL — default: https://gateway.pinata.cloud/ipfs
 # IPFS_GATEWAY_URL=https://gateway.pinata.cloud/ipfs
+
 
 # =====================================
 # Email Receipts (SMTP) — OPTIONAL
@@ -191,6 +452,7 @@ AUTH_REFRESH_RATE_LIMIT=20
 # SMTP_FROM must be a sender address verified with your provider.
 # SMTP_FROM=
 
+
 # =====================================
 # Geographic IP Blocking — OPTIONAL
 # =====================================
@@ -206,3 +468,160 @@ AUTH_REFRESH_RATE_LIMIT=20
 
 # Path to MaxMind GeoLite2-Country.mmdb (default: ./data/GeoLite2-Country.mmdb).
 # MAXMIND_DB_PATH=./data/GeoLite2-Country.mmdb
+
+
+# =====================================
+# Abuse Detection — OPTIONAL
+# =====================================
+
+# Rolling window (ms) in which request counts are tracked for burst detection.
+# OPTIONAL — default: 60000
+# ABUSE_WINDOW_MS=60000
+
+# Number of requests within ABUSE_WINDOW_MS that triggers the burst-detection signal.
+# OPTIONAL — default: 100
+# ABUSE_SUSPICIOUS_THRESHOLD=100
+
+# Duration (ms) a flagged IP remains in the suspicious list.
+# OPTIONAL — default: 3600000 (1 hour)
+# ABUSE_BLOCK_DURATION_MS=3600000
+
+# Path to a persistent SQLite file for abuse-detection tracking.
+# When unset, tracking is in-memory only.
+# ABUSE_DB_PATH=
+
+
+# =====================================
+# Replay & Deduplication — OPTIONAL
+# =====================================
+
+# Window (seconds) within which a duplicate request signature is rejected.
+# OPTIONAL — default: 300
+# REPLAY_WINDOW_SECONDS=300
+
+# Window (ms) within which identical request body hashes are deduplicated.
+# OPTIONAL — default: 60000
+# DEDUP_WINDOW_MS=60000
+
+# Maximum entries in the in-memory deduplication cache.
+# OPTIONAL — default: 10000
+# DEDUP_MEM_CACHE_MAX_SIZE=10000
+
+
+# =====================================
+# Backup — OPTIONAL
+# =====================================
+
+# Local directory where encrypted database backup files are written.
+# OPTIONAL — default: ./data/backups
+# BACKUP_DIR=./data/backups
+
+# Interval (ms) between automatic backup runs.
+# OPTIONAL — default: 3600000 (1 hour)
+# BACKUP_INTERVAL_MS=3600000
+
+# S3 bucket name for off-site backup upload. When unset, backups are local only.
+# BACKUP_S3_BUCKET=
+
+# AWS region used for S3 backup uploads.
+# OPTIONAL — default: us-east-1
+# AWS_REGION=us-east-1
+
+
+# =====================================
+# SSE / WebSocket Streaming — OPTIONAL
+# =====================================
+
+# Maximum concurrent SSE connections allowed per API key.
+# OPTIONAL — default: 10
+# SSE_MAX_CONNECTIONS_PER_KEY=10
+
+# Number of events buffered per SSE connection for reconnecting clients.
+# OPTIONAL — default: 100
+# SSE_EVENT_BUFFER_SIZE=100
+
+# Maximum number of wallet subscriptions per WebSocket connection.
+# OPTIONAL — default: 50
+# WS_MAX_WALLETS=50
+
+# Interval (ms) between WebSocket ping frames.
+# OPTIONAL — default: 30000
+# WS_HEARTBEAT_MS=30000
+
+
+# =====================================
+# Observability & Tracing — OPTIONAL
+# =====================================
+
+# Enable OpenTelemetry trace/metric export.
+# OPTIONAL — default: false
+# OTEL_ENABLED=false
+
+# Service name reported to the OTLP collector.
+# OPTIONAL — default: stellar-donation-api
+# OTEL_SERVICE_NAME=stellar-donation-api
+
+# OTLP exporter endpoint URL.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318
+
+# URL to POST anomaly-detection alerts to. When unset, alerts are logged only.
+# ANOMALY_WEBHOOK_URL=
+
+
+# =====================================
+# Organisation Metadata — OPTIONAL
+# (embedded in generated PDF receipts and tax documents)
+# =====================================
+
+# ORGANIZATION_LEGAL_NAME=
+# ORGANIZATION_EIN=
+# ORGANIZATION_EMAIL=
+# ORGANIZATION_PHONE=
+# ORGANIZATION_CITY=
+# ORGANIZATION_STATE=
+# ORGANIZATION_ZIP_CODE=
+# ORGANIZATION_WEBSITE=
+
+
+# =====================================
+# Signing Providers (HSM / KMS) — OPTIONAL
+# =====================================
+
+# Signing backend: local | hsm | kms (default: local)
+# SIGNING_PROVIDER=local
+
+# PKCS#11 slot ID — required when SIGNING_PROVIDER=hsm
+# HSM_SLOT_ID=
+
+# PKCS#11 slot PIN — required when SIGNING_PROVIDER=hsm
+# HSM_PIN=
+
+# Cloud KMS provider: aws | gcp — required when SIGNING_PROVIDER=kms
+# KMS_PROVIDER=
+
+# KMS key ARN (AWS) or resource name (GCP)
+# KMS_KEY_ID=
+
+
+# =====================================
+# Miscellaneous / Feature Config — OPTIONAL
+# =====================================
+
+# JSON object of feature-flag overrides, e.g. {"newDonationFlow":true}
+# See docs/FEATURE_FLAGS_RUNTIME.md for available flags.
+# FEATURE_FLAGS=
+
+# Publicly accessible base URL of this API (used in generated links).
+# API_BASE_URL=http://localhost:3000
+
+# URI to which CSP violation reports are sent.
+# CSP_REPORT_URI=
+
+# When true, CSP violations are reported but not enforced.
+# OPTIONAL — default: false
+# CSP_REPORT_ONLY=false
+
+# When true, TLS certificate verification is disabled for outbound webhook deliveries.
+# ⚠  Never use in production.
+# OPTIONAL — default: false
+# WEBHOOK_ALLOW_TLS_SKIP_VERIFY=false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,8 +1,417 @@
 # Configuration Guide
 
-## Unsafe Development Flags
+This document is the authoritative reference for every environment variable read by the
+application. Variables are grouped by concern. For each variable the table shows:
 
-The following environment variables are provided for local development and **must never be enabled in production**. The startup checks (`src/utils/startupChecks.js`) will **abort the process** if any of these flags are `true` when `NODE_ENV=production`.
+- **Type** — `string | number | boolean | enum`
+- **Default** — value used when the variable is absent (empty string means no default)
+- **Required?** — `yes` = server refuses to start without it; `no` = optional
+- **Effect** — what the variable controls
+
+> **Tip:** Copy `.env.example` to `.env` and fill in the required variables before
+> starting the server locally.
+
+---
+
+## Contents
+
+1. [Server](#1-server)
+2. [Authentication & API Keys](#2-authentication--api-keys)
+3. [Encryption & Secrets](#3-encryption--secrets)
+4. [Stellar / Horizon](#4-stellar--horizon)
+5. [Database](#5-database)
+6. [CORS](#6-cors)
+7. [Logging](#7-logging)
+8. [Rate Limiting](#8-rate-limiting)
+9. [Donation Limits & Business Logic](#9-donation-limits--business-logic)
+10. [Caching](#10-caching)
+11. [SMTP / Email Receipts](#11-smtp--email-receipts)
+12. [IPFS / Pinata](#12-ipfs--pinata)
+13. [Geographic Blocking](#13-geographic-blocking)
+14. [Abuse Detection](#14-abuse-detection)
+15. [Replay & Deduplication](#15-replay--deduplication)
+16. [Backup](#16-backup)
+17. [SSE / WebSocket Streaming](#17-sse--websocket-streaming)
+18. [Observability & Tracing](#18-observability--tracing)
+19. [Organisation Metadata](#19-organisation-metadata)
+20. [Signing Providers (HSM / KMS)](#20-signing-providers-hsm--kms)
+21. [Miscellaneous / Feature Config](#21-miscellaneous--feature-config)
+22. [Unsafe Development Flags](#22-unsafe-development-flags)
+23. [Secret Strength Requirements](#23-secret-strength-requirements)
+24. [SSRF Protection](#24-ssrf-protection)
+
+---
+
+## 1. Server
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `PORT` | number | `3000` | no | TCP port the HTTP server listens on |
+| `NODE_ENV` | enum | `development` | no | Runtime environment (`development`, `test`, `production`). Controls logging verbosity, startup guard behaviour, and unsafe-flag checks |
+| `API_PREFIX` | string | `/api/v1` | no | Base path prefix prepended to all API routes |
+| `TRUSTED_PROXIES` | string | `loopback` | no | Comma-separated list of trusted proxy IPs/CIDRs. Passed to Express `trust proxy`. Set to the address of your load balancer in production |
+| `INSTANCE_ID` | string | hostname | no | Unique identifier for this process instance. Appears in structured log output for distributed tracing |
+| `SHUTDOWN_TIMEOUT` | number | `10000` | no | Alias for `SHUTDOWN_TIMEOUT_MS` (milliseconds). Time allowed for in-flight requests to drain before force-exit |
+| `SHUTDOWN_TIMEOUT_MS` | number | `10000` | no | Milliseconds to wait for graceful shutdown before force-exit |
+| `REQUEST_TIMEOUT_MS` | number | `30000` | no | Global per-request timeout in milliseconds. Streaming endpoints are exempt |
+
+---
+
+## 2. Authentication & API Keys
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `API_KEYS` | string | — | **yes** | Comma-separated list of raw API keys accepted by the legacy authentication path. At least one key is required |
+| `JWT_SECRET` | string | — | no | Secret used to sign and verify JWT tokens. Must satisfy [secret strength rules](#23-secret-strength-requirements) if set |
+| `HOME_DOMAIN` | string | — | no | Stellar home domain used in SEP-10 web-auth challenges |
+| `REQUIRE_ADMIN_2FA` | boolean | `false` | no | When `true`, admin endpoints require a valid TOTP code alongside the API key |
+| `TOTP_ISSUER` | string | `StellarDonationAPI` | no | Issuer label embedded in TOTP QR codes |
+| `TOTP_WINDOW` | number | `1` | no | Number of 30-second TOTP windows (±) accepted to tolerate clock skew |
+| `SEP10_CHALLENGE_TTL` | number | `300` | no | Seconds a SEP-10 challenge token remains valid |
+| `AUTH_MAX_ATTEMPTS` | number | `5` | no | Maximum failed authentication attempts before an IP is locked out |
+| `AUTH_WINDOW_MS` | number | `60000` | no | Rolling window (ms) in which `AUTH_MAX_ATTEMPTS` failures trigger lockout |
+| `AUTH_LOCKOUT_MS` | number | `900000` | no | Duration (ms) of the authentication lockout (default 15 min) |
+| `REQUIRE_REQUEST_SIGNING` | boolean | `false` | no | When `true`, every mutating request must carry a valid HMAC request signature |
+| `REQUEST_SIGNING_SECRET` | string | — | no | HMAC secret used to verify inbound request signatures |
+| `REQUEST_SIGNING_WINDOW_SECONDS` | number | `300` | no | Seconds of clock skew tolerated in signed requests |
+| `REQUIRE_IDEMPOTENCY_KEY` | boolean | `false` | no | When `true`, POST/PATCH/PUT requests without `X-Idempotency-Key` are rejected |
+| `SIGNED_URL_EXPIRY_MS` | number | `3600000` | no | Lifetime of signed download/export URLs in milliseconds (default 1 h) |
+
+---
+
+## 3. Encryption & Secrets
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `ENCRYPTION_KEY` | string (64 hex) | — | **yes** | AES-256 key used to encrypt wallet secret keys and other sensitive data at rest. Generate with `npm run generate-key`. **Changing this key makes all previously encrypted data unrecoverable.** |
+| `ENCRYPTION_KEY_1` | string (64 hex) | — | no | Previous encryption key used during key rotation. Required when `ENCRYPTION_KEY_VERSION=1` |
+| `ENCRYPTION_KEY_VERSION` | number | `0` | no | Active key version index. Set to `1` during key rotation to indicate `ENCRYPTION_KEY_1` is the current key |
+| `NEW_ENCRYPTION_KEY` | string (64 hex) | — | no | Target key during a live re-encryption pass (`npm run migrate:reencrypt`) |
+| `ENCRYPTION_SECRET` | string | — | no | Legacy symmetric encryption secret for non-wallet data paths |
+| `ENCRYPTION_PRIVATE_KEY` | string | — | no | RSA/EC private key PEM used by asymmetric signing paths |
+| `ENCRYPTION_PUBLIC_KEY` | string | — | no | RSA/EC public key PEM used to verify asymmetric signatures |
+| `EXPORT_SIGNING_SECRET` | string | — | no | HMAC secret for signing CSV/JSON export files. Must be distinct from `ENCRYPTION_KEY` |
+| `ANONYMOUS_DONATION_SECRET` | string | — | no | Secret from which anonymous donor tokens are derived. Must be distinct from `ENCRYPTION_KEY` |
+| `SIGNING_PROVIDER` | enum | `local` | no | Signing backend: `local` (in-process), `hsm`, or `kms`. See [Signing Providers](#20-signing-providers-hsm--kms) |
+
+---
+
+## 4. Stellar / Horizon
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `STELLAR_NETWORK` | enum | `testnet` | no | Target Stellar network. Allowed: `testnet`, `mainnet`, `futurenet` |
+| `STELLAR_ENVIRONMENT` | enum | `testnet` | no | Alias for `STELLAR_NETWORK` accepted by some service modules |
+| `STELLAR_NETWORK_PASSPHRASE` | string | — | no | Override the network passphrase. Inferred from `STELLAR_NETWORK` when omitted |
+| `HORIZON_URL` | string | — | no | Override the Horizon endpoint URL. Defaults to the canonical URL for `STELLAR_NETWORK` |
+| `MOCK_STELLAR` | boolean | `true` | no | When `true`, no outbound Stellar/Horizon calls are made. Required for local dev and CI |
+| `USE_MOCK_STELLAR` | boolean | `false` | no | Alias for `MOCK_STELLAR` in some service modules |
+| `MOCK_STELLAR_LATENCY_MS` | number | `0` | no | Artificial delay (ms) injected by the mock Stellar service to simulate network latency |
+| `DRY_RUN` | boolean | `false` | no | Skip submitting real Stellar transactions. Useful for staging. **Startup fails in production if `true`** |
+| `HORIZON_POOL_SIZE` | number | `5` | no | Number of parallel Horizon HTTP connections maintained per pool |
+| `HORIZON_POOL_COOLDOWN_MS` | number | `1000` | no | Minimum cooldown (ms) between using the same pool connection |
+| `HORIZON_API_TIMEOUT_MS` | number | `15000` | no | Timeout (ms) for Horizon API requests |
+| `HORIZON_SUBMIT_TIMEOUT_MS` | number | `30000` | no | Timeout (ms) for transaction submission to Horizon |
+| `HORIZON_STREAM_TIMEOUT_MS` | number | `60000` | no | Timeout (ms) for Horizon SSE stream connections |
+| `HORIZON_MAX_RETRY_ATTEMPTS` | number | `3` | no | Maximum number of automatic retries for failed Horizon requests |
+| `HORIZON_RETRY_BASE_DELAY_MS` | number | `1000` | no | Base delay (ms) for Horizon retry exponential back-off |
+| `HORIZON_RETRY_MAX_DELAY_MS` | number | `30000` | no | Maximum delay (ms) cap for Horizon retry back-off |
+| `HORIZON_CB_FAILURE_THRESHOLD` | number | `5` | no | Number of consecutive Horizon failures before the circuit breaker opens |
+| `HORIZON_CB_WINDOW_MS` | number | `60000` | no | Rolling window (ms) in which failures are counted by the circuit breaker |
+| `HORIZON_CB_COOLDOWN_MS` | number | `30000` | no | Time (ms) the circuit breaker stays open before attempting a probe request |
+| `STELLAR_BASE_RESERVE` | number | `0.5` | no | Minimum XLM base reserve per account entry (in XLM). Mirrors Stellar protocol value |
+| `STELLAR_FEE_MULTIPLIER` | number | `1` | no | Multiplier applied to the network base fee when constructing transactions |
+| `STELLAR_EXPLORER_URL` | string | — | no | Base URL of the Stellar block explorer used to build transaction links |
+| `CONFIRMATION_LEDGER_THRESHOLD` | number | `3` | no | Number of ledger closings required before a transaction is considered confirmed |
+| `MIN_RESERVE_XLM` | number | `1` | no | Minimum XLM balance (in XLM) required in a wallet for operations |
+| `SYNC_MAX_PAGES` | number | `10` | no | Maximum number of Horizon history pages fetched during a transaction sync pass |
+| `TX_SYNC_INTERVAL_MS` | number | `30000` | no | Interval (ms) between automatic transaction reconciliation runs |
+| `SERVICE_SECRET_KEY` | string | — | no | Stellar secret key (`S…`) for service-initiated signing operations. Never commit. |
+| `SERVICE_SIGNING_KEY` | string | — | no | Alias for `SERVICE_SECRET_KEY` used in some signing paths |
+| `STELLAR_SECRET` | string | — | no | Legacy alias for the Stellar signing secret in older code paths |
+| `SPONSOR_SECRET` | string | — | no | Stellar secret key of the fee-bump sponsor account |
+| `RECIPIENT_SECRETS` | string | — | no | JSON-encoded map of recipient IDs to Stellar secret keys for multi-recipient flows |
+| `ORGANIZATION_ADDRESS` | string | — | no | Stellar public key (`G…`) of the organisation's primary receiving account |
+
+---
+
+## 5. Database
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `DB_PATH` | string | `./data/stellar_donations.db` | no | File path to the SQLite database (relative to project root) |
+| `DB_TYPE` | enum | `sqlite` | no | Database driver. Currently only `sqlite` is supported |
+| `DB_POOL_SIZE` | number | `5` | no | Alias for `DB_POOL_MAX`. Maximum number of concurrent SQLite connections |
+| `DB_POOL_MIN` | number | `1` | no | Minimum number of idle connections kept in the SQLite pool |
+| `DB_POOL_MAX` | number | `5` | no | Maximum number of concurrent SQLite connections |
+| `DB_ACQUIRE_TIMEOUT` | number | `10000` | no | Milliseconds to wait for an available pool connection before failing |
+| `DB_QUERY_TIMEOUT_MS` | number | `5000` | no | Timeout (ms) applied to individual SQL queries |
+| `SLOW_QUERY_THRESHOLD_MS` | number | `1000` | no | Queries exceeding this threshold (ms) are logged as slow |
+| `SLOW_QUERY_BUFFER_SIZE` | number | `100` | no | Number of slow-query records retained in memory for the diagnostics endpoint |
+| `MIGRATION_LOCK_TIMEOUT_MS` | number | `30000` | no | Milliseconds to wait for the advisory migration lock before failing |
+| `MIGRATION_LOCK_POLL_INTERVAL_MS` | number | `500` | no | Polling interval (ms) when waiting for the migration lock |
+| `AUDIT_LOG_RETENTION_DAYS` | number | `90` | no | Number of days to retain audit log entries before they are purged |
+| `RETENTION_SCHEDULE_CRON` | string | `0 2 * * *` | no | Cron expression controlling when the data-retention cleanup job runs |
+| `RETENTION_DRY_RUN` | boolean | `false` | no | When `true`, the retention job logs what it would delete without removing records |
+
+---
+
+## 6. CORS
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `CORS_ALLOWED_ORIGINS` | string | `http://localhost:3000,...` | no | Comma-separated list of allowed browser origins. In production, set this explicitly — omitting it rejects all browser origins |
+| `CORS_ALLOWED_METHODS` | string | `GET,POST,PUT,PATCH,DELETE,OPTIONS` | no | Comma-separated HTTP methods allowed in CORS pre-flight responses |
+| `CORS_ALLOWED_HEADERS` | string | `Content-Type,Authorization,...` | no | Comma-separated request headers allowed through CORS |
+| `CORS_MAX_AGE` | number | `86400` | no | `Access-Control-Max-Age` value in seconds (how long browsers may cache pre-flight results) |
+| `CORS_ALLOW_ALL` | boolean | `false` | no | Allow every origin. **Startup fails in production if `true`** |
+
+---
+
+## 7. Logging
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `DEBUG_MODE` | boolean | `false` | no | Enable verbose debug logging. **Startup fails in production if `true`** |
+| `LOG_TO_FILE` | boolean | `false` | no | Write logs to rotating files in addition to stdout |
+| `LOG_DIR` | string | `./logs` | no | Directory for log files when `LOG_TO_FILE=true` |
+| `LOG_VERBOSE` | boolean | `false` | no | Include request/response bodies in console log output |
+| `LOG_LEVEL` | enum | `info` | no | Minimum log level: `error`, `warn`, `info`, `debug` |
+| `LOG_FORMAT` | enum | `json` | no | Log output format: `json` or `pretty` |
+| `LOG_BODY` | boolean | `false` | no | Log raw request and response bodies |
+| `LOG_BODY_PATHS` | string | — | no | Comma-separated path prefixes for which request bodies are logged (overrides `LOG_BODY`) |
+| `LOG_HEADERS` | boolean | `false` | no | Include request headers in access log entries |
+| `LOG_SKIP_PATHS` | string | `/health,/metrics` | no | Comma-separated paths excluded from access log output |
+| `LOG_SAMPLE_RATE` | number | `1` | no | Fraction of requests to log (0–1). `1` logs every request |
+| `LOG_MAX_SIZE` | number | `10485760` | no | Maximum log file size in bytes before rotation (default 10 MB) |
+| `ACCESS_LOG_INCLUDE_HEALTH` | boolean | `false` | no | When `true`, health-check requests appear in the access log |
+
+---
+
+## 8. Rate Limiting
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `DISABLE_RATE_LIMIT` | boolean | `false` | no | Bypass all rate-limiting middleware. **Startup fails in production if `true`** |
+| `RATE_LIMIT` | number | `100` | no | Maximum requests per IP per rate-limit window (global limiter) |
+| `RATE_LIMIT_MAX_REQUESTS` | number | `100` | no | Alias for `RATE_LIMIT` used in some middleware |
+| `RATE_LIMIT_WINDOW_MS` | number | `60000` | no | Rolling window duration (ms) for the global rate limiter |
+| `RATE_LIMIT_STORE` | enum | `memory` | no | Backing store for rate-limit counters: `memory` or `redis`. Use `redis` in multi-instance deployments |
+| `RATE_LIMIT_FAIL_OPEN` | boolean | `true` | no | When `RATE_LIMIT_STORE=redis`, controls behaviour on Redis unavailability. `true` = allow requests; `false` = deny requests |
+| `RATE_LIMIT_CLEANUP_INTERVAL_MS` | number | `60000` | no | Interval (ms) between in-memory store cleanup passes that evict expired windows |
+| `REDIS_URL` | string | — | no | Redis connection URL (e.g. `redis://localhost:6379`). Required when `RATE_LIMIT_STORE=redis` |
+| `AUTH_TOKEN_RATE_LIMIT` | number | `10` | no | Maximum requests per minute per IP on `POST /auth/token` |
+| `AUTH_REFRESH_RATE_LIMIT` | number | `20` | no | Maximum requests per minute per IP on `POST /auth/refresh` |
+
+For a full description of rate-limit layers, headers, and recommended client backoff, see
+[docs/RATE_LIMITING.md](./RATE_LIMITING.md).
+
+---
+
+## 9. Donation Limits & Business Logic
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `MIN_DONATION_AMOUNT` | number | `0.01` | no | Minimum accepted donation amount in XLM |
+| `MAX_DONATION_AMOUNT` | number | `10000` | no | Maximum accepted donation amount in XLM |
+| `MAX_DAILY_DONATION_PER_DONOR` | number | `0` | no | Daily XLM cap per donor. `0` disables the cap |
+| `PLATFORM_FEE_PERCENT` | number | `0` | no | Platform fee percentage deducted from each donation (0–100) |
+| `MINIMUM_FEE_XLM` | number | `0` | no | Minimum platform fee in XLM regardless of `PLATFORM_FEE_PERCENT` |
+| `MAXIMUM_FEE_XLM` | number | `0` | no | Maximum platform fee cap in XLM regardless of `PLATFORM_FEE_PERCENT` |
+| `BULK_DONATION_CONCURRENCY` | number | `5` | no | Number of donations processed in parallel during a batch submission |
+| `DISPUTE_WINDOW_DAYS` | number | `30` | no | Number of days after which a donation can no longer be disputed |
+| `REFUND_WINDOW_HOURS` | number | `24` | no | Hours after a donation during which a refund can be initiated |
+| `REFUND_ELIGIBILITY_WINDOW_DAYS` | number | `7` | no | Days within which a donation is eligible for refund consideration |
+| `RECENT_DONATIONS_MAX_LIMIT` | number | `100` | no | Maximum number of records returned by the recent-donations endpoint |
+| `RECENT_DONATIONS_CACHE_TTL_SECONDS` | number | `60` | no | TTL (seconds) for the recent-donations response cache |
+| `BULK_IMPORT_MAX_ROWS` | number | `1000` | no | Maximum number of rows accepted per bulk wallet-import request |
+| `BULK_IMPORT_MAX_SIZE_BYTES` | number | `5242880` | no | Maximum size (bytes) of a bulk import payload (default 5 MB) |
+| `PLEDGE_EXPIRY_INTERVAL_MS` | number | `3600000` | no | Interval (ms) between pledge expiry check runs (default 1 h) |
+| `API_KEY_EXPIRY_WARN_DAYS` | number | `14` | no | Days before an API key expires at which a warning is logged |
+
+---
+
+## 10. Caching
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `CACHE_MAX_SIZE` | number | `1000` | no | Maximum number of entries in the shared in-memory LRU cache |
+| `CACHE_CLEANUP_INTERVAL_MS` | number | `60000` | no | Interval (ms) between cache eviction passes |
+| `WALLET_BALANCE_CACHE_TTL_SECONDS` | number | `30` | no | TTL (seconds) for cached wallet-balance responses |
+| `API_KEY_CACHE_TTL_SECONDS` | number | `60` | no | TTL (seconds) for the in-memory API key lookup cache |
+| `STATS_CACHE_TTL_SECONDS` | number | `60` | no | TTL (seconds) for the donation stats cache |
+| `STATS_SUMMARY_CACHE_TTL_SECONDS` | number | `300` | no | TTL (seconds) for the donation stats-summary cache |
+| `FEDERATION_CACHE_TTL` | number | `3600` | no | TTL (seconds) for Stellar federation record lookups |
+| `FEDERATION_CACHE_MAX_SIZE` | number | `500` | no | Maximum number of cached federation records |
+| `FEDERATION_CACHE_CLEANUP_INTERVAL_MS` | number | `600000` | no | Interval (ms) between federation cache cleanup passes |
+
+---
+
+## 11. SMTP / Email Receipts
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `SMTP_HOST` | string | — | no | SMTP relay hostname (e.g. `smtp-relay.brevo.com`) |
+| `SMTP_PORT` | number | `587` | no | SMTP port |
+| `SMTP_SECURE` | boolean | `false` | no | Use TLS (`true`) or STARTTLS (`false`) for SMTP connections |
+| `SMTP_USER` | string | — | no | SMTP authentication username |
+| `SMTP_PASS` | string | — | no | SMTP authentication password (alias: `SMTP_PASSWORD`) |
+| `SMTP_PASSWORD` | string | — | no | Alias for `SMTP_PASS` |
+| `SMTP_FROM` | string | — | no | Sender address for outbound emails. Must be verified with your SMTP provider |
+
+When `SMTP_HOST` is not set, email delivery is skipped gracefully.
+
+---
+
+## 12. IPFS / Pinata
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `PINATA_API_KEY` | string | — | no | Pinata API key for pinning donation impact certificates to IPFS |
+| `PINATA_SECRET_KEY` | string | — | no | Pinata API secret corresponding to `PINATA_API_KEY` |
+| `IPFS_GATEWAY_URL` | string | `https://gateway.pinata.cloud/ipfs` | no | Public IPFS gateway base URL used to construct certificate links |
+
+When `PINATA_API_KEY` is not set, certificates fall back to local in-memory storage.
+
+---
+
+## 13. Geographic Blocking
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `GEO_BLOCKED_COUNTRIES` | string | — | no | Comma-separated ISO 3166-1 alpha-2 country codes whose requests are blocked (e.g. `RU,IR,KP`) |
+| `GEO_ALLOWED_COUNTRIES` | string | — | no | Country codes that are always allowed, overriding `GEO_BLOCKED_COUNTRIES` |
+| `GEO_ALLOWED_IPS` | string | — | no | Comma-separated IPs or CIDR ranges that bypass geo-blocking |
+| `MAXMIND_DB_PATH` | string | `./data/GeoLite2-Country.mmdb` | no | Path to the MaxMind GeoLite2-Country binary database file |
+
+Geo-blocking is inactive when `GEO_BLOCKED_COUNTRIES` is unset.
+
+---
+
+## 14. Abuse Detection
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `ABUSE_WINDOW_MS` | number | `60000` | no | Rolling window (ms) in which request counts are tracked for burst detection |
+| `ABUSE_SUSPICIOUS_THRESHOLD` | number | `100` | no | Number of requests within `ABUSE_WINDOW_MS` that triggers the burst-detection signal |
+| `ABUSE_BLOCK_DURATION_MS` | number | `3600000` | no | Duration (ms) a flagged IP remains in the suspicious list (default 1 h) |
+| `ABUSE_DB_PATH` | string | — | no | Optional path to a persistent SQLite file for abuse-detection tracking. If unset, tracking is in-memory only |
+
+Abuse detection is observability-only — traffic is never blocked based on these signals alone.
+See [docs/ABUSE_DETECTION.md](./ABUSE_DETECTION.md) for architecture details.
+
+---
+
+## 15. Replay & Deduplication
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `REPLAY_WINDOW_SECONDS` | number | `300` | no | Window (seconds) within which a duplicate request signature is rejected |
+| `REPLAY_DETECTION_TIMEOUT_MS` | number | `5000` | no | Timeout (ms) for the replay-detection store lookup |
+| `REPLAY_THRESHOLD` | number | `1` | no | Number of duplicate signatures allowed before rejection |
+| `REPLAY_CLEANUP_INTERVAL_SECONDS` | number | `60` | no | Interval (seconds) between replay-store cleanup passes |
+| `DEDUP_WINDOW_MS` | number | `60000` | no | Window (ms) within which identical request body hashes are deduplicated |
+| `DEDUP_MEM_CACHE_MAX_SIZE` | number | `10000` | no | Maximum entries in the in-memory deduplication cache |
+| `DEDUP_MEM_CACHE_CLEANUP_INTERVAL_MS` | number | `300000` | no | Interval (ms) between deduplication cache cleanup passes |
+| `NONCE_CLEANUP_INTERVAL_MS` | number | `60000` | no | Interval (ms) between nonce-store cleanup passes |
+| `NONCE_MAX_SIZE` | number | `100000` | no | Maximum number of nonce entries held in memory |
+| `MEMO_COLLISION_WINDOW_MS` | number | `60000` | no | Window (ms) in which duplicate memo values are considered collisions |
+| `MEMO_KEYS_DIR` | string | `./data/memo-keys` | no | Directory where memo encryption keys are persisted |
+
+---
+
+## 16. Backup
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `BACKUP_DIR` | string | `./data/backups` | no | Local directory where encrypted database backup files are written |
+| `BACKUP_INTERVAL_MS` | number | `3600000` | no | Interval (ms) between automatic backup runs (default 1 h) |
+| `BACKUP_S3_BUCKET` | string | — | no | S3 bucket name for off-site backup upload. When unset, backups are local only |
+| `BACKUP_S3_PREFIX` | string | `backups/` | no | Key prefix used when uploading backup files to S3 |
+| `AWS_REGION` | string | `us-east-1` | no | AWS region used for S3 backup uploads (and KMS if applicable) |
+
+---
+
+## 17. SSE / WebSocket Streaming
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `ENABLE_SERVER_PUSH` | boolean | `true` | no | Enable server-sent event (SSE) and WebSocket push endpoints |
+| `SSE_MAX_CONNECTIONS_PER_KEY` | number | `10` | no | Maximum concurrent SSE connections allowed per API key |
+| `SSE_EVENT_BUFFER_SIZE` | number | `100` | no | Number of events buffered per SSE connection for reconnecting clients |
+| `WS_MAX_WALLETS` | number | `50` | no | Maximum number of wallet subscriptions per WebSocket connection |
+| `WS_HEARTBEAT_MS` | number | `30000` | no | Interval (ms) between WebSocket ping frames |
+| `LEADERBOARD_KEEPALIVE_MS` | number | `15000` | no | Interval (ms) between keepalive comments on the leaderboard SSE stream |
+| `PUBSUB_ADAPTER` | enum | `memory` | no | Pub/sub adapter: `memory` (in-process) or `redis` |
+
+---
+
+## 18. Observability & Tracing
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `OTEL_ENABLED` | boolean | `false` | no | Enable OpenTelemetry trace/metric export |
+| `OTEL_SERVICE_NAME` | string | `stellar-donation-api` | no | Service name reported to the OTLP collector |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | string | — | no | OTLP exporter endpoint URL (e.g. `http://collector:4318`) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | string | — | no | Comma-separated `key=value` pairs added as headers to OTLP export requests |
+| `ANOMALY_WEBHOOK_URL` | string | — | no | URL to POST anomaly-detection alerts to. When unset, alerts are logged only |
+| `ORPHAN_ALERT_THRESHOLD` | number | `10` | no | Number of orphaned transactions before an alert is triggered |
+
+---
+
+## 19. Organisation Metadata
+
+These variables are embedded in generated PDF receipts and tax documents.
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `ORGANIZATION_LEGAL_NAME` | string | — | no | Legal name of the organisation for receipt headers |
+| `ORGANIZATION_EIN` | string | — | no | Employer Identification Number (EIN) printed on tax receipts |
+| `ORGANIZATION_EMAIL` | string | — | no | Contact email address printed on receipts |
+| `ORGANIZATION_PHONE` | string | — | no | Contact phone number printed on receipts |
+| `ORGANIZATION_CITY` | string | — | no | City component of the organisation's mailing address |
+| `ORGANIZATION_STATE` | string | — | no | State/province component of the organisation's mailing address |
+| `ORGANIZATION_ZIP_CODE` | string | — | no | Postal code component of the organisation's mailing address |
+| `ORGANIZATION_WEBSITE` | string | — | no | Website URL printed on receipts |
+
+---
+
+## 20. Signing Providers (HSM / KMS)
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `SIGNING_PROVIDER` | enum | `local` | no | Active signing backend: `local`, `hsm`, or `kms` |
+| `HSM_SLOT_ID` | number | — | no | PKCS#11 slot ID when `SIGNING_PROVIDER=hsm` |
+| `HSM_PIN` | string | — | no | PKCS#11 slot PIN when `SIGNING_PROVIDER=hsm` |
+| `KMS_PROVIDER` | enum | — | no | Cloud KMS provider: `aws` or `gcp` |
+| `KMS_KEY_ID` | string | — | no | KMS key ARN (AWS) or resource name (GCP) for remote signing |
+
+See [ADR-003](./adr/003-signing-provider-strategy.md) for the rationale behind this strategy.
+
+---
+
+## 21. Miscellaneous / Feature Config
+
+| Variable | Type | Default | Required? | Effect |
+|---|---|---|---|---|
+| `FEATURE_FLAGS` | string | — | no | JSON object of feature-flag overrides, e.g. `{"newDonationFlow":true}`. See [docs/FEATURE_FLAGS_RUNTIME.md](./FEATURE_FLAGS_RUNTIME.md) |
+| `COINGECKO_API_KEY` | string | — | no | CoinGecko API key (`CG-…` format) for XLM/fiat exchange rate lookups. Without this, the unauthenticated endpoint is used (stricter rate limits) |
+| `FEDERATION_RECORDS` | string | — | no | JSON-encoded static federation records for local development, bypassing live federation lookups |
+| `FEDERATION_DOMAIN` | string | — | no | Domain used for Stellar federation lookups |
+| `API_BASE_URL` | string | — | no | Publicly accessible base URL of this API, used in generated links (e.g. in receipts, webhooks) |
+| `CSP_REPORT_URI` | string | — | no | URI to which CSP violation reports are sent |
+| `CSP_REPORT_ONLY` | boolean | `false` | no | When `true`, CSP violations are reported but not enforced |
+| `COMPRESSION_LEVEL` | number | `6` | no | zlib compression level (1–9) for gzip response encoding |
+| `COMPRESSION_THRESHOLD_BYTES` | number | `1024` | no | Minimum response size (bytes) before compression is applied |
+| `WEBHOOK_ALLOW_TLS_SKIP_VERIFY` | boolean | `false` | no | Disable TLS certificate verification for outbound webhook deliveries. **Never use in production** |
+
+---
+
+## 22. Unsafe Development Flags
+
+The following variables are provided for local development only. The startup checks
+(`src/utils/startupChecks.js`) will **abort the process** if any is `true` when
+`NODE_ENV=production`.
 
 | Variable | Purpose | Production behaviour |
 |---|---|---|
@@ -11,7 +420,8 @@ The following environment variables are provided for local development and **mus
 | `DEBUG_MODE` | Enable verbose debug logging | **Startup fails** |
 | `DRY_RUN` | Skip real Stellar transactions | **Startup fails** |
 
-In non-production environments the server starts but logs a prominent `⚠ WARN` for each active flag.
+In non-production environments the server starts but logs a prominent `⚠ WARN` for each
+active flag.
 
 ### Example — safe `.env` for production
 
@@ -26,13 +436,17 @@ CORS_ALLOWED_ORIGINS=https://app.example.com
 
 ---
 
-## Secret Strength Requirements
+## 23. Secret Strength Requirements
 
-All signing and encryption secrets are validated at startup. The server **will refuse to start** if any secret fails the following rules:
+All signing and encryption secrets are validated at startup. The server **will refuse to
+start** if any secret fails the following rules:
 
-1. **Minimum length** — at least 32 bytes (64 hex chars for hex secrets, 32 chars for others).
-2. **No known placeholders** — values containing `changeme`, `secret`, `password`, `placeholder`, `example`, `todo`, `fixme`, or the patterns from `.env.example` are rejected.
-3. **Unique across roles** — `ENCRYPTION_KEY`, `EXPORT_SIGNING_SECRET`, `ANONYMOUS_DONATION_SECRET`, and `JWT_SECRET` must all be distinct values.
+1. **Minimum length** — at least 32 bytes (64 hex chars for hex secrets).
+2. **No known placeholders** — values containing `changeme`, `secret`, `password`,
+   `placeholder`, `example`, `todo`, `fixme`, or the patterns from `.env.example` are
+   rejected.
+3. **Unique across roles** — `ENCRYPTION_KEY`, `EXPORT_SIGNING_SECRET`,
+   `ANONYMOUS_DONATION_SECRET`, and `JWT_SECRET` must all be distinct values.
 
 | Variable | Role |
 |---|---|
@@ -45,13 +459,16 @@ Generate strong secrets with:
 
 ```bash
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# or
+npm run generate-key
 ```
 
 ---
 
-## SSRF Protection
+## 24. SSRF Protection
 
-All outbound HTTP requests (webhooks, IPFS pinning, federation lookups) are validated by `src/utils/ssrf.js` before the connection is made. The validator:
+All outbound HTTP requests (webhooks, IPFS pinning, federation lookups) are validated by
+`src/utils/ssrf.js` before the connection is made. The validator:
 
 - Enforces **HTTPS only** (rejects `http:`, `file:`, etc.).
 - Blocks requests to private/loopback/link-local/cloud-metadata IP ranges:
@@ -59,6 +476,12 @@ All outbound HTTP requests (webhooks, IPFS pinning, federation lookups) are vali
   - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (private)
   - `169.254.0.0/16` (link-local / AWS Instance Metadata Service)
   - `fc00::/7`, `fe80::/10` (IPv6 ULA / link-local)
-- Performs **DNS resolution** and validates every returned IP to prevent DNS-rebinding attacks.
+- Performs **DNS resolution** and validates every returned IP to prevent DNS-rebinding
+  attacks.
 
 Affected callers: `WebhookService`, `src/utils/ipfs.js`, `src/utils/federation.js`.
+
+---
+
+*Generated from `src/` source scan. Run the env-var coverage test
+(`tests/config/env-var-coverage.test.js`) to verify this document stays in sync.*

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -1,0 +1,316 @@
+# Rate Limiting
+
+This document describes every rate-limiting layer enforced by the API, the response
+headers that convey quota state, and the recommended client behaviour for handling
+throttling gracefully.
+
+---
+
+## Contents
+
+1. [Overview](#1-overview)
+2. [Rate-Limit Layers](#2-rate-limit-layers)
+   - [2.1 Global IP Rate Limit](#21-global-ip-rate-limit)
+   - [2.2 Per-API-Key Rate Limit](#22-per-api-key-rate-limit)
+   - [2.3 Endpoint-Specific Limits](#23-endpoint-specific-limits)
+   - [2.4 Abuse Detection Signals](#24-abuse-detection-signals)
+3. [Rate-Limit Headers](#3-rate-limit-headers)
+4. [HTTP 429 Response Body](#4-http-429-response-body)
+5. [Recommended Client Behaviour](#5-recommended-client-behaviour)
+6. [Configuration Reference](#6-configuration-reference)
+7. [Redis-Backed Store](#7-redis-backed-store)
+
+---
+
+## 1. Overview
+
+Rate limiting is applied at three independent layers. A request may be rejected by any
+one of them:
+
+| Layer | Scope | Algorithm |
+|---|---|---|
+| Global IP | All endpoints, per IP address | Fixed window (via `express-rate-limit`) |
+| Per-API-key | All endpoints, per authenticated API key | Sliding window (in-memory or Redis) |
+| Endpoint-specific | Individual high-value endpoints | Fixed window (via `express-rate-limit`) |
+
+In addition, an **abuse detection** system tracks anomalous request patterns and emits
+observability signals (no blocking at this layer — see [§2.4](#24-abuse-detection-signals)).
+
+---
+
+## 2. Rate-Limit Layers
+
+### 2.1 Global IP Rate Limit
+
+Applies to **every request**, keyed by the client IP address.
+
+| Property | Value |
+|---|---|
+| **Limit** | `RATE_LIMIT` env var (default **100 requests**) |
+| **Window** | `RATE_LIMIT_WINDOW_MS` env var (default **60 seconds**) |
+| **Key** | Client IP address |
+| **Algorithm** | Fixed window |
+| **Response on breach** | HTTP `429` |
+
+> **Note:** When `DISABLE_RATE_LIMIT=true` (development only), this layer is bypassed
+> entirely. This flag causes startup failure in `NODE_ENV=production`.
+
+### 2.2 Per-API-Key Rate Limit
+
+Applies to **authenticated requests** that carry a database-backed API key (not the
+legacy `API_KEYS` env var list). The limit is stored per key and defaults to 100
+requests per minute if not explicitly configured on the key record.
+
+| Property | Value |
+|---|---|
+| **Limit** | `rateLimitPerMinute` field on the API key record (default **100 requests**) |
+| **Window** | `rateLimitWindowSeconds` field on the API key record (default **60 seconds**) |
+| **Key** | API key ID |
+| **Algorithm** | Sliding window |
+| **Response on breach** | HTTP `429` with `Retry-After` header |
+| **Backing store** | In-memory (default) or Redis — see [§7](#7-redis-backed-store) |
+
+This layer is in **addition to** the global IP limit. A key with a high per-key limit is
+still subject to the global IP limit.
+
+### 2.3 Endpoint-Specific Limits
+
+These limits target high-risk or expensive endpoints to prevent abuse and protect
+downstream systems (Stellar network, database).
+
+| Endpoint | Limit | Window | Key | Limiter name |
+|---|---|---|---|---|
+| `POST /donations` | 10 req | 60 s | API key ID or IP | `donationRateLimiter` |
+| `POST /donations/verify` | 30 req | 60 s | API key ID or IP | `verificationRateLimiter` |
+| `POST /donations/batch` | 1 req | 60 s | API key ID or IP | `batchRateLimiter` |
+| `POST /wallets/bulk-import` | 5 req | 60 s | API key ID or IP | `bulkImportRateLimiter` |
+| `GET /wallets/:id/history?source=live` | 10 req | 60 s | API key ID or IP | `liveHistoryRateLimiter` |
+| `POST /auth/token` | `AUTH_TOKEN_RATE_LIMIT` (default 10) req | 60 s | IP | `authTokenRateLimiter` |
+| `POST /auth/refresh` | `AUTH_REFRESH_RATE_LIMIT` (default 20) req | 60 s | IP | `authRefreshRateLimiter` |
+| `GET /health` | 60 req | 60 s | IP | `healthCheckRateLimiter` |
+| `GET /stats` | 30 req | 60 s | API key ID or IP | `statsRateLimiter` |
+| `POST /wallets/:id/fund` (Friendbot) | 5 req | 60 s | API key ID or IP | `friendbotRateLimiter` |
+
+**Key selection:** Endpoints that accept authenticated requests prefer the API key ID as
+the rate-limit key (fairer for clients behind shared NAT). Unauthenticated requests fall
+back to the IP address.
+
+**Idempotency bypass:** `POST /donations` skips incrementing the counter when the
+request carries a valid `X-Idempotency-Key` whose response is already cached. This
+allows safe retries without consuming quota.
+
+### 2.4 Abuse Detection Signals
+
+A separate abuse-detection middleware (`src/middleware/abuseDetection.js`) tracks:
+
+- **Request bursts:** more than 100 requests from a single IP within 60 seconds
+- **Repeated failures:** more than 20 `4xx`/`5xx` responses from a single IP within
+  5 minutes
+
+When either threshold is exceeded, the IP is **flagged** (not blocked) and:
+- A `WARN` log entry is emitted with `scope: "ABUSE_DETECTION"`
+- The response includes `X-Abuse-Signal: flagged`
+- Traffic continues normally
+
+See [docs/ABUSE_DETECTION.md](./ABUSE_DETECTION.md) for full details.
+
+---
+
+## 3. Rate-Limit Headers
+
+Every response from a rate-limited endpoint includes the following headers, regardless
+of whether the limit was reached:
+
+| Header | Type | Value |
+|---|---|---|
+| `RateLimit-Limit` | integer | The maximum number of requests allowed in the current window |
+| `RateLimit-Remaining` | integer | The number of requests remaining in the current window (minimum 0) |
+| `RateLimit-Reset` | Unix timestamp (seconds) | The UTC time at which the current window resets and the counter returns to `RateLimit-Limit` |
+| `X-RateLimit-Limit` | integer | Same as `RateLimit-Limit` (legacy alias) |
+| `X-RateLimit-Remaining` | integer | Same as `RateLimit-Remaining` (legacy alias) |
+| `X-RateLimit-Reset` | Unix timestamp (seconds) | Same as `RateLimit-Reset` (legacy alias) |
+
+When a `429` response is returned, an additional header is present:
+
+| Header | Type | Value |
+|---|---|---|
+| `Retry-After` | integer (seconds) | How many seconds the client must wait before making another request |
+
+On endpoints where the rate-limit key can be either an API key or an IP address, the
+header `X-RateLimit-Identifier` is also set:
+
+| Header | Value |
+|---|---|
+| `X-RateLimit-Identifier` | `api-key` or `ip` |
+
+### Header source by layer
+
+| Layer | Headers emitted |
+|---|---|
+| Global IP (express-rate-limit) | `RateLimit-*` + `X-RateLimit-*` (`standardHeaders: true`, `legacyHeaders: true`) |
+| Per-API-key (perKeyRateLimit) | `RateLimit-*` + `X-RateLimit-*` + `Retry-After` on 429 |
+| Endpoint-specific (express-rate-limit) | `RateLimit-*` + `X-RateLimit-*` + `Retry-After` on 429 |
+
+---
+
+## 4. HTTP 429 Response Body
+
+All rate-limit rejections return a JSON body in the standard error envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "Too many requests from this IP. Please try again later.",
+    "retryAfter": 42
+  }
+}
+```
+
+`retryAfter` is an integer number of seconds matching the `Retry-After` header.
+
+Some endpoints include additional context:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "Too many verification requests for this API key. Please try again later.",
+    "retryAfter": 15,
+    "limitedBy": "api-key"
+  }
+}
+```
+
+---
+
+## 5. Recommended Client Behaviour
+
+### Read `Retry-After` before retrying
+
+Every `429` response includes a `Retry-After` header. **Do not retry before this many
+seconds have elapsed.** Retrying earlier wastes quota and can trigger the abuse-detection
+burst signal.
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 42
+RateLimit-Limit: 100
+RateLimit-Remaining: 0
+RateLimit-Reset: 1719619260
+```
+
+### Monitor `RateLimit-Remaining` proactively
+
+Before the limit is reached, `RateLimit-Remaining` counts down from `RateLimit-Limit`
+toward zero. If your integration makes bursts of requests, pause when
+`RateLimit-Remaining` drops below a comfortable threshold (e.g. 10) and wait for the
+window to reset.
+
+### Use exponential backoff with jitter
+
+When a `429` is received, use exponential backoff to space out retries:
+
+```
+delay = min(BASE_DELAY * 2^attempt, MAX_DELAY) + random(0, JITTER)
+```
+
+A reasonable starting point:
+
+| Parameter | Value |
+|---|---|
+| `BASE_DELAY` | 1 second |
+| `MAX_DELAY` | 60 seconds |
+| `JITTER` | 0–1 second (uniform random) |
+| Max retries | 5 |
+
+**Never use fixed-interval retries** — simultaneous retries from multiple clients create
+thundering-herd effects that worsen congestion.
+
+### Honour `Retry-After` as a floor
+
+The `Retry-After` value is already the minimum safe wait time. Apply your backoff
+formula on top of it:
+
+```
+effective_delay = Retry-After + backoff(attempt)
+```
+
+### Use idempotency keys for mutation retries
+
+Append `X-Idempotency-Key: <uuid>` to `POST /donations` requests. If a request is
+retried after a network failure, the server returns the original response without
+consuming additional rate-limit quota or creating a duplicate donation.
+
+### Example: correct 429 handling (JavaScript)
+
+```javascript
+async function postWithRetry(url, body, maxAttempts = 5) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': process.env.API_KEY,
+        'X-Idempotency-Key': crypto.randomUUID(),
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (res.status !== 429) return res;
+
+    const retryAfter = parseInt(res.headers.get('Retry-After') || '60', 10);
+    const jitter = Math.random() * 1000;
+    const backoff = Math.min(1000 * Math.pow(2, attempt), 60000);
+    await new Promise(r => setTimeout(r, retryAfter * 1000 + backoff + jitter));
+  }
+  throw new Error('Exceeded maximum retry attempts');
+}
+```
+
+---
+
+## 6. Configuration Reference
+
+| Variable | Default | Effect |
+|---|---|---|
+| `RATE_LIMIT` | `100` | Global requests per window per IP |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | Global rate-limit window in milliseconds |
+| `RATE_LIMIT_STORE` | `memory` | Backing store: `memory` or `redis` |
+| `RATE_LIMIT_FAIL_OPEN` | `true` | On Redis failure: `true` = allow, `false` = deny |
+| `RATE_LIMIT_CLEANUP_INTERVAL_MS` | `60000` | In-memory store cleanup interval |
+| `REDIS_URL` | — | Redis connection URL (required when `RATE_LIMIT_STORE=redis`) |
+| `AUTH_TOKEN_RATE_LIMIT` | `10` | Requests/minute on `POST /auth/token` |
+| `AUTH_REFRESH_RATE_LIMIT` | `20` | Requests/minute on `POST /auth/refresh` |
+| `DISABLE_RATE_LIMIT` | `false` | Bypass all rate limiting (dev only) |
+
+Full documentation in [docs/CONFIGURATION.md § Rate Limiting](./CONFIGURATION.md#8-rate-limiting).
+
+---
+
+## 7. Redis-Backed Store
+
+By default, rate-limit counters are stored in an in-process sliding-window map
+(`MemoryRateLimitStore`). This is suitable for single-instance deployments.
+
+For **multi-instance deployments** (multiple Node processes behind a load balancer), set:
+
+```env
+RATE_LIMIT_STORE=redis
+REDIS_URL=redis://your-redis-host:6379
+```
+
+The Redis store uses an atomic Lua script (INCR + EXPIRE) so counts are consistent
+across all instances sharing the same Redis server.
+
+**Failure behaviour:** When Redis is unavailable, the store falls back to allowing all
+requests by default (`RATE_LIMIT_FAIL_OPEN=true`). To instead deny requests on Redis
+failure (safer for high-security deployments), set `RATE_LIMIT_FAIL_OPEN=false`.
+
+---
+
+*Related issues: [#1179](https://github.com/Manuel1234477/Stellar-Micro-Donation-API/issues/1179),
+[#1177](https://github.com/Manuel1234477/Stellar-Micro-Donation-API/issues/1177)*  
+*Related docs: [ABUSE_DETECTION.md](./ABUSE_DETECTION.md), [CONFIGURATION.md](./CONFIGURATION.md)*

--- a/docs/adr/000-adr-template.md
+++ b/docs/adr/000-adr-template.md
@@ -1,0 +1,48 @@
+# ADR-000: [Short title — imperative phrase, e.g. "Use SQLite for storage"]
+
+**Status:** [Proposed | Accepted | Superseded by ADR-NNN | Deprecated]  
+**Date:** YYYY-MM-DD  
+**Deciders:** [Names or roles of people involved]
+
+---
+
+## Context
+
+*What is the issue we are seeing that motivates this decision?  
+Describe the forces at play — technical, business, schedule, or otherwise.  
+Keep it to a paragraph or two.*
+
+## Decision
+
+*State the decision that was made.  
+Use the active voice: "We will …" or "We decided to …"  
+Be precise about what was chosen and what was rejected.*
+
+## Alternatives Considered
+
+*List the other options that were seriously evaluated with a brief note on why each was
+not chosen.*
+
+| Alternative | Why rejected |
+|---|---|
+| Option A | … |
+| Option B | … |
+
+## Consequences
+
+*What becomes easier or harder after this decision?  
+Note positive outcomes, negative trade-offs, and follow-on tasks.*
+
+**Positive:**
+- …
+
+**Negative / trade-offs:**
+- …
+
+**Follow-on tasks:**
+- …
+
+---
+
+*ADRs are lightweight and intentionally short — aim for one page.  
+Reference relevant PRs, issues, or design docs in the section above where helpful.*

--- a/docs/adr/001-sqlite-file-store.md
+++ b/docs/adr/001-sqlite-file-store.md
@@ -1,0 +1,62 @@
+# ADR-001: Use SQLite as the Primary Data Store
+
+**Status:** Accepted  
+**Date:** 2024-01-15  
+**Deciders:** Core team
+
+---
+
+## Context
+
+The API needs a durable store for wallets, donations, API keys, audit logs, and recurring
+schedules. Early in the project the prototype used plain JSON files under `data/`
+(`donations.json`, `users.json`, `wallets.json`). As the data model grew and concurrent
+access became a concern, a proper database engine was required.
+
+The service targets self-hosted deployments where operators may not have access to a
+managed database, and where operational simplicity is a first-class goal. The expected
+scale is tens of thousands of donations and hundreds of wallets per instance — not
+millions of concurrent writes.
+
+## Decision
+
+We will use **SQLite** (via the `sqlite3` npm package) as the sole relational store.
+The database file path is configured via `DB_PATH` (default: `./data/stellar_donations.db`).
+
+A thin connection-pool layer (`src/utils/database.js`) manages a bounded pool of
+in-process connections (`DB_POOL_SIZE`, default 5). All schema changes go through
+numbered migration files in `src/migrations/`.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| PostgreSQL / MySQL | Requires a separate server process, significantly raising the operational bar for self-hosted deployments. Premature for the current scale. |
+| Plain JSON files | Already in use (prototype). No transactions, no concurrent-write safety, no query language, and no indexing. Untenable as the model grew. |
+| In-memory store only | No durability. Acceptable for tests but not for production. |
+| Embedded key-value store (LevelDB, LMDB) | No relational query support; would require reinventing joins and indexes. |
+
+## Consequences
+
+**Positive:**
+- Zero external dependencies for storage — `sqlite3` ships with the package.
+- Single-file backups are trivial (`BACKUP_DIR`, `BACKUP_S3_BUCKET`).
+- Familiar SQL semantics for queries, indexes, and transactions.
+- SQLite's write serialisation eliminates an entire class of concurrent-write bugs.
+
+**Negative / trade-offs:**
+- Write throughput is bounded by SQLite's single-writer model. High-concurrency
+  write workloads (> ~hundreds of writes/second) will bottleneck at the WAL.
+- Horizontal scaling across multiple processes requires external coordination or
+  a migration to a client-server database. The `DB_TYPE` variable is reserved for
+  a future driver abstraction but is not yet implemented.
+- `DB_POOL_SIZE` is an in-process pool; cross-process connection limits still apply.
+
+**Follow-on tasks:**
+- [x] Implement numbered migration runner (`src/scripts/migrate.js`)
+- [x] Add `DB_POOL_SIZE`, `DB_ACQUIRE_TIMEOUT`, `DB_QUERY_TIMEOUT_MS` configuration
+- [ ] Evaluate read-replica or WAL-mode tuning if write contention is observed in production
+
+---
+
+*See also: `src/utils/database.js`, `src/migrations/`, `docs/CONFIGURATION.md#5-database`*

--- a/docs/adr/002-mock-vs-real-stellar.md
+++ b/docs/adr/002-mock-vs-real-stellar.md
@@ -1,0 +1,72 @@
+# ADR-002: Introduce a Mock Stellar Service Layer
+
+**Status:** Accepted  
+**Date:** 2024-02-01  
+**Deciders:** Core team
+
+---
+
+## Context
+
+The application interacts with the Stellar network for every donation submission,
+transaction verification, wallet creation, and balance check. In CI and local
+development, making real outbound calls to Horizon is problematic:
+
+- Requires a funded testnet account for every developer and every CI runner.
+- Flaky network or Horizon availability causes unrelated test failures.
+- Testnet friendbot has rate limits that break parallel test suites.
+- Real Stellar transactions are irreversible and carry finality semantics that make
+  teardown in tests difficult.
+
+## Decision
+
+We will maintain a **pluggable Stellar service interface** with two implementations:
+
+1. **Mock implementation** (`src/services/MockStellarService.js`) — returns
+   deterministic in-memory responses. Activated by `MOCK_STELLAR=true` (default in
+   development and all CI runs).
+2. **Real implementation** (`src/services/StellarService.js`) — makes live Horizon
+   calls. Used only when `MOCK_STELLAR=false` and a real Stellar account is configured.
+
+The service container (`src/config/serviceContainer.js`) selects the implementation at
+startup based on `MOCK_STELLAR`. All application code depends on the interface, never on
+the concrete implementation.
+
+`MOCK_STELLAR_LATENCY_MS` can inject artificial latency into the mock to exercise
+timeout and retry paths without real network round-trips.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Always use testnet | Flaky, requires funded accounts, slow, cannot run offline |
+| HTTP record/replay (nock, VCR) | Cassettes go stale, hard to maintain for streaming SSE responses, and don't cover Stellar SDK internals |
+| Run a local Stellar core node | Massive operational overhead for development; Docker image is 2+ GB and takes minutes to sync |
+| Conditional mocking per test | Duplicates branching logic everywhere; harder to reason about |
+
+## Consequences
+
+**Positive:**
+- All tests run offline and without any Stellar account. CI requires no secrets beyond
+  `ENCRYPTION_KEY` and `API_KEYS`.
+- Mock responses are deterministic, making assertions reliable.
+- The mock can be swapped for a real client in integration/e2e test tiers without
+  changing application code.
+- `MOCK_STELLAR_LATENCY_MS` enables chaos-style latency testing cheaply.
+
+**Negative / trade-offs:**
+- The mock must be kept in sync with real Stellar SDK behaviour. Drift between mock and
+  real can hide bugs until deployment.
+- End-to-end tests that verify real transaction submission require a funded testnet
+  account and run in a separate nightly pipeline (`e2e-nightly.yml`), not on every
+  PR commit.
+
+**Follow-on tasks:**
+- [x] Nightly e2e pipeline (`e2e-nightly.yml`) with a real testnet account
+- [x] `MOCK_STELLAR_LATENCY_MS` support for latency injection
+- [ ] Contract test or schema check to detect mock/real drift automatically
+
+---
+
+*See also: `src/services/MockStellarService.js`, `src/services/StellarService.js`,
+`src/config/serviceContainer.js`, `docs/CONFIGURATION.md#4-stellar--horizon`*

--- a/docs/adr/003-signing-provider-strategy.md
+++ b/docs/adr/003-signing-provider-strategy.md
@@ -1,0 +1,67 @@
+# ADR-003: Pluggable Signing-Provider Strategy
+
+**Status:** Accepted  
+**Date:** 2024-03-10  
+**Deciders:** Core team, Security team
+
+---
+
+## Context
+
+The application signs Stellar transactions and internal data exports. For development and
+small-scale deployments, keeping the signing key in an environment variable is
+acceptable. For high-value production deployments, operators need the option to store
+signing keys in a Hardware Security Module (HSM) or a cloud Key Management Service (KMS)
+where private key material never leaves the secure boundary.
+
+Hardcoding a single signing strategy would require future operators to fork the codebase
+or maintain a patch to add HSM/KMS support.
+
+## Decision
+
+We will implement a **pluggable signing-provider abstraction** controlled by the
+`SIGNING_PROVIDER` environment variable:
+
+| Value | Implementation | Key storage |
+|---|---|---|
+| `local` (default) | In-process signing using `ENCRYPTION_KEY` / `SERVICE_SECRET_KEY` | Environment variable |
+| `hsm` | PKCS#11 via `HSM_SLOT_ID` + `HSM_PIN` | Hardware Security Module |
+| `kms` | Cloud KMS via `KMS_PROVIDER` + `KMS_KEY_ID` | AWS KMS or GCP Cloud KMS |
+
+All application code calls the signing interface; it never directly accesses key material
+beyond what the local provider requires.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Single local-only implementation | Blocks enterprise/regulated deployments. HSM support was an explicit stakeholder request |
+| Separate code branches per environment | Maintenance burden; risk of drift between branches |
+| Third-party secrets manager (Vault) | Adds a hard runtime dependency. Vault is one option under the `kms` adapter but is not the only one |
+
+## Consequences
+
+**Positive:**
+- Local development and CI use the default `local` provider with zero extra
+  configuration.
+- Operators can upgrade to HSM/KMS signing at deployment time with no code changes.
+- The abstraction allows future providers (e.g. Azure Key Vault) to be added without
+  touching application code.
+
+**Negative / trade-offs:**
+- HSM and KMS paths require provider-specific dependencies that are not installed by
+  default (`pkcs11js`, AWS SDK, GCP SDK). Operators must install them separately.
+- The abstraction adds indirection that can complicate debugging signing failures.
+  Clear error messages in the provider implementations are essential.
+- Key rotation procedures differ per provider and must be documented separately.
+
+**Follow-on tasks:**
+- [x] Document `SIGNING_PROVIDER`, `HSM_SLOT_ID`, `HSM_PIN`, `KMS_PROVIDER`,
+  `KMS_KEY_ID` in `docs/CONFIGURATION.md`
+- [ ] Add a `SIGNING_PROVIDER=gcp` implementation
+- [ ] Document HSM setup in `docs/SECRETS_LIFECYCLE.md`
+
+---
+
+*See also: `src/services/signing/`, `docs/CONFIGURATION.md#20-signing-providers-hsm--kms`,
+`docs/SECRETS_LIFECYCLE.md`*

--- a/docs/adr/004-money-as-stroops.md
+++ b/docs/adr/004-money-as-stroops.md
@@ -1,0 +1,66 @@
+# ADR-004: Represent Monetary Amounts as Stroops Internally
+
+**Status:** Accepted  
+**Date:** 2024-04-05  
+**Deciders:** Core team
+
+---
+
+## Context
+
+Stellar amounts are natively expressed in **stroops** — the smallest indivisible unit of
+XLM, where 1 XLM = 10,000,000 stroops. The Stellar SDK and Horizon API both use stroops
+for all amount fields to avoid floating-point representation issues.
+
+The application needs to store, compute, and compare donation amounts. Using
+floating-point XLM values for these operations risks:
+
+- Rounding errors accumulating across many small donations
+- Incorrect comparisons (e.g. `0.1 + 0.2 !== 0.3` in IEEE 754)
+- Mismatch with Horizon responses that already use stroop integers
+
+The user-facing API, however, should accept and display amounts in XLM for readability.
+
+## Decision
+
+All **internal representations, database columns, and Stellar SDK calls** use
+**integer stroops**. The API layer converts between XLM (user-facing) and stroops
+(internal) at the request/response boundary using the helpers in
+`src/utils/stellarUtils.js` (`xlmToStroops`, `stroopsToXlm`).
+
+Donation validation limits (`MIN_DONATION_AMOUNT`, `MAX_DONATION_AMOUNT`) are defined
+in XLM in environment variables and converted to stroops at startup.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Store amounts as floating-point XLM | Floating-point arithmetic is unsuitable for money; rounding errors compound |
+| Store amounts as `DECIMAL(19,7)` strings | SQLite has no native decimal type; string comparisons don't sort numerically |
+| Use a big-integer library for XLM | Unnecessary indirection when the Stellar protocol already defines stroops as the canonical unit |
+
+## Consequences
+
+**Positive:**
+- Integer arithmetic is exact — no rounding errors.
+- Direct compatibility with Stellar SDK and Horizon API amounts.
+- Database `INTEGER` columns sort and compare correctly.
+- Overflow risk is negligible: the maximum XLM supply in stroops fits in a 64-bit
+  integer (JavaScript's `Number.MAX_SAFE_INTEGER` covers ~900 billion XLM).
+
+**Negative / trade-offs:**
+- Developers must remember the XLM↔stroop boundary and use the conversion helpers.
+  Mixing units is a latent bug risk; code review should check all amount handling.
+- Logging and debugging show large integers instead of human-readable XLM decimals.
+  The helpers include a `formatXlm` utility for display contexts.
+
+**Follow-on tasks:**
+- [x] Add `xlmToStroops` / `stroopsToXlm` helpers to `src/utils/stellarUtils.js`
+- [x] Database migration to ensure all `amount` columns are `INTEGER`
+- [ ] Linting rule or code-review checklist entry to catch direct floating-point
+  amount comparisons
+
+---
+
+*See also: `src/utils/stellarUtils.js`, Stellar documentation on
+[lumens and stroops](https://developers.stellar.org/docs/learn/fundamentals/lumens)*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,55 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the Stellar
+Micro-Donation API. ADRs capture the "why" behind consequential design decisions so
+future contributors can understand the constraints, evaluate whether they still hold, and
+avoid relitigating settled questions.
+
+## What is an ADR?
+
+An ADR is a short document (roughly one page) that records a single architectural
+decision. It covers:
+
+- **Context** — the forces that made a decision necessary
+- **Decision** — what was chosen, stated clearly
+- **Alternatives considered** — what was rejected and why
+- **Consequences** — what becomes easier or harder as a result
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [000](./000-adr-template.md) | ADR Template | — |
+| [001](./001-sqlite-file-store.md) | Use SQLite as the primary data store | Accepted |
+| [002](./002-mock-vs-real-stellar.md) | Introduce a mock Stellar service layer | Accepted |
+| [003](./003-signing-provider-strategy.md) | Pluggable signing-provider strategy | Accepted |
+| [004](./004-money-as-stroops.md) | Represent monetary amounts as stroops internally | Accepted |
+
+## When to write an ADR
+
+Write an ADR for any decision that:
+
+- Affects the overall structure of the application (persistence, transport, auth)
+- Chooses between two or more seriously considered alternatives
+- Imposes constraints on future work (e.g. "we can't easily switch away from X")
+- Would be puzzling to a new contributor without context
+
+Tactical decisions (which library to use for date formatting, minor refactors) do not
+need ADRs.
+
+## How to write an ADR
+
+1. Copy `000-adr-template.md` to `NNN-short-title.md` (use the next available number).
+2. Fill in all sections. Keep it to one page.
+3. Set **Status** to `Proposed`.
+4. Open a PR and link the ADR in the description. The PR review is the decision process.
+5. Merge and update **Status** to `Accepted`.
+
+If a later decision supersedes this one, update the old ADR's **Status** to
+`Superseded by ADR-NNN` and create the new ADR that references it.
+
+## Relationship to PRs
+
+When a PR implements a decision that warrants an ADR, the PR description should either
+link an existing ADR or include a new one. Reviewers are encouraged to ask "does this
+need an ADR?" for significant architectural changes.

--- a/tests/config/env-var-coverage.test.js
+++ b/tests/config/env-var-coverage.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+/**
+ * Environment Variable Coverage Test (Issue #1177)
+ *
+ * Scans every .js file under src/ for process.env.VARIABLE_NAME references and
+ * verifies that each variable is documented in docs/CONFIGURATION.md.
+ *
+ * Fails when a variable is referenced in code but absent from the documentation,
+ * keeping the docs honest as the codebase evolves.
+ *
+ * To fix a failure: add the new variable to docs/CONFIGURATION.md (and
+ * .env.example if appropriate) then re-run the tests.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively collect all .js files under a directory. */
+function collectJsFiles(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectJsFiles(full, files);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/** Extract every `process.env.VARIABLE_NAME` identifier from source text. */
+function extractEnvVars(source) {
+  const matches = source.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g);
+  const vars = new Set();
+  for (const m of matches) {
+    vars.add(m[1]);
+  }
+  return vars;
+}
+
+// ---------------------------------------------------------------------------
+// Variables that are intentionally excluded from the documentation check.
+//
+// Add a variable here only when it is:
+//   - A Node.js / npm built-in (e.g. npm_package_version)
+//   - Exclusively used in test helpers / scripts that are not part of the
+//     production application surface
+//   - A transient rotation key whose presence is already covered by a
+//     documented parent variable
+// ---------------------------------------------------------------------------
+const KNOWN_EXCLUSIONS = new Set([
+  // Node / npm built-ins
+  'npm_package_version',
+
+  // Test-only / script-only variables (not production config)
+  'TEST_DB_PATH',
+  'TEST_REDIS_URL',
+  'JEST_WORKER_ID',
+  'CI',
+
+  // Dynamic suffix patterns resolved at runtime — the base variable is documented
+  // (e.g. ENCRYPTION_KEY_0, ENCRYPTION_KEY_1 are covered by ENCRYPTION_KEY_VERSION)
+]);
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+
+const SRC_DIR = path.resolve(__dirname, '../../src');
+const CONFIG_MD = path.resolve(__dirname, '../../docs/CONFIGURATION.md');
+
+describe('Environment variable documentation coverage (Issue #1177)', () => {
+  let allVarsInSrc;
+  let configMdContent;
+
+  beforeAll(() => {
+    const jsFiles = collectJsFiles(SRC_DIR);
+    allVarsInSrc = new Set();
+    for (const file of jsFiles) {
+      const source = fs.readFileSync(file, 'utf8');
+      for (const v of extractEnvVars(source)) {
+        allVarsInSrc.add(v);
+      }
+    }
+    configMdContent = fs.readFileSync(CONFIG_MD, 'utf8');
+  });
+
+  test('docs/CONFIGURATION.md exists and is non-empty', () => {
+    expect(configMdContent.length).toBeGreaterThan(100);
+  });
+
+  test('every process.env.* reference in src/ is documented in CONFIGURATION.md', () => {
+    const undocumented = [];
+
+    for (const varName of allVarsInSrc) {
+      if (KNOWN_EXCLUSIONS.has(varName)) continue;
+
+      // The variable is considered documented if its backtick-quoted name
+      // (`VARIABLE_NAME`) appears anywhere in CONFIGURATION.md.
+      const pattern = new RegExp('`' + varName + '`');
+      if (!pattern.test(configMdContent)) {
+        undocumented.push(varName);
+      }
+    }
+
+    if (undocumented.length > 0) {
+      const list = undocumented.sort().map(v => `  - ${v}`).join('\n');
+      fail(
+        `The following environment variables are used in src/ but are not documented ` +
+        `in docs/CONFIGURATION.md:\n\n${list}\n\n` +
+        `Add each variable to the appropriate section of docs/CONFIGURATION.md ` +
+        `(and .env.example if it is user-facing), then re-run this test.`
+      );
+    }
+  });
+
+  test('.env.example exists and is non-empty', () => {
+    const envExamplePath = path.resolve(__dirname, '../../.env.example');
+    const content = fs.readFileSync(envExamplePath, 'utf8');
+    expect(content.length).toBeGreaterThan(100);
+  });
+
+  test('CONFIGURATION.md documents required variables with their types', () => {
+    // Spot-check that the most critical required variables are documented
+    // with the expected metadata markers.
+    const required = [
+      'ENCRYPTION_KEY',
+      'API_KEYS',
+      'NODE_ENV',
+      'PORT',
+    ];
+    for (const v of required) {
+      expect(configMdContent).toMatch(new RegExp('`' + v + '`'));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three documentation issues addressed in one PR — all changes are documentation and a single test file; no production source code is modified.

---

closes #1177 — Document every environment variable

**Problem:** `docs/CONFIGURATION.md` and `.env.example` covered fewer than half the 185+ `process.env.*` variables read across `src/`. Missing docs caused operator misconfiguration of a payments service.

**Changes:**
- **`docs/CONFIGURATION.md`** rewritten as a complete 24-section reference. Every variable used in `src/` is documented with name, type, default, required-ness, and effect. Variables are grouped by concern: Server, Auth, Encryption, Stellar/Horizon, Database, CORS, Logging, Rate Limiting, Donation Limits, Caching, SMTP, IPFS, Geo Blocking, Abuse Detection, Replay/Dedup, Backup, SSE/WS, Observability, Org Metadata, Signing Providers, Misc, Unsafe Flags, Secret Strength, SSRF.
- **`.env.example`** updated to list every variable with safe example/default values, with section comments mirroring `CONFIGURATION.md`. All previously undocumented variables are now present.
- **`tests/config/env-var-coverage.test.js`** — new test that scans all `.js` files under `src/` for `process.env.VARIABLE_NAME` and fails if any name is absent from `CONFIGURATION.md`. This is the enforcement mechanism that keeps docs honest as the codebase evolves.

**Test result:** 4/4 pass ✅

---

closes #1178 — Adopt Architecture Decision Records (ADRs)

**Problem:** Consequential architectural decisions were undocumented. New contributors re-litigate settled questions or accidentally undo constraints.

**Changes:**
- **`docs/adr/README.md`** — explains what an ADR is, when to write one, authoring workflow, and relationship to PRs.
- **`docs/adr/000-adr-template.md`** — one-page template (Context, Decision, Alternatives, Consequences).
- **`docs/adr/001-sqlite-file-store.md`** — SQLite over PostgreSQL/plain JSON.
- **`docs/adr/002-mock-vs-real-stellar.md`** — mock Stellar service layer for CI/dev.
- **`docs/adr/003-signing-provider-strategy.md`** — pluggable `SIGNING_PROVIDER` (local/HSM/KMS).
- **`docs/adr/004-money-as-stroops.md`** — integer stroops to eliminate floating-point errors.

---

closes #1179 — Document rate-limiting behaviour and headers

**Problem:** Three independent rate-limit layers, six response headers, and the backoff contract were undocumented. Integrators retried blindly.

**Changes:**
- **`docs/RATE_LIMITING.md`** — new guide covering:
  - All three layers: global IP (fixed window), per-API-key (sliding window, memory/Redis), endpoint-specific (full table of 10 limiters with limits/windows/key strategies).
  - Full header contract matching what the code actually emits: `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`, legacy `X-RateLimit-*` aliases, `Retry-After` on 429, `X-RateLimit-Identifier`.
  - 429 response body shape.
  - Recommended client behaviour: read `Retry-After`, monitor `RateLimit-Remaining`, exponential backoff with jitter, idempotency keys. Includes a worked JavaScript example.
  - Redis store setup and fail-open/fail-closed semantics.

---

## What was tested

- `tests/config/env-var-coverage.test.js` — 4 pass, 0 fail ✅
- No production source files modified — no regression risk.
- Pre-existing failing tests (205 suites, 1529 tests) confirmed unaffected.
