### PR TITLE
Memoize/precompute expensive leaderboard aggregations

### DIFF
--- a/docs/LEADERBOARD_CACHING.md
+++ b/docs/LEADERBOARD_CACHING.md
@@ -1,0 +1,57 @@
+# Leaderboard Caching & Freshness
+
+`LeaderboardStatsService.getDonorLeaderboard()` / `getRecipientLeaderboard()`
+aggregate over confirmed transactions, which is expensive to redo on every
+request. Results are cached in-memory (`src/utils/cache.js`) per
+`(type, period, limit)` combination.
+
+## Freshness guarantee
+
+- **TTL**: `LEADERBOARD_CACHE_TTL_MS` = 60 000 ms (1 minute). A cached result
+  is served as-is for up to 60s after it was computed.
+- **Event-driven invalidation**: every confirmed donation invalidates *all*
+  leaderboard cache entries (`StatsService.invalidateLeaderboardCache()`,
+  wired up in `src/services/LeaderboardSSE.js` via the `donation.confirmed`
+  event), so in practice data is rarely more than one request-interval stale
+  even within the 60s window.
+- **SSE windows** (`daily`/`weekly`/`all-time`, used by `/leaderboard/stream`
+  and `/leaderboard/snapshot`) are recomputed and broadcast immediately on
+  every confirmed donation, independent of the TTL.
+
+## Reading freshness from the API
+
+`GET /leaderboard/donors` and `GET /leaderboard/recipients` include in
+`metadata`:
+
+| Field | Meaning |
+|---|---|
+| `generatedAt` | When this HTTP response was generated (always "now"). |
+| `cachedAt` | When the underlying leaderboard data was actually computed. May be earlier than `generatedAt` if served from cache. |
+| `ttlMs` | The cache TTL (`LEADERBOARD_CACHE_TTL_MS`). A consumer can treat the data as stale once `now - cachedAt > ttlMs`. |
+
+## Observability
+
+Two Prometheus metrics (`src/utils/metrics.js`, scraped at `/metrics`) report
+compute vs. cache-hit behaviour:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `leaderboard_cache_lookups_total{result="hit"|"miss"}` | Counter | Whether a leaderboard request was served from cache or required a full recomputation |
+| `leaderboard_compute_duration_seconds` | Histogram | Wall-clock time of a full recomputation (cache miss only) |
+
+A high miss rate relative to request rate, or a rising compute-duration p99,
+indicates the dataset has grown large enough that the TTL/invalidation
+strategy here should be revisited (e.g. moving to a scheduled background
+precompute or incremental aggregation) before it becomes a hot-path
+bottleneck.
+
+## Why not incremental aggregation (yet)
+
+Each lookup currently recomputes the leaderboard from the full filtered
+transaction set rather than maintaining running per-donor/per-recipient
+totals incrementally. Incremental aggregation would avoid the full scan on
+every cache miss, but requires persisting aggregate state per period bucket
+and handling edge cases (refunds/reversals, period-boundary rollover). The
+metrics above give the data needed to decide if/when that investment is
+justified; until the miss rate or compute duration becomes a problem, the
+cache + event-driven invalidation here is the simpler, lower-risk approach.

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -106,7 +106,12 @@ router.get('/donors', checkPermission(PERMISSIONS.STATS_READ), auditLeaderboardA
         period,
         limit,
         totalEntries: leaderboard.length,
-        generatedAt: new Date().toISOString()
+        generatedAt: new Date().toISOString(),
+        // cachedAt reflects when this data was actually computed; the
+        // leaderboard is served from cache for up to LEADERBOARD_CACHE_TTL_MS
+        // after that, so cachedAt may be earlier than generatedAt.
+        cachedAt: leaderboard.cachedAt || null,
+        ttlMs: StatsService.LEADERBOARD_CACHE_TTL_MS,
       }
     });
   } catch (error) {
@@ -142,7 +147,9 @@ router.get('/recipients', checkPermission(PERMISSIONS.STATS_READ), auditLeaderbo
         period,
         limit,
         totalEntries: leaderboard.length,
-        generatedAt: new Date().toISOString()
+        generatedAt: new Date().toISOString(),
+        cachedAt: leaderboard.cachedAt || null,
+        ttlMs: StatsService.LEADERBOARD_CACHE_TTL_MS,
       }
     });
   } catch (error) {

--- a/src/services/LeaderboardStatsService.js
+++ b/src/services/LeaderboardStatsService.js
@@ -1,5 +1,10 @@
 const Transaction = require('../models/transaction');
 const Cache = require('../utils/cache');
+const {
+  leaderboardComputeDuration,
+  recordLeaderboardCacheHit,
+  recordLeaderboardCacheMiss,
+} = require('../utils/metrics');
 
 const STROOPS_PER_XLM = 10_000_000n;
 
@@ -17,6 +22,20 @@ const LEADERBOARD_CACHE_TTL_MS = 60_000;
  * Default number of top entries to return
  */
 const DEFAULT_TOP_N = 10;
+
+/**
+ * Attach a non-enumerable `cachedAt` timestamp to a leaderboard array so
+ * callers can report freshness without changing the array's JSON shape
+ * (existing consumers index/iterate it as a plain array of entries).
+ *
+ * @param {Array} leaderboard
+ * @param {string} cachedAt - ISO 8601 timestamp of when the data was computed.
+ * @returns {Array} The same array, with `cachedAt` attached.
+ */
+function withCacheMeta(leaderboard, cachedAt) {
+  Object.defineProperty(leaderboard, 'cachedAt', { value: cachedAt, enumerable: false });
+  return leaderboard;
+}
 
 class StatsService {
   /**
@@ -458,12 +477,15 @@ class StatsService {
    */
   static getDonorLeaderboard(period = 'all', limit = DEFAULT_TOP_N) {
     const cacheKey = `leaderboard:donors:${period}:${limit}`;
-    
+
     // Check cache
     const cached = Cache.get(cacheKey);
     if (cached) {
+      recordLeaderboardCacheHit();
       return cached;
     }
+    recordLeaderboardCacheMiss();
+    const computeTimer = leaderboardComputeDuration.startTimer();
 
     let transactions;
     const { startDate, endDate } = this.getDateRangeForPeriod(period);
@@ -476,7 +498,7 @@ class StatsService {
     }
 
     // Filter confirmed transactions only
-    const confirmedTransactions = transactions.filter(t => 
+    const confirmedTransactions = transactions.filter(t =>
       t.status === 'confirmed' || t.status === 'COMPLETED'
     );
 
@@ -518,6 +540,9 @@ class StatsService {
         period: entry.period,
       }));
 
+    computeTimer();
+    withCacheMeta(leaderboard, new Date().toISOString());
+
     // Cache the result
     Cache.set(cacheKey, leaderboard, LEADERBOARD_CACHE_TTL_MS);
 
@@ -532,12 +557,15 @@ class StatsService {
    */
   static getRecipientLeaderboard(period = 'all', limit = DEFAULT_TOP_N) {
     const cacheKey = `leaderboard:recipients:${period}:${limit}`;
-    
+
     // Check cache
     const cached = Cache.get(cacheKey);
     if (cached) {
+      recordLeaderboardCacheHit();
       return cached;
     }
+    recordLeaderboardCacheMiss();
+    const computeTimer = leaderboardComputeDuration.startTimer();
 
     let transactions;
     const { startDate, endDate } = this.getDateRangeForPeriod(period);
@@ -592,6 +620,9 @@ class StatsService {
         period: entry.period,
       }));
 
+    computeTimer();
+    withCacheMeta(leaderboard, new Date().toISOString());
+
     // Cache the result
     Cache.set(cacheKey, leaderboard, LEADERBOARD_CACHE_TTL_MS);
 
@@ -605,5 +636,7 @@ class StatsService {
     Cache.clearPrefix('leaderboard:');
   }
 }
+
+StatsService.LEADERBOARD_CACHE_TTL_MS = LEADERBOARD_CACHE_TTL_MS;
 
 module.exports = StatsService;

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -125,6 +125,43 @@ const recurringDonationsSkippedTotal = new client.Counter({
   registers: [registry],
 });
 
+// ─── Leaderboard Metrics ─────────────────────────────────────────────────────
+
+/**
+ * Counter: leaderboard lookups, labelled by whether they were served from
+ * cache or required a full recomputation.
+ * Labels: result ('hit'|'miss')
+ * @type {client.Counter}
+ */
+const leaderboardCacheLookupsTotal = new client.Counter({
+  name: 'leaderboard_cache_lookups_total',
+  help: 'Total number of leaderboard lookups, labelled by cache hit/miss',
+  labelNames: ['result'],
+  registers: [registry],
+});
+
+/**
+ * Histogram: wall-clock duration of a full leaderboard recomputation
+ * (cache miss only).
+ * @type {client.Histogram}
+ */
+const leaderboardComputeDuration = new client.Histogram({
+  name: 'leaderboard_compute_duration_seconds',
+  help: 'Duration of a full leaderboard recomputation on a cache miss',
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5],
+  registers: [registry],
+});
+
+/** Increment the leaderboard cache-hit counter. */
+function recordLeaderboardCacheHit() {
+  leaderboardCacheLookupsTotal.inc({ result: 'hit' });
+}
+
+/** Increment the leaderboard cache-miss counter. */
+function recordLeaderboardCacheMiss() {
+  leaderboardCacheLookupsTotal.inc({ result: 'miss' });
+}
+
 /**
  * Express middleware that records request duration for every response.
  * Normalises dynamic path segments (e.g. /donations/123 → /donations/:id)
@@ -175,4 +212,9 @@ module.exports = {
   recurringDonationsSuspendedTotal,
   recurringDonationsActiveCount,
   recurringDonationsSkippedTotal,
+  // Leaderboard metrics
+  leaderboardCacheLookupsTotal,
+  leaderboardComputeDuration,
+  recordLeaderboardCacheHit,
+  recordLeaderboardCacheMiss,
 };

--- a/tests/issue-1206-leaderboard-cache-metrics.test.js
+++ b/tests/issue-1206-leaderboard-cache-metrics.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Tests for leaderboard cache observability and freshness reporting (issue #1206).
+ */
+
+const StatsService = require('../src/services/LeaderboardStatsService');
+const Transaction = require('../src/models/transaction');
+const Cache = require('../src/utils/cache');
+const { registry } = require('../src/utils/metrics');
+
+const createTransaction = (data) => Transaction.create({
+  id: data.id || `tx-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  amount: 'amount' in data ? data.amount : 100,
+  donor: 'donor' in data ? data.donor : 'GDONOR',
+  recipient: 'recipient' in data ? data.recipient : 'GRECIPIENT',
+  status: data.status || 'confirmed',
+  timestamp: data.timestamp || new Date().toISOString(),
+  memo: '',
+  tags: [],
+});
+
+const clearState = () => {
+  Transaction._clearAllData();
+  StatsService.invalidateLeaderboardCache();
+  Cache.clear();
+};
+
+async function getCounterValue(name, labels) {
+  const metrics = await registry.getMetricsAsJSON();
+  const metric = metrics.find((m) => m.name === name);
+  if (!metric) return 0;
+  const match = metric.values.find((v) =>
+    Object.entries(labels).every(([k, val]) => v.labels[k] === val)
+  );
+  return match?.value || 0;
+}
+
+describe('Leaderboard cache metrics + freshness', () => {
+  beforeEach(clearState);
+  afterEach(clearState);
+
+  test('a cache miss followed by a hit increments the right counters', async () => {
+    createTransaction({ donor: 'GA', amount: 100 });
+
+    const missesBefore = await getCounterValue('leaderboard_cache_lookups_total', { result: 'miss' });
+    const hitsBefore = await getCounterValue('leaderboard_cache_lookups_total', { result: 'hit' });
+
+    StatsService.getDonorLeaderboard('all', 10); // miss — computes and caches
+    StatsService.getDonorLeaderboard('all', 10); // hit — served from cache
+
+    const missesAfter = await getCounterValue('leaderboard_cache_lookups_total', { result: 'miss' });
+    const hitsAfter = await getCounterValue('leaderboard_cache_lookups_total', { result: 'hit' });
+
+    expect(missesAfter).toBe(missesBefore + 1);
+    expect(hitsAfter).toBe(hitsBefore + 1);
+  });
+
+  test('compute duration histogram records a sample on cache miss', async () => {
+    createTransaction({ donor: 'GA', amount: 100 });
+    StatsService.getDonorLeaderboard('all', 10);
+
+    const metrics = await registry.getMetricsAsJSON();
+    const histogram = metrics.find((m) => m.name === 'leaderboard_compute_duration_seconds');
+    const countSample = histogram.values.find((v) => v.metricName.endsWith('_count'));
+    expect(countSample.value).toBeGreaterThan(0);
+  });
+
+  test('result carries a cachedAt timestamp that survives a cache hit', () => {
+    createTransaction({ donor: 'GA', amount: 100 });
+
+    const first = StatsService.getDonorLeaderboard('all', 10);
+    expect(first.cachedAt).toBeDefined();
+    expect(new Date(first.cachedAt).getTime()).not.toBeNaN();
+
+    const second = StatsService.getDonorLeaderboard('all', 10);
+    expect(second.cachedAt).toBe(first.cachedAt); // same computed-at, served from cache
+  });
+
+  test('cachedAt does not appear in JSON output (non-enumerable, backward compatible)', () => {
+    createTransaction({ donor: 'GA', amount: 100 });
+    const leaderboard = StatsService.getDonorLeaderboard('all', 10);
+
+    expect(JSON.parse(JSON.stringify(leaderboard))).toEqual(leaderboard.map((e) => ({ ...e })));
+  });
+
+  test('exposes the cache TTL constant for consumers', () => {
+    expect(StatsService.LEADERBOARD_CACHE_TTL_MS).toBe(60_000);
+  });
+
+  test('recipient leaderboard also records cachedAt and metrics', async () => {
+    createTransaction({ recipient: 'GR', amount: 50 });
+
+    const missesBefore = await getCounterValue('leaderboard_cache_lookups_total', { result: 'miss' });
+    const leaderboard = StatsService.getRecipientLeaderboard('all', 10);
+    const missesAfter = await getCounterValue('leaderboard_cache_lookups_total', { result: 'miss' });
+
+    expect(leaderboard.cachedAt).toBeDefined();
+    expect(missesAfter).toBe(missesBefore + 1);
+  });
+});


### PR DESCRIPTION
## Summary
`LeaderboardStatsService` already had most of what this issue asks for — a 60s TTL cache (`LEADERBOARD_CACHE_TTL_MS`) per `(type, period, limit)`, and event-driven invalidation + immediate recompute-and-broadcast on every confirmed donation (`LeaderboardSSE.handleDonationConfirmed`). The two concrete gaps were: no visibility into compute-vs-cache-hit behavior, and the API's `generatedAt` field always showed "now" even when serving stale cached data — actively hiding staleness from consumers. This PR closes those two gaps without changing the existing caching/invalidation strategy or the leaderboard response array shape (avoiding a much larger, riskier rewrite to true incremental aggregation — see "Why not incremental aggregation" in the new doc for the tradeoff reasoning).

- Adds `leaderboard_cache_lookups_total{result="hit"|"miss"}` (counter) and `leaderboard_compute_duration_seconds` (histogram) metrics in `src/utils/metrics.js`, recorded from `getDonorLeaderboard`/`getRecipientLeaderboard` in `src/services/LeaderboardStatsService.js`. Scraped via the existing `/metrics` endpoint.
- Attaches a non-enumerable `cachedAt` timestamp to the returned leaderboard array (doesn't change its JSON/array shape — `JSON.stringify` and all existing `.length`/`[i]` consumers are unaffected) so callers know when the data was actually computed, not just when the HTTP response was generated.
- `GET /leaderboard/donors` / `GET /leaderboard/recipients` now include `cachedAt` and `ttlMs` in `metadata` alongside the existing `generatedAt`, so a consumer can compute real staleness (`now - cachedAt > ttlMs`) instead of being told everything is always fresh.
- Documents the freshness/staleness guarantee, caching strategy, and the new metrics in `docs/LEADERBOARD_CACHING.md`.

## Test plan
- [x] Added `tests/issue-1206-leaderboard-cache-metrics.test.js`: cache-miss-then-hit increments the right counter labels, compute-duration histogram records a sample on miss, `cachedAt` is present and stable across a cache hit, `cachedAt` doesn't leak into `JSON.stringify` output, `LEADERBOARD_CACHE_TTL_MS` is exposed, recipient leaderboard also reports correctly.
- [x] `npx eslint` clean on touched files.
- [x] `npm run openapi:check` passes.
- [x] No regressions vs. pre-existing baseline: `tests/donations/realtime-donation-leaderboard.test.js` + `tests/issues/issues-1160-1161-1162-1163.test.js` — identical 6 failed/76 passed before and after (pre-existing, unrelated `toStroops`/teardown issues).

Closes #1206