### PR TITLE
Tune and document the Horizon connection pool

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -62,3 +62,75 @@ All outbound HTTP requests (webhooks, IPFS pinning, federation lookups) are vali
 - Performs **DNS resolution** and validates every returned IP to prevent DNS-rebinding attacks.
 
 Affected callers: `WebhookService`, `src/utils/ipfs.js`, `src/utils/federation.js`.
+
+---
+
+## Horizon Connection Pool Sizing
+
+`StellarService` round-robins Horizon calls across a small pool of `Horizon.Server`
+instances (`src/services/HorizonPool.js`) so that a single misbehaving connection
+doesn't serialize every Stellar call behind it. Pool behaviour is controlled by:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HORIZON_POOL_SIZE` | `3` (capped at `10`) | Number of `Horizon.Server` instances per process |
+| `HORIZON_POOL_COOLDOWN_MS` | `30000` | How long a member that hit a transient network error stays out of rotation before a health-check re-admits it |
+
+### Why pool size matters
+
+- **Too small** — every retry/backoff on a failing member serializes calls onto
+  the remaining members, increasing p95/p99 latency under load and bringing
+  the failing member back into rotation (via cooldown) before traffic has
+  recovered.
+- **Too large** — `HORIZON_POOL_SIZE` is *per process*. The number that matters
+  for rate-limit purposes is `HORIZON_POOL_SIZE × number_of_instances`. The
+  public Horizon fleet (`horizon.stellar.org` / `horizon-testnet.stellar.org`)
+  rate-limits per source IP; a self-hosted Horizon enforces whatever limit
+  operators configure. Sizing the pool without accounting for instance count
+  is the single most common way to get an entire fleet throttled at once.
+
+### Sizing guidance
+
+1. Start from your Horizon rate limit (requests/second) for the IP(s) your
+   fleet egresses from.
+2. Decide your target fleet-wide concurrent-request budget, leaving headroom
+   (e.g. 70-80% of the hard limit) for retries and bursts.
+3. `HORIZON_POOL_SIZE ≈ target_budget / number_of_instances`. Round down —
+   it is always safer to under-provision a pool (callers wait briefly via
+   round-robin reuse) than to over-provision and trip the shared rate limit.
+4. Re-check the math whenever you change instance count (e.g. autoscaling)
+   — the pool size is per-instance and does not adjust itself.
+5. `HORIZON_POOL_COOLDOWN_MS` should be long enough that a transient Horizon
+   blip doesn't flap a member in and out of rotation, but short enough that a
+   recovered Horizon node isn't left idle for minutes. 30s (the default) is a
+   reasonable starting point; raise it if `horizon_pool_cooldown_events_total`
+   shows members flapping repeatedly.
+
+### Observability
+
+Pool health is exposed via Prometheus metrics (`src/utils/metrics.js`,
+scraped at `/metrics`):
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `horizon_pool_size` | Gauge | Configured pool size |
+| `horizon_pool_healthy_count` | Gauge | Members currently in rotation |
+| `horizon_pool_unhealthy_count` | Gauge | Members currently cooling down |
+| `horizon_pool_cooldown_events_total` | Counter | Times a member was marked unhealthy after a transient failure |
+| `horizon_pool_recovery_events_total` | Counter | Times a member was re-admitted after cooldown |
+| `horizon_pool_acquire_duration_seconds` | Histogram | Time spent in `getServer()` acquiring a pool member |
+
+A sustained rise in `horizon_pool_unhealthy_count` or a high rate of
+`horizon_pool_cooldown_events_total` indicates the pool is undersized or
+Horizon itself is degraded — both are strong signals to revisit the sizing
+math above before tripping the fleet-wide rate limit.
+
+### Retry / circuit-breaker integration
+
+Cooldown is already tied into the unified retry policy: `StellarService._executeWithRetry`
+(`src/services/StellarService.js`) wraps every Horizon call in the shared
+circuit breaker, and on a transient network error it calls
+`HorizonPool.markUnhealthy()` for the specific member that failed *before*
+retrying on the next pool member. This means a single bad connection is
+isolated within the same retry attempt rather than waiting for a future
+request to discover it.

--- a/src/services/HorizonPool.js
+++ b/src/services/HorizonPool.js
@@ -9,6 +9,12 @@
 
 const StellarSdk = require('stellar-sdk');
 const log = require('../utils/log');
+const {
+  horizonPoolAcquireDuration,
+  recordHorizonPoolStatus,
+  recordHorizonPoolCooldownEvent,
+  recordHorizonPoolRecoveryEvent,
+} = require('../utils/metrics');
 
 const DEFAULT_POOL_SIZE = 3;
 const MAX_POOL_SIZE = 10;
@@ -36,6 +42,7 @@ class HorizonPool {
     this._index = 0;          // round-robin cursor
 
     this._init();
+    recordHorizonPoolStatus(this.getStatus());
   }
 
   _init() {
@@ -58,17 +65,22 @@ class HorizonPool {
    * @returns {import('stellar-sdk').Horizon.Server}
    */
   getServer() {
-    this._tryRecover();
+    const endTimer = horizonPoolAcquireDuration.startTimer();
+    try {
+      this._tryRecover();
 
-    const healthyMembers = this._members.filter(m => m.healthy);
-    if (healthyMembers.length === 0) {
-      // All unhealthy — return first member as emergency fallback
-      return this._members[0].server;
+      const healthyMembers = this._members.filter(m => m.healthy);
+      if (healthyMembers.length === 0) {
+        // All unhealthy — return first member as emergency fallback
+        return this._members[0].server;
+      }
+
+      // Round-robin over healthy members
+      this._index = (this._index + 1) % healthyMembers.length;
+      return healthyMembers[this._index % healthyMembers.length].server;
+    } finally {
+      endTimer();
     }
-
-    // Round-robin over healthy members
-    this._index = (this._index + 1) % healthyMembers.length;
-    return healthyMembers[this._index % healthyMembers.length].server;
   }
 
   /**
@@ -80,6 +92,8 @@ class HorizonPool {
     if (member && member.healthy) {
       member.healthy = false;
       member.unhealthyAt = Date.now();
+      recordHorizonPoolCooldownEvent();
+      recordHorizonPoolStatus(this.getStatus());
       log.warn('HORIZON_POOL', 'Pool member marked unhealthy', {
         url: this.horizonUrl,
         healthy: this.healthyCount,
@@ -101,6 +115,8 @@ class HorizonPool {
         this._healthCheck(member).catch(() => {});
         member.healthy = true;
         member.unhealthyAt = null;
+        recordHorizonPoolRecoveryEvent();
+        recordHorizonPoolStatus(this.getStatus());
         log.info('HORIZON_POOL', 'Pool member re-admitted after cooldown', {
           url: this.horizonUrl,
         });

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -125,6 +125,93 @@ const recurringDonationsSkippedTotal = new client.Counter({
   registers: [registry],
 });
 
+// ─── Horizon Connection Pool Metrics ─────────────────────────────────────────
+
+/**
+ * Gauge: configured size of the Horizon connection pool.
+ * @type {client.Gauge}
+ */
+const horizonPoolSize = new client.Gauge({
+  name: 'horizon_pool_size',
+  help: 'Configured size of the Horizon connection pool',
+  registers: [registry],
+});
+
+/**
+ * Gauge: number of currently-healthy pool members.
+ * @type {client.Gauge}
+ */
+const horizonPoolHealthyCount = new client.Gauge({
+  name: 'horizon_pool_healthy_count',
+  help: 'Number of currently healthy Horizon pool members',
+  registers: [registry],
+});
+
+/**
+ * Gauge: number of currently-unhealthy (cooling down) pool members.
+ * @type {client.Gauge}
+ */
+const horizonPoolUnhealthyCount = new client.Gauge({
+  name: 'horizon_pool_unhealthy_count',
+  help: 'Number of currently unhealthy (cooling down) Horizon pool members',
+  registers: [registry],
+});
+
+/**
+ * Counter: total number of times a Horizon pool member was marked unhealthy
+ * and entered cooldown.
+ * @type {client.Counter}
+ */
+const horizonPoolCooldownEventsTotal = new client.Counter({
+  name: 'horizon_pool_cooldown_events_total',
+  help: 'Total number of times a Horizon pool member entered cooldown after a failure',
+  registers: [registry],
+});
+
+/**
+ * Counter: total number of times a Horizon pool member was re-admitted
+ * to rotation after its cooldown elapsed.
+ * @type {client.Counter}
+ */
+const horizonPoolRecoveryEventsTotal = new client.Counter({
+  name: 'horizon_pool_recovery_events_total',
+  help: 'Total number of times a Horizon pool member was re-admitted after cooldown',
+  registers: [registry],
+});
+
+/**
+ * Histogram: time spent acquiring a pool member from getServer().
+ * Near-instant today (round-robin, no queueing), but tracked so a future
+ * blocking/queued pool implementation has an existing saturation signal.
+ * @type {client.Histogram}
+ */
+const horizonPoolAcquireDuration = new client.Histogram({
+  name: 'horizon_pool_acquire_duration_seconds',
+  help: 'Time spent acquiring a Horizon server instance from the pool',
+  buckets: [0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5],
+  registers: [registry],
+});
+
+/**
+ * Update the Horizon pool gauges from a pool status snapshot.
+ * @param {{ size: number, healthy: number, unhealthy: number }} status
+ */
+function recordHorizonPoolStatus(status) {
+  horizonPoolSize.set(status.size);
+  horizonPoolHealthyCount.set(status.healthy);
+  horizonPoolUnhealthyCount.set(status.unhealthy);
+}
+
+/** Increment the Horizon pool cooldown-event counter. */
+function recordHorizonPoolCooldownEvent() {
+  horizonPoolCooldownEventsTotal.inc();
+}
+
+/** Increment the Horizon pool recovery-event counter. */
+function recordHorizonPoolRecoveryEvent() {
+  horizonPoolRecoveryEventsTotal.inc();
+}
+
 /**
  * Express middleware that records request duration for every response.
  * Normalises dynamic path segments (e.g. /donations/123 → /donations/:id)
@@ -175,4 +262,14 @@ module.exports = {
   recurringDonationsSuspendedTotal,
   recurringDonationsActiveCount,
   recurringDonationsSkippedTotal,
+  // Horizon connection pool metrics
+  horizonPoolSize,
+  horizonPoolHealthyCount,
+  horizonPoolUnhealthyCount,
+  horizonPoolCooldownEventsTotal,
+  horizonPoolRecoveryEventsTotal,
+  horizonPoolAcquireDuration,
+  recordHorizonPoolStatus,
+  recordHorizonPoolCooldownEvent,
+  recordHorizonPoolRecoveryEvent,
 };

--- a/tests/issue-1205-horizon-pool-metrics.test.js
+++ b/tests/issue-1205-horizon-pool-metrics.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Tests for Horizon connection pool metrics/observability (issue #1205).
+ *
+ * Verifies that HorizonPool reports pool utilization, cooldown, and recovery
+ * events through the shared Prometheus registry so operators can size
+ * HORIZON_POOL_SIZE / HORIZON_POOL_COOLDOWN_MS with real signal instead of
+ * tuning blind.
+ */
+
+const HorizonPool = require('../src/services/HorizonPool');
+const { registry } = require('../src/utils/metrics');
+
+async function getMetricValue(name, labels) {
+  const metrics = await registry.getMetricsAsJSON();
+  const metric = metrics.find((m) => m.name === name);
+  if (!metric) return undefined;
+  if (!labels) return metric.values[0]?.value;
+  const match = metric.values.find((v) =>
+    Object.entries(labels).every(([k, val]) => v.labels[k] === val)
+  );
+  return match?.value;
+}
+
+describe('HorizonPool metrics', () => {
+  test('reports pool size and healthy count on construction', async () => {
+    new HorizonPool('https://horizon-testnet.stellar.org', { size: 4 });
+
+    expect(await getMetricValue('horizon_pool_size')).toBe(4);
+    expect(await getMetricValue('horizon_pool_healthy_count')).toBe(4);
+    expect(await getMetricValue('horizon_pool_unhealthy_count')).toBe(0);
+  });
+
+  test('markUnhealthy increments cooldown counter and updates gauges', async () => {
+    const pool = new HorizonPool('https://horizon-testnet.stellar.org', { size: 2 });
+    const before = (await getMetricValue('horizon_pool_cooldown_events_total')) || 0;
+
+    const server = pool.getServer();
+    pool.markUnhealthy(server);
+
+    expect(await getMetricValue('horizon_pool_cooldown_events_total')).toBe(before + 1);
+    expect(await getMetricValue('horizon_pool_unhealthy_count')).toBe(1);
+    expect(await getMetricValue('horizon_pool_healthy_count')).toBe(1);
+  });
+
+  test('recovery after cooldown increments recovery counter', async () => {
+    const pool = new HorizonPool('https://horizon-testnet.stellar.org', { size: 2, cooldownMs: 1 });
+    const server = pool.getServer();
+    pool.markUnhealthy(server);
+
+    const before = (await getMetricValue('horizon_pool_recovery_events_total')) || 0;
+
+    // Cooldown is 1ms; wait it out, then trigger _tryRecover via getServer().
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    pool.getServer();
+
+    expect(await getMetricValue('horizon_pool_recovery_events_total')).toBe(before + 1);
+  });
+
+  test('getServer() acquisition time is recorded in the histogram', async () => {
+    const pool = new HorizonPool('https://horizon-testnet.stellar.org', { size: 1 });
+    pool.getServer();
+
+    const metrics = await registry.getMetricsAsJSON();
+    const histogram = metrics.find((m) => m.name === 'horizon_pool_acquire_duration_seconds');
+    expect(histogram).toBeDefined();
+    const countSample = histogram.values.find((v) => v.metricName.endsWith('_count'));
+    expect(countSample.value).toBeGreaterThan(0);
+  });
+
+  test('getStatus() shape is unchanged for existing consumers', () => {
+    const pool = new HorizonPool('https://horizon-testnet.stellar.org', { size: 3 });
+    expect(pool.getStatus()).toEqual({ size: 3, healthy: 3, unhealthy: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Prometheus metrics for the Horizon connection pool in `src/utils/metrics.js`, wired up from `HorizonPool.js`: `horizon_pool_size`, `horizon_pool_healthy_count`, `horizon_pool_unhealthy_count` (gauges), `horizon_pool_cooldown_events_total`, `horizon_pool_recovery_events_total` (counters), and `horizon_pool_acquire_duration_seconds` (histogram around `getServer()`). All are exposed automatically via the existing `/metrics` endpoint (shared registry).
- Documents `HORIZON_POOL_SIZE` / `HORIZON_POOL_COOLDOWN_MS` sizing guidance in `docs/CONFIGURATION.md` — specifically how to size relative to **instance count** (pool size is per-process, so the number that matters for Horizon's rate limit is `pool size × instance count`) and how to read the new metrics to tell if the pool is undersized.
- Confirms and documents that cooldown is already tied into the unified retry/circuit-breaker policy: `StellarService._executeWithRetry` already calls `HorizonPool.markUnhealthy()` on a transient failure within the same circuit-breaker-wrapped retry loop — this was previously undocumented/invisible.
- No load-testing infra exists in this repo/environment to empirically determine an optimal default, so the default `HORIZON_POOL_SIZE=3` / `HORIZON_POOL_COOLDOWN_MS=30000` is left unchanged; the new metrics give operators the data to tune it for their own traffic/instance count instead of guessing.

## Test plan
- [x] Added `tests/issue-1205-horizon-pool-metrics.test.js`: pool size/healthy/unhealthy gauges on construction, cooldown counter + gauge updates on `markUnhealthy`, recovery counter on re-admission after cooldown, acquire-duration histogram is recorded, `getStatus()` shape unchanged for existing consumers.
- [x] `npx eslint` clean on touched files.
- [x] All 5 new tests pass; existing `HorizonPool`/`StellarService` behavior (round-robin selection, `getStatus()` return shape) is unchanged — only added side-effect metric recording.

Closes #1205