### PR TITLE
Set explicit per-route timeouts and propagate cancellation

### DIFF
--- a/src/bootstrap/middleware.js
+++ b/src/bootstrap/middleware.js
@@ -141,9 +141,16 @@ function applyMiddleware(app) {
   app.use(fieldFilterMiddleware());
 
   // ─── Global request timeout (exempt streaming endpoints) ─────────────────────
+  // Health checks get their own tight budget (TIMEOUTS.health); everything else
+  // falls back to the configured global timeout unless a route sets its own
+  // explicit, tighter requestTimeout() (e.g. donation submission, balance
+  // lookups, exports — see those route files).
   const GLOBAL_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || TIMEOUTS.donation;
   app.use((req, res, next) => {
     if (STREAMING_PATH_RE.test(req.path)) return next();
+    if (req.path.startsWith('/health') || req.path.startsWith('/api/v1/health')) {
+      return requestTimeout(TIMEOUTS.health)(req, res, next);
+    }
     return requestTimeout(GLOBAL_TIMEOUT_MS)(req, res, next);
   });
 

--- a/src/middleware/requestTimeout.js
+++ b/src/middleware/requestTimeout.js
@@ -21,6 +21,7 @@ const TIMEOUTS = {
   balance: 10_000,    // 10 s — wallet balance lookups
   default: 15_000,    // 15 s — general fallback
   donation: 30_000,   // 30 s — Stellar transaction submission
+  export: 45_000,     // 45 s — synchronous large exports (CSV/JSON generation)
   stream: 60_000,     // 60 s — recurring-donation schedule creation
 };
 

--- a/src/routes/auditLogExport.js
+++ b/src/routes/auditLogExport.js
@@ -17,6 +17,7 @@ const { validateSchema } = require('../middleware/schemaValidation');
 const asyncHandler = require('../utils/asyncHandler');
 const AuditLogService = require('../services/AuditLogService');
 const AuditLogExportService = require('../services/AuditLogExportService');
+const { requestTimeout, TIMEOUTS } = require('../middleware/requestTimeout');
 
 /**
  * Schema for audit log export request
@@ -69,8 +70,10 @@ const exportStatusSchema = validateSchema({
 /**
  * GET /api-keys/:id/audit-log
  * Export audit logs for a specific API key
+ *
+ * Explicit 45s timeout (TIMEOUTS.export) — this generates CSV/JSON synchronously.
  */
-router.get('/:id/audit-log', requireAdmin(), auditLogExportSchema, asyncHandler(async (req, res, next) => {
+router.get('/:id/audit-log', requestTimeout(TIMEOUTS.export), requireAdmin(), auditLogExportSchema, asyncHandler(async (req, res, next) => {
   try {
     const apiKeyId = req.params.id;
     const { startDate, endDate, action, format = 'json' } = req.query;

--- a/src/routes/donation.js
+++ b/src/routes/donation.js
@@ -186,6 +186,7 @@ const { validateSchema } = require('../middleware/schemaValidation');
 const { validateDateRange } = require('../middleware/validation');
 const { parseCursorPaginationQuery } = require('../utils/pagination');
 const { payloadSizeLimiter, ENDPOINT_LIMITS } = require('../middleware/payloadSizeLimiter');
+const { requestTimeout, TIMEOUTS } = require('../middleware/requestTimeout');
 const { parseAssetInput } = require('../utils/stellarAsset');
 const federation = require('../utils/federation');
 const { LIFECYCLE_STAGES } = require('../middleware/requestLifecycle');
@@ -493,8 +494,11 @@ const createDonationSchema = validateSchema({
 /**
  * POST /donations
  * Create a non-custodial donation record
+ *
+ * Explicit 30s timeout (TIMEOUTS.donation) — this route submits to Horizon,
+ * which is the slowest operation in the API.
  */
-router.post('/', payloadSizeLimiter(ENDPOINT_LIMITS.singleDonation), donationRateLimiter, perKeyRateLimit, requireApiKey, requireIdempotency, createDonationSchema, async (req, res, next) => {
+router.post('/', requestTimeout(TIMEOUTS.donation), payloadSizeLimiter(ENDPOINT_LIMITS.singleDonation), donationRateLimiter, perKeyRateLimit, requireApiKey, requireIdempotency, createDonationSchema, async (req, res, next) => {
   try {
     // Custodial mode: when both senderId and receiverId are supplied, the parties
     // are wallet/user ids rather than on-chain addresses — route to the custodial flow.

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -24,6 +24,7 @@ const { cacheMiddleware } = require('../middleware/caching');
 const { validateDataEntry } = require('../middleware/validateDataEntry');
 const { toWalletResponse } = require('../utils/responseSanitizer');
 const Wallet = require('../models/wallet');
+const { requestTimeout, TIMEOUTS } = require('../middleware/requestTimeout');
 const { STROOPS_PER_XLM } = require('../constants');
 const WalletService = require('../services/WalletService');
 const AuditLogService = require('../services/AuditLogService');
@@ -425,8 +426,10 @@ router.get('/', checkPermission(PERMISSIONS.WALLETS_READ), cacheMiddleware('wall
  * GET /wallets/:id/balance
  * Returns XLM balance with TTL caching. Use ?refresh=true to force a live query.
  * Requires wallets:read permission.
+ *
+ * Explicit 10s timeout (TIMEOUTS.balance) — bounds the live-refresh Horizon lookup.
  */
-router.get('/:id/balance', checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, asyncHandler(async (req, res, next) => {
+router.get('/:id/balance', requestTimeout(TIMEOUTS.balance), checkPermission(PERMISSIONS.WALLETS_READ), walletIdSchema, asyncHandler(async (req, res, next) => {
   try {
     const forceRefresh = req.query.refresh === 'true';
 

--- a/src/services/StellarService.js
+++ b/src/services/StellarService.js
@@ -19,6 +19,7 @@ const { STELLAR_NETWORKS, HORIZON_URLS } = require('../constants');
 const StellarErrorHandler = require('../utils/stellarErrorHandler');
 const log = require('../utils/log');
 const { withTimeout, TIMEOUT_DEFAULTS, TimeoutError } = require('../utils/timeoutHandler');
+const { runWithAbortController, getCurrentAbortSignal } = require('../utils/abortContext');
 const { CircuitBreaker } = require('../utils/circuitBreaker');
 const HorizonPool = require('./HorizonPool');
 const {
@@ -246,10 +247,12 @@ class StellarService extends StellarServiceInterface {
           'X-Request-ID': this.correlationId || correlationHeaders['X-Correlation-ID'],
         };
         
+        const signal = getCurrentAbortSignal();
         const response = await fetch(url, {
           method,
           headers: mergedHeaders,
           body: data ? JSON.stringify(data) : undefined,
+          ...(signal ? { signal } : {}),
         });
         
         if (!response.ok) {
@@ -382,8 +385,15 @@ class StellarService extends StellarServiceInterface {
       try {
         // Each attempt goes through the circuit breaker so that failures are
         // counted and the circuit can open mid-retry if the threshold is hit.
+        // The operation runs inside an abort context so that if this attempt's
+        // timeout fires, the underlying HTTP request (see
+        // StellarService._createHttpClient) is actually aborted rather than
+        // left to finish in the background after we've already moved on.
+        const abortController = new AbortController();
         return await this.circuitBreaker.execute(() =>
-          withTimeout(operation(), timeoutMs, operationName)
+          runWithAbortController(abortController, () =>
+            withTimeout(operation(), timeoutMs, operationName, abortController)
+          )
         );
       } catch (error) {
         // Fast-fail immediately when the circuit is open — no retries
@@ -439,6 +449,13 @@ class StellarService extends StellarServiceInterface {
     const txHash = builtTx.hash().toString('hex');
 
     try {
+      // Deliberately not abort-cancelled on timeout: once submitTransaction's
+      // HTTP request has reached Horizon, the transaction may already be
+      // broadcast to the network — aborting the client-side wait can't undo
+      // that. Instead, on timeout we fall through to the verification step
+      // below, which checks whether the transaction actually landed so the
+      // caller (combined with the idempotency-key middleware) never produces
+      // a duplicate submission just because the client timed out waiting.
       const result = await withTimeout(
         this.server.submitTransaction(builtTx),
         this.timeouts.submit,

--- a/src/utils/abortContext.js
+++ b/src/utils/abortContext.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Abort Context - propagates an AbortController's signal to nested async work
+ * without threading it through every function signature in between.
+ *
+ * Used so that when a Horizon API call times out (StellarService's own
+ * per-operation timeout, see withTimeout()), the underlying fetch() request
+ * is actually aborted instead of just being abandoned to finish in the
+ * background. The HTTP client (StellarService._createHttpClient) reads the
+ * current signal via getCurrentAbortSignal() and passes it to fetch().
+ */
+
+const { AsyncLocalStorage } = require('async_hooks');
+
+const storage = new AsyncLocalStorage();
+
+/**
+ * Run `fn` with `controller` set as the current abort context.
+ * Any async work started synchronously inside `fn` (including across
+ * awaits) can read the controller's signal via getCurrentAbortSignal().
+ *
+ * @param {AbortController} controller
+ * @param {Function} fn
+ * @returns {*} The return value of `fn()`
+ */
+function runWithAbortController(controller, fn) {
+  return storage.run(controller, fn);
+}
+
+/**
+ * @returns {AbortSignal|undefined} The current abort signal, if any.
+ */
+function getCurrentAbortSignal() {
+  return storage.getStore()?.signal;
+}
+
+module.exports = { runWithAbortController, getCurrentAbortSignal };

--- a/src/utils/timeoutHandler.js
+++ b/src/utils/timeoutHandler.js
@@ -33,13 +33,20 @@ class TimeoutError extends Error {
 }
 
 /**
- * Wrap a promise with a timeout
+ * Wrap a promise with a timeout.
+ *
+ * If `abortController` is supplied, it is aborted when the timeout fires so
+ * the underlying work (e.g. a fetch() request) actually stops instead of
+ * being abandoned to complete in the background after this function has
+ * already rejected.
+ *
  * @param {Promise} promise - Promise to wrap
  * @param {number} timeoutMs - Timeout in milliseconds
  * @param {string} operation - Operation name for error messages
+ * @param {AbortController} [abortController] - Aborted when the timeout fires
  * @returns {Promise} Promise that rejects if timeout is exceeded
  */
-function withTimeout(promise, timeoutMs, operation = 'operation') {
+function withTimeout(promise, timeoutMs, operation = 'operation', abortController = null) {
   return Promise.race([
     promise,
     new Promise((_, reject) => {
@@ -54,9 +61,12 @@ function withTimeout(promise, timeoutMs, operation = 'operation') {
           timeoutMs,
           timestamp: error.timestamp
         });
+        if (abortController) {
+          abortController.abort();
+        }
         reject(error);
       }, timeoutMs);
-      
+
       // Clean up timer without creating an unhandled rejection branch.
       promise.then(
         () => clearTimeout(timer),

--- a/tests/issue-1207-route-timeouts-cancellation.test.js
+++ b/tests/issue-1207-route-timeouts-cancellation.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Tests for explicit per-route timeouts and cancellation propagation (issue #1207).
+ */
+
+const { withTimeout, TimeoutError } = require('../src/utils/timeoutHandler');
+const { runWithAbortController, getCurrentAbortSignal } = require('../src/utils/abortContext');
+const { TIMEOUTS } = require('../src/middleware/requestTimeout');
+
+describe('withTimeout — abort propagation', () => {
+  test('aborts the supplied AbortController when the timeout fires', async () => {
+    const controller = new AbortController();
+    const neverResolves = new Promise(() => {});
+
+    await expect(withTimeout(neverResolves, 20, 'slow_op', controller)).rejects.toThrow(TimeoutError);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test('does not abort when the operation resolves before the timeout', async () => {
+    const controller = new AbortController();
+    const fast = Promise.resolve('ok');
+
+    await expect(withTimeout(fast, 50, 'fast_op', controller)).resolves.toBe('ok');
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test('works without an AbortController (backward compatible)', async () => {
+    const neverResolves = new Promise(() => {});
+    await expect(withTimeout(neverResolves, 20, 'slow_op')).rejects.toThrow(TimeoutError);
+  });
+});
+
+describe('abortContext', () => {
+  test('getCurrentAbortSignal is undefined outside any context', () => {
+    expect(getCurrentAbortSignal()).toBeUndefined();
+  });
+
+  test('getCurrentAbortSignal returns the active controller signal inside the context', () => {
+    const controller = new AbortController();
+    const signal = runWithAbortController(controller, () => getCurrentAbortSignal());
+    expect(signal).toBe(controller.signal);
+  });
+
+  test('the signal is reachable across an await inside the context', async () => {
+    const controller = new AbortController();
+    const signal = await runWithAbortController(controller, async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      return getCurrentAbortSignal();
+    });
+    expect(signal).toBe(controller.signal);
+  });
+
+  test('context does not leak outside of runWithAbortController', async () => {
+    const controller = new AbortController();
+    await runWithAbortController(controller, async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    expect(getCurrentAbortSignal()).toBeUndefined();
+  });
+});
+
+describe('TIMEOUTS presets', () => {
+  test('exports an export preset for synchronous large exports', () => {
+    expect(TIMEOUTS.export).toBe(45_000);
+  });
+
+  test('donation timeout remains the slowest non-streaming preset below stream', () => {
+    expect(TIMEOUTS.donation).toBeLessThan(TIMEOUTS.export);
+    expect(TIMEOUTS.export).toBeLessThan(TIMEOUTS.stream);
+  });
+});
+
+describe('StellarService HTTP client — abort signal forwarding', () => {
+  let originalFetch;
+  let fetchCalls;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, opts) => {
+      fetchCalls.push(opts);
+      return { ok: true, json: async () => ({}) };
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function buildClient() {
+    const StellarService = require('../src/services/StellarService');
+    const service = Object.create(StellarService.prototype);
+    return service._createHttpClient();
+  }
+
+  test('fetch is called with the current abort signal when one is active', async () => {
+    const client = buildClient();
+    const controller = new AbortController();
+
+    await runWithAbortController(controller, () => client.request('GET', 'https://example.invalid/x'));
+
+    expect(fetchCalls[0].signal).toBe(controller.signal);
+  });
+
+  test('fetch is called without a signal option when no abort context is active', async () => {
+    const client = buildClient();
+
+    await client.request('GET', 'https://example.invalid/x');
+
+    expect(fetchCalls[0].signal).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `src/middleware/requestTimeout.js` already defined `TIMEOUTS` presets (health/balance/default/donation/stream), but only `donation` was actually used — every other route shared one 30s global timeout. Adds explicit `requestTimeout()` calls matched to each operation: health checks (5s, via the global middleware's path check in `src/bootstrap/middleware.js`), wallet balance lookups (10s), donation submission (30s, now explicit instead of incidental), and a new `export` preset (45s) applied to the synchronous audit-log export route.
- Fixes the actual "timeout doesn't stop the work" problem: `src/utils/timeoutHandler.js#withTimeout` only ever abandoned the losing promise via `Promise.race` — the real Horizon HTTP call kept running. Adds an optional `AbortController` param that gets aborted when the timeout fires, plus a small `AsyncLocalStorage`-based abort context (`src/utils/abortContext.js`) so `StellarService._executeWithRetry`'s own per-operation timeout (api/stream calls) now actually cancels the underlying native `fetch()` request via the existing HTTP client, instead of letting it complete in the background.
- `submitTransaction` is deliberately **excluded** from this cancellation: once the HTTP request has reached Horizon, the transaction may already be broadcast, so aborting client-side doesn't undo it. That path already does the right thing — on timeout it falls through to a verification call to check if the tx landed, and combined with the existing idempotency-key middleware, a client timeout can't produce a duplicate submission. Documented this explicitly in code.

## Test plan
- [x] Added `tests/issue-1207-route-timeouts-cancellation.test.js`: `withTimeout` aborts the supplied controller on timeout / doesn't abort on success / stays backward compatible without one; abort-context signal propagation across awaits and non-leakage outside the context; new `TIMEOUTS.export` preset; `StellarService`'s HTTP client forwards the active abort signal to `fetch()` when present and omits it otherwise.
- [x] `npx eslint` clean on touched files (pre-existing unrelated warnings/errors in `middleware.js` and `donation.js` left untouched).
- [x] `npm run openapi:check` passes.
- [x] No regressions: `tests/middleware/request-timeout-middleware-configurable-l.test.js` (31/31 still pass) and `tests/donations/donation-routes.test.js` + `send-donation.test.js` (20 failed/28 passed both before and after — pre-existing environment failures, identical count).

Closes #1207