### PR TITLE
fix(deploy): define container resources and termination grace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,8 @@ NODE_ENV=development
 # INSTANCE_ID=
 
 # Milliseconds to wait for in-flight requests to drain before force-exit.
-# OPTIONAL — default: 10000
-# SHUTDOWN_TIMEOUT_MS=10000
+# OPTIONAL — default: 30000
+# SHUTDOWN_TIMEOUT_MS=30000
 
 # Global per-request timeout in milliseconds. Streaming endpoints are exempt.
 # OPTIONAL — default: 30000

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stellar-micro-donation-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stellar-micro-donation-api
+  template:
+    metadata:
+      labels:
+        app: stellar-micro-donation-api
+    spec:
+      # Includes the 5-second preStop hook, the application's
+      # 30-second shutdown budget, and a 5-second buffer.
+      terminationGracePeriodSeconds: 40
+
+      containers:
+        - name: api
+          image: your-registry/stellar-micro-donation-api:latest
+          ports:
+            - name: http
+              containerPort: 3000
+
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: SHUTDOWN_TIMEOUT_MS
+              value: "30000"
+
+          resources:
+            requests:
+              cpu: "1"
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,12 +28,15 @@ services:
       - DB_PATH=/app/data/donations.db
       - LOG_LEVEL=info
       - SECURE_SECRETS=true
+      - SHUTDOWN_TIMEOUT_MS=30000
     volumes:
       # Persist SQLite database across container restarts
       - db_data:/app/data
       # Mount logs directory for external log aggregation
       - logs:/app/logs
     restart: always
+    # Allow the 30-second shutdown budget to complete before SIGKILL.
+    stop_grace_period: 35s
     # Resource limits to prevent container resource exhaustion
     deploy:
       resources:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,8 +51,8 @@ application. Variables are grouped by concern. For each variable the table shows
 | `API_PREFIX` | string | `/api/v1` | no | Base path prefix prepended to all API routes |
 | `TRUSTED_PROXIES` | string | `loopback` | no | Comma-separated list of trusted proxy IPs/CIDRs. Passed to Express `trust proxy`. Set to the address of your load balancer in production |
 | `INSTANCE_ID` | string | hostname | no | Unique identifier for this process instance. Appears in structured log output for distributed tracing |
-| `SHUTDOWN_TIMEOUT` | number | `10000` | no | Alias for `SHUTDOWN_TIMEOUT_MS` (milliseconds). Time allowed for in-flight requests to drain before force-exit |
-| `SHUTDOWN_TIMEOUT_MS` | number | `10000` | no | Milliseconds to wait for graceful shutdown before force-exit |
+| `SHUTDOWN_TIMEOUT` | number | `30000` | no | Alias for `SHUTDOWN_TIMEOUT_MS` (milliseconds). Time allowed for in-flight requests to drain before force-exit |
+| `SHUTDOWN_TIMEOUT_MS` | number | `30000` | no | Milliseconds to wait for graceful shutdown before force-exit |
 | `REQUEST_TIMEOUT_MS` | number | `30000` | no | Global per-request timeout in milliseconds. Streaming endpoints are exempt |
 
 ---

--- a/docs/KUBERNETES_PROBES.md
+++ b/docs/KUBERNETES_PROBES.md
@@ -94,6 +94,15 @@ spec:
           env:
             - name: NODE_ENV
               value: production
+            - name: SHUTDOWN_TIMEOUT_MS
+              value: "30000"
+          resources:
+            requests:
+              cpu: "1"
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health/live
@@ -113,10 +122,14 @@ spec:
           lifecycle:
             preStop:
               exec:
-                # Give in-flight requests a few seconds to drain before SIGTERM
+                # Allow readiness changes to propagate before SIGTERM.
                 command: ["/bin/sh", "-c", "sleep 5"]
-      terminationGracePeriodSeconds: 30
+      # 5-second preStop + 30-second shutdown budget + 5-second buffer.
+      terminationGracePeriodSeconds: 40
 ```
+
+The reference Kubernetes workload configuration is available at
+`deploy/kubernetes/deployment.yaml`.
 
 ## Docker / Compose Health Check
 

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -87,6 +87,7 @@ The production deployment uses file-based secret injection. Configure these envi
 | `DB_PATH` | SQLite database location | `/app/data/donations.db` |
 | `LOG_LEVEL` | Logging level | `info`, `debug`, `error` |
 | `SECURE_SECRETS` | Enable secure secret file handling | `true` |
+| `SHUTDOWN_TIMEOUT_MS` | Graceful-shutdown budget in milliseconds | `30000` |
 
 ## Resource Configuration
 
@@ -94,13 +95,21 @@ The production docker-compose applies the following resource limits:
 
 ### CPU
 - **Limit**: 2 CPUs max
-- **Reservation**: 1 CPU (guaranteed)
+- **Reservation/request**: 1 CPU
 
 ### Memory
 - **Limit**: 1 GB max
-- **Reservation**: 512 MB (guaranteed)
+- **Reservation/request**: 512 MB
 
-Adjust these values based on your expected traffic and infrastructure:
+Adjust these values based on your expected traffic and infrastructure.
+
+An initial local process-level resource observation using the existing load suite with 10
+concurrent users and 50 iterations per scenario reached approximately one CPU
+core and 151 MiB maximum resident memory. The recommended 1 CPU / 512 MiB
+request and 2 CPU / 1 GiB limit provide scheduling capacity and burst
+headroom above that observation. Because the donation-creation scenario had a
+separate functional baseline failure during this run, operators should repeat
+the profile with healthy production-like traffic before reducing these values.
 
 ```yaml
 deploy:
@@ -112,6 +121,12 @@ deploy:
       cpus: '1.0'
       memory: 512M
 ```
+
+## Graceful Container Termination
+
+The application uses `SHUTDOWN_TIMEOUT_MS=30000`, giving it 30 seconds to drain in-flight requests after `SIGTERM`. The production Compose service sets `stop_grace_period: 35s`, providing a five-second buffer before Docker sends `SIGKILL`.
+
+The container grace period must be greater than or equal to the application shutdown budget.
 
 ## Restart Policy
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -138,4 +138,4 @@ The server handles `SIGTERM` and `SIGINT` by:
 2. Waiting for in-flight requests to complete
 3. Closing the database connection
 
-Kubernetes/ECS will send `SIGTERM` before killing the container — the default 30-second grace period is sufficient.
+Kubernetes/ECS sends `SIGTERM` before killing the container. Configure the orchestrator grace period to exceed the application shutdown budget and include time for lifecycle hooks.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>This PR defines explicit container resource requests and limits and aligns container termination settings with the application’s existing graceful-shutdown budget.</p><h3>Resource configuration</h3><p>The following baseline settings are now configured consistently for Docker Compose and Kubernetes:</p>
Resource | Request / Reservation | Limit
-- | -- | --
CPU | 1 CPU | 2 CPUs
Memory | 512 MiB | 1 GiB

<p>A local process-level run of the existing load suite with 10 concurrent users and 50 iterations per scenario reached approximately one CPU core and 151 MiB maximum resident memory. These defaults provide scheduling capacity and additional burst headroom.</p><p>The donation-creation load scenario encountered a separate functional baseline failure, so the documentation recommends repeating the profile with healthy production-like traffic before lowering the resource values.</p><h3>Graceful termination</h3><p>The application shutdown budget is standardised at:</p><pre><code class="language-text">SHUTDOWN_TIMEOUT_MS=30000
</code></pre><p>The deployment grace periods are configured as follows:</p><ul><li><p>Docker Compose: <code inline="">stop_grace_period: 35s</code></p></li><li><p>Kubernetes <code inline="">preStop</code> hook: 5 seconds</p></li><li><p>Kubernetes <code inline="">terminationGracePeriodSeconds</code>: 40 seconds</p></li></ul><p>The Kubernetes grace period covers:</p><pre><code class="language-text">5-second preStop + 30-second application shutdown budget + 5-second buffer
</code></pre><p>This gives the application enough time to stop accepting new traffic, drain in-flight requests and exit before the orchestrator sends <code inline="">SIGKILL</code>.</p><h3>Kubernetes manifest</h3><p>Added:</p><pre><code class="language-text">deploy/kubernetes/deployment.yaml
</code></pre><p>The reference Deployment includes:</p><ul><li><p>CPU and memory requests</p></li><li><p>CPU and memory limits</p></li><li><p><code inline="">SHUTDOWN_TIMEOUT_MS</code></p></li><li><p>Readiness and liveness probes</p></li><li><p>A <code inline="">preStop</code> lifecycle hook</p></li><li><p>An aligned termination grace period</p></li></ul><h3>Documentation</h3><p>Updated the configuration and deployment documentation to:</p><ul><li><p>Correct the documented shutdown default from 10 seconds to 30 seconds</p></li><li><p>Document the recommended CPU and memory settings</p></li><li><p>Explain the resource observation supporting the baseline</p></li><li><p>Document Docker and Kubernetes termination behaviour</p></li><li><p>Reference the Kubernetes Deployment manifest</p></li><li><p>Remove the inaccurate statement that a 30-second orchestrator grace period is always sufficient</p></li></ul><h2>Linked Issue</h2><p>Closes #1235</p><h2>Type of Change</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Bug fix</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> New feature</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Refactor / code quality</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Documentation</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Tests</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> CI / tooling</p></li></ul><h2>Test Evidence</h2><h3>Passed</h3><p>Docker Compose configuration validation:</p><pre><code class="language-bash">docker compose -f docker-compose.prod.yml config
# Exit code: 0
</code></pre><p>Kubernetes YAML validation:</p><pre><code class="language-bash">docker run --rm \
  -v "$PWD:/work" \
  mikefarah/yq:4 \
  eval '.' /work/deploy/kubernetes/deployment.yaml &gt;/dev/null
# Exit code: 0
</code></pre><p>Focused graceful-shutdown test:</p><pre><code class="language-bash">npm test -- --runInBand tests/misc/graceful-shutdown-inflight-request-.test.js
</code></pre><p>Result:</p><pre><code class="language-text">Test Suites: 1 passed
Tests:       6 passed
</code></pre><p>The focused test verifies that:</p><ul><li><p>Requests are accepted normally before shutdown</p></li><li><p>New requests are rejected during shutdown</p></li><li><p>Health checks remain accessible</p></li><li><p>In-flight requests are allowed to finish</p></li><li><p>Hanging requests trigger the configured force-exit timeout</p></li></ul><p>Patch formatting:</p><pre><code class="language-bash">git diff --check
# Passed
</code></pre><h3>Full test suite</h3><p>The complete test suite was also run:</p><pre><code class="language-bash">npm test
</code></pre><p>Result:</p><pre><code class="language-text">Test Suites: 237 failed, 147 passed, 384 total
Tests:       2058 failed, 11 skipped, 5895 passed, 7964 total
</code></pre><p>The failures span unrelated repository areas, including admin routes, authentication expectations, database tests, claimable balances, schema validation, missing test modules and tests containing no cases. This PR changes only deployment manifests, environment documentation and operator documentation.</p><h3>Dependency audit</h3><pre><code class="language-bash">npm audit --audit-level=high
</code></pre><p>The repository currently reports:</p><pre><code class="language-text">12 vulnerabilities
2 low
1 moderate
8 high
1 critical
</code></pre><p>No dependency updates were included because they are outside the scope of #1235 and one recommended update requires a breaking version change.</p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> Lint passes (<code inline="">npm run lint</code>) - update based on the recorded lint result</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> All tests pass (<code inline="">npm test</code>) - full-suite baseline failures documented above</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> <code inline="">openapi:check</code> passes (<code inline="">npm run openapi:check</code>) - N/A; no OpenAPI changes</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">npm audit --audit-level=high</code> passes - existing findings documented above</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Database migration included if schema changed - N/A; no schema changes</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Documentation updated if behaviour changed</p></li></ul></body></html><!--EndFragment-->
</body>
</html>
