### PR TITLE
docs(tests): document naming convention and add migration plan (#1175)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,12 @@ to go from a fresh clone to an open PR.
 
 1. [Local Setup](#1-local-setup)
 2. [Running Tests](#2-running-tests)
-3. [Linting & Security](#3-linting--security)
-4. [Database Migrations](#4-database-migrations)
-5. [OpenAPI Spec](#5-openapi-spec)
-6. [Branch & Commit Conventions](#6-branch--commit-conventions)
-7. [Pre-PR Checklist](#7-pre-pr-checklist)
+3. [Test Naming Convention](#3-test-naming-convention)
+4. [Linting & Security](#4-linting--security)
+5. [Database Migrations](#5-database-migrations)
+6. [OpenAPI Spec](#6-openapi-spec)
+7. [Branch & Commit Conventions](#7-branch--commit-conventions)
+8. [Pre-PR Checklist](#8-pre-pr-checklist)
 
 ---
 
@@ -71,7 +72,30 @@ state between runs. See [Test Isolation Guide](docs/TEST_ISOLATION.md) for detai
 
 ---
 
-## 3. Linting & Security
+## 3. Test Naming Convention
+
+See **[docs/TEST_NAMING_CONVENTION.md](docs/TEST_NAMING_CONVENTION.md)** for the full
+convention and migration plan. The short version:
+
+- Name your test file after the **module it exercises**, not the issue or feature
+  that prompted it.
+- Mirror the `src/` directory structure: `src/routes/donation.js` →
+  `tests/routes/donation.test.js`.
+- Use `.smoke.test.js` for smoke tests in `tests/smoke/` and `.e2e.test.js` for
+  end-to-end tests in `tests/e2e/`.
+
+**Quick check** — run this before opening a PR to ensure no new legacy-named file
+was accidentally created:
+
+```bash
+node scripts/check-test-naming.js
+```
+
+CI runs this check automatically on every PR.
+
+---
+
+## 4. Linting & Security
 
 ```bash
 # ESLint (style + security rules)
@@ -89,7 +113,7 @@ Fix all reported issues before opening a PR — CI will fail otherwise.
 
 ---
 
-## 4. Database Migrations
+## 5. Database Migrations
 
 Migrations live in `src/migrations/` and are applied in version order.
 
@@ -114,7 +138,7 @@ If you add a feature that requires a schema change:
 
 ---
 
-## 5. OpenAPI Spec
+## 6. OpenAPI Spec
 
 The OpenAPI spec at `docs/openapi.json` and `docs/openapi.yaml` must stay in sync
 with the route JSDoc annotations.
@@ -132,7 +156,7 @@ and will fail if the spec is stale.
 
 ---
 
-## 6. Branch & Commit Conventions
+## 7. Branch & Commit Conventions
 
 **Branches**
 
@@ -156,17 +180,18 @@ Breaking changes must include a `BREAKING CHANGE:` footer in the commit body.
 
 ---
 
-## 7. Pre-PR Checklist
+## 8. Pre-PR Checklist
 
 Before pushing and opening a PR, run through this list:
 
 ```bash
-npm run lint            # no ESLint errors
-npm run security:scan   # no new security findings
-npm test                # full suite passes
-npm run check-coverage  # coverage ≥ 80%
-npm run openapi:check   # spec is up to date
-npm run migrate:status  # no pending unapplied migrations
+npm run lint                       # no ESLint errors
+npm run security:scan              # no new security findings
+npm test                           # full suite passes
+npm run check-coverage             # coverage ≥ 80%
+npm run openapi:check              # spec is up to date
+npm run migrate:status             # no pending unapplied migrations
+node scripts/check-test-naming.js  # no new legacy-named test files
 ```
 
 CI enforces all of the above and will block merge if any step fails.

--- a/docs/TEST_NAMING_CONVENTION.md
+++ b/docs/TEST_NAMING_CONVENTION.md
@@ -1,0 +1,136 @@
+# Test Naming Convention & Migration Plan
+
+Issue [#1175](https://github.com/Manuel1234477/Stellar-Micro-Donation-API/issues/1175)
+
+## Convention
+
+All test files **mirror the `src/` directory structure** and name themselves
+after the module they exercise:
+
+```
+src/services/DonationService.js          → tests/services/donation-service.test.js
+src/routes/donation.js                   → tests/routes/donation.test.js
+src/middleware/rateLimiter.js            → tests/middleware/rate-limiter.test.js
+src/utils/memoEncryption.js             → tests/utils/memo-encryption.test.js
+```
+
+### Rules
+
+| Rule | Example |
+|------|---------|
+| File name = kebab-case of the source module name | `DonationService` → `donation-service.test.js` |
+| Directory mirrors `src/` | `src/routes/wallet.js` → `tests/routes/wallet.test.js` |
+| Smoke tests live in `tests/smoke/` and use the `.smoke.test.js` suffix | `tests/smoke/server-startup.smoke.test.js` |
+| E2E tests live in `tests/e2e/` and use the `.e2e.test.js` suffix | `tests/e2e/donation.e2e.test.js` |
+| Cross-cutting integration tests live in `tests/integration/` | `tests/integration/idempotency.test.js` |
+| Feature-scoped helpers (builders, fixtures) live in `tests/helpers/` | `tests/helpers/dbBootstrap.js` |
+
+### What NOT to do
+
+- ❌ `add-pagination-to-all-list-endpoints.test.js` — issue-slug naming
+- ❌ `issues-796-797-798.test.js` — issue-number naming
+- ❌ `security-issues-1122-1123-1124-1125.test.js` — issue-batch naming
+- ✅ `tests/utils/pagination-to-all-list-endpoints.test.js` — module-scoped
+- ✅ `tests/routes/donation.test.js` — mirrors src/routes/donation.js
+
+### Why
+
+Issue-slug names (`add-X.test.js`, `issue-NNN.test.js`) make it impossible
+to answer the question "which file tests module X?" without a full-text search.
+Convention-named files are discoverable from the source file they cover,
+duplicates are easy to spot, and `jest --testPathPattern routes/donation`
+filters correctly.
+
+---
+
+## Migration Plan
+
+Migration is **gradual** (high-traffic modules first) to keep PRs reviewable
+and preserve `git log --follow` history.
+
+### Phase 0 — Documentation (this PR)
+
+- [x] Document the convention in `docs/TEST_NAMING_CONVENTION.md` (this file).
+- [x] Update `CONTRIBUTING.md` to reference the convention.
+- [x] Add a lightweight CI lint rule (`scripts/check-test-naming.js`) that
+      **warns** (non-blocking) on new files that match the legacy patterns so
+      no new legacy-named files land.
+
+### Phase 1 — Highest-traffic source modules (next 2 sprints)
+
+Rename the files that exercise the core donation/wallet/stats paths first,
+since those are touched most often and benefit most from discoverability.
+
+| Legacy file | Canonical target | git mv command |
+|---|---|---|
+| `tests/add-pagination-to-all-list-endpoints.test.js` | `tests/utils/pagination-to-all-list-endpoints.test.js` | `git mv tests/add-pagination-to-all-list-endpoints.test.js tests/utils/pagination-to-all-list-endpoints.test.js` |
+| `tests/add-support-for-donation-notes-and-tags.test.js` | `tests/donations/donation-notes-and-tags.test.js` | `git mv tests/add-support-for-donation-notes-and-tags.test.js tests/donations/donation-notes-and-tags.test.js` |
+| `tests/add-openapiswagger-documentation-generation.test.js` | `tests/utils/openapi-documentation.test.js` | `git mv tests/add-openapiswagger-documentation-generation.test.js tests/utils/openapi-documentation.test.js` |
+| `tests/smart-donation-routing.test.js` | `tests/services/donation-router.test.js` | `git mv tests/smart-donation-routing.test.js tests/services/donation-router.test.js` |
+| `tests/donation-velocity-limits.test.js` | `tests/services/donation-velocity.test.js` | `git mv tests/donation-velocity-limits.test.js tests/services/donation-velocity.test.js` |
+| `tests/issues-796-797-798.test.js` | Split or move to `tests/integration/regression-796-798.test.js` | `git mv tests/issues-796-797-798.test.js tests/integration/regression-796-798.test.js` |
+| `tests/issues-802-803.test.js` | `tests/integration/regression-802-803.test.js` | `git mv tests/issues-802-803.test.js tests/integration/regression-802-803.test.js` |
+| `tests/issue-806.test.js` | `tests/integration/regression-806.test.js` | `git mv tests/issue-806.test.js tests/integration/regression-806.test.js` |
+| `tests/security-issues-1122-1123-1124-1125.test.js` | `tests/security/security-1122-1125.test.js` | `git mv tests/security-issues-1122-1123-1124-1125.test.js tests/security/security-1122-1125.test.js` |
+| `tests/issues-65-66-67-68.test.js` | `tests/integration/regression-65-68.test.js` | `git mv tests/issues-65-66-67-68.test.js tests/integration/regression-65-68.test.js` |
+
+### Phase 2 — Remaining issue-slug files at root level (1 sprint)
+
+After Phase 1, the remaining root-level `tests/issues-NNN*.test.js` and
+`tests/issue-NNN*.test.js` files (those inside `tests/issues/` are already
+scoped) can be moved in a single batch PR:
+
+```bash
+# Example batch for root-level issue files
+git mv tests/issues-764-765-766-767.test.js tests/integration/regression-764-767.test.js
+git mv tests/issues-1144-1145-1146-1147.test.js tests/integration/regression-1144-1147.test.js
+# … and so on for any remaining root-level issue-slug files
+```
+
+### Phase 3 — `tests/misc/` triage (ongoing)
+
+`tests/misc/` is a catch-all. Files there should be moved to the appropriate
+subdirectory as they are edited:
+
+```
+tests/misc/graceful-shutdown-inflight-request-.test.js
+  → tests/bootstrap/graceful-shutdown-inflight.test.js
+
+tests/misc/scheduler-resilience.test.js
+  → tests/services/recurring-donation-scheduler-resilience.test.js
+
+tests/misc/validation.test.js
+  → tests/middleware/validation.test.js
+```
+
+### Phase 4 — Enforce strictly (after Phase 3 complete)
+
+Once the suite is mostly migrated, flip the CI lint rule from warn to error
+so all new test files must follow the convention.
+
+---
+
+## Checking Compliance
+
+A helper script is provided at `scripts/check-test-naming.js`. Run it locally:
+
+```bash
+node scripts/check-test-naming.js
+```
+
+It prints files that match legacy naming patterns. In CI it exits non-zero
+only if a _new_ file (not already tracked as a legacy exception) is found,
+so existing violations do not block the build until they are migrated.
+
+---
+
+## New-File Checklist (for contributors)
+
+When adding a new test file:
+
+1. Identify the source module it exercises (`src/X/Y.js`).
+2. Create the file at `tests/X/y.test.js` (kebab-case).
+3. If it spans multiple modules, use `tests/integration/` or the most
+   relevant subdirectory.
+4. Never use an issue number or feature-slug as the file name — put that
+   context in the `describe` block header instead.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "mutation:watch": "node scripts/run-mutation-tests.js --watch",
     "changelog": "node scripts/generate-changelog.js",
     "changelog:write": "node scripts/generate-changelog.js --write",
-    "check:no-json-persistence": "node scripts/check-no-json-persistence.js"
+    "check:no-json-persistence": "node scripts/check-no-json-persistence.js",
+    "check:test-naming": "node scripts/check-test-naming.js"
   },
   "dependencies": {
     "ajv": "^8.12.0",

--- a/scripts/check-test-naming.js
+++ b/scripts/check-test-naming.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-test-naming.js (#1175)
+ *
+ * Scans the tests/ directory for files that match legacy issue-slug naming
+ * patterns.  Used as a lightweight CI gate so no new legacy-named files land
+ * while the gradual migration (see docs/TEST_NAMING_CONVENTION.md) is in
+ * progress.
+ *
+ * Behaviour
+ * ---------
+ * - Prints every legacy-named file it finds.
+ * - Exits 0 when only _known_ legacy files are found (migration in progress).
+ * - Exits 1 when a file that is NOT in the known-legacy whitelist is found,
+ *   meaning a contributor added a new file with the wrong naming.
+ *
+ * Usage
+ * -----
+ *   node scripts/check-test-naming.js          # local check
+ *   node scripts/check-test-naming.js --strict # treat ALL legacy names as errors
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TESTS_DIR = path.join(__dirname, '..', 'tests');
+const STRICT = process.argv.includes('--strict');
+
+// ─── Legacy patterns (issue-slug naming) ─────────────────────────────────────
+// A file is "legacy-named" if its basename matches any of these patterns.
+const LEGACY_PATTERNS = [
+  // issue-NNN or issues-NNN style (anywhere in the tests tree)
+  /^issue-\d+/i,
+  /^issues-\d+/i,
+  // feature-slug style at the repo root tests/ level (not inside a subdirectory)
+  /^add-/i,
+];
+
+// ─── Known-legacy whitelist ───────────────────────────────────────────────────
+// Files that were already in the repo when this rule was introduced.
+// They are excluded from the "new violation" check so the build stays green
+// until each file is migrated (Phase 1–3 of the migration plan).
+// To migrate a file: rename it (git mv), remove it from this list.
+const KNOWN_LEGACY = new Set([
+  // Root-level issue-slug files
+  'tests/issues-65-66-67-68.test.js',
+  'tests/issues-764-765-766-767.test.js',
+  'tests/issues-796-797-798.test.js',
+  'tests/issues-802-803.test.js',
+  'tests/issue-806.test.js',
+  'tests/security-issues-1122-1123-1124-1125.test.js',
+  // Root-level feature-slug files
+  'tests/add-pagination-to-all-list-endpoints.test.js',
+  'tests/add-support-for-donation-notes-and-tags.test.js',
+  'tests/add-openapiswagger-documentation-generation.test.js',
+  // tests/issues/ sub-directory (all files there are issue-scoped by design —
+  // they will be moved in Phase 2 of the migration)
+  'tests/issues/issue-908-db-tracing.test.js',
+  'tests/issues/issues-1144-1145-1146-1147.test.js',
+  'tests/issues/issue-63-mock-latency.test.js',
+  'tests/issues/issue-61-extend-api-key.test.js',
+  'tests/issues/issues-18-19-20-21.test.js',
+  'tests/issues/issues-1116-1117-1118-1119.test.js',
+  'tests/issues/808-next-execution-date.test.js',
+  'tests/issues/issue-1157-idempotency.test.js',
+  'tests/issues/issue-916-exponential-backoff.test.js',
+  'tests/issues/issues-1160-1161-1162-1163.test.js',
+  'tests/issues/issue-64-system-info.test.js',
+  'tests/issues/issue-39-patch-stream-schedule.test.js',
+  'tests/issues/issue-909-receipt-get.test.js',
+  'tests/issues/issue-910-cors-config.test.js',
+  'tests/issues/debug-patch.test.js',
+  'tests/issues/issues-918-919-920-921.test.js',
+  'tests/issues/issue-917-transaction-sync-pagination.test.js',
+  'tests/issues/issue-123-async-donation-export.test.js',
+  'tests/issues/issue-62-wallet-tx-pagination.test.js',
+  'tests/issues/issue-911-soft-delete-schedule.test.js',
+  'tests/issues/issues-69-70-71.test.js',
+  'tests/issues/issue-915-wallet-balance-endpoint.test.js',
+  'tests/issues/issues-1144-1145-1146-1147.test.js',
+  // tests/admin/ issue-prefixed files (pre-existing)
+  'tests/admin/issue-104-keys-import.test.js',
+  'tests/admin/issue-105-pending-transactions.test.js',
+  'tests/admin/issue-106-db-reindex.test.js',
+  'tests/admin/issue-107-matching-status.test.js',
+  'tests/admin/issue-108-quota-usage.test.js',
+  'tests/admin/issue-110-anomalies.test.js',
+  'tests/admin/issue-111-cost-breakdown.test.js',
+  // tests/config/ issue-prefixed files (pre-existing)
+  'tests/config/issue-1101-encryption-key-validation.test.js',
+  // tests/donations/ issue-prefixed files (pre-existing)
+  'tests/donations/issue-109-donation-notes.test.js',
+  // tests/misc/ issue-prefixed files (pre-existing)
+  'tests/misc/issue-793-tiers-public.test.js',
+  'tests/misc/issue-794-fees.test.js',
+  'tests/misc/issue-795-donations-pending.test.js',
+  // tests/routes/ issue-prefixed files (pre-existing)
+  'tests/routes/issue-1113-csv-formula-injection.test.js',
+]);
+
+// ─── Scan ─────────────────────────────────────────────────────────────────────
+
+function walk(dir, results = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip non-test directories
+      if (!['node_modules', '.git', 'coverage', 'dist'].includes(entry.name)) {
+        walk(full, results);
+      }
+    } else if (entry.name.endsWith('.test.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const allTestFiles = walk(TESTS_DIR);
+const legacyFiles = [];
+const newViolations = [];
+
+for (const absPath of allTestFiles) {
+  const relPath = path.relative(path.join(__dirname, '..'), absPath).replace(/\\/g, '/');
+  const base = path.basename(absPath);
+
+  const isLegacy = LEGACY_PATTERNS.some((re) => re.test(base));
+  if (!isLegacy) continue;
+
+  legacyFiles.push(relPath);
+  if (STRICT || !KNOWN_LEGACY.has(relPath)) {
+    newViolations.push(relPath);
+  }
+}
+
+// ─── Output ───────────────────────────────────────────────────────────────────
+
+if (legacyFiles.length === 0) {
+  console.log('✅  No legacy-named test files found.');
+  process.exit(0);
+}
+
+console.log(`\nLegacy-named test files (${legacyFiles.length} total):`);
+for (const f of legacyFiles) {
+  const isNew = newViolations.includes(f);
+  console.log(`  ${isNew ? '❌' : '⚠️ '} ${f}`);
+}
+
+if (newViolations.length > 0) {
+  console.error(
+    `\n❌  ${newViolations.length} new legacy-named file(s) found.\n` +
+    '   Please follow the naming convention in docs/TEST_NAMING_CONVENTION.md:\n' +
+    '   name your test file after the module it covers, not the issue it fixes.\n'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `\n⚠️   ${legacyFiles.length} known-legacy file(s) above are scheduled for migration.\n` +
+  '   See docs/TEST_NAMING_CONVENTION.md for the migration plan.\n' +
+  '   No new violations were introduced — build passes.\n'
+);
+process.exit(0);


### PR DESCRIPTION
Establishes a discoverable, module-mirroring test naming convention and provides a gradual migration path for the ~40 legacy issue-slug-named files.

Changes
- docs/TEST_NAMING_CONVENTION.md  – convention rules, examples, 4-phase migration plan with exact git-mv commands for each high-traffic file
- scripts/check-test-naming.js   – CI-safe lint script; warns on known-legacy
  files, exits 1 only on new violations so the build stays green during the
  migration; run with --strict to treat all legacy names as errors
- CONTRIBUTING.md                – adds section 3 referencing the convention
  and the check script; updates pre-PR checklist
- package.json                   – adds check:test-naming script alias

Closes #1175

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] `npm audit --audit-level=high` passes — or vulnerability triaged in `SECURITY.md`
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed
