### PR TITLE
fix: resolve issues #1338, #1337, #1336, and #1335

### DIFF
--- a/src/middleware/schemaValidation.js
+++ b/src/middleware/schemaValidation.js
@@ -174,7 +174,7 @@ function stripUnknown(data, segmentSchema) {
       if (isPlainObject(value) && rules.fields) {
         result[key] = stripUnknown(value, rules);
       } else {
-        result[key] = value;
+        result[key] = (typeof value === 'string' && rules.trim === true) ? value.trim() : value;
       }
     } else if (allowUnknown) {
       result[key] = value;
@@ -319,6 +319,8 @@ function validateSchema(schemaOrKey, versions, options) {
 
     if (allErrors.length === 0) {
       if (schemaToUse.body) req.body = stripUnknown(req.body ?? {}, schemaToUse.body);
+      if (schemaToUse.query) req.query = stripUnknown(req.query ?? {}, schemaToUse.query);
+      if (schemaToUse.params) req.params = stripUnknown(req.params ?? {}, schemaToUse.params);
     }
 
     if (allErrors.length > 0) {

--- a/src/utils/csvSerializer.js
+++ b/src/utils/csvSerializer.js
@@ -36,9 +36,12 @@ function escapeField(value) {
     str = String(value);
   }
 
-  // Neutralize formula-injection prefixes
+  // Neutralize formula-injection prefixes (except legitimate negative numbers)
   if (FORMULA_PREFIXES.has(str.charAt(0))) {
-    str = `'${str}`;
+    const isNegativeNumber = /^-\d+(\.\d+)?([eE][+-]?\d+)?$/.test(str);
+    if (!isNegativeNumber) {
+      str = `'${str}`;
+    }
   }
 
   // Quote if the field contains special characters

--- a/src/utils/donationValidator.js
+++ b/src/utils/donationValidator.js
@@ -5,6 +5,28 @@
 
 const config = require('../config');
 
+/**
+ * Calculate the number of decimal places of a numeric value,
+ * robustly handling scientific exponential notation (e.g., 1e-8).
+ * @param {number} num
+ * @returns {number}
+ */
+function getDecimalPlaces(num) {
+  const str = num.toString();
+  if (str.includes('e') || str.includes('E')) {
+    const [base, expStr] = str.toLowerCase().split('e');
+    const exp = parseInt(expStr, 10);
+    if (exp < 0) {
+      const baseDecimals = (base.split('.')[1] || '').length;
+      return baseDecimals + Math.abs(exp);
+    }
+    const baseDecimals = (base.split('.')[1] || '').length;
+    return Math.max(0, baseDecimals - exp);
+  }
+  const decimals = str.split('.')[1];
+  return decimals ? decimals.length : 0;
+}
+
 class DonationValidator {
   constructor() {
     this.minAmount = config.donations.minAmount;
@@ -28,8 +50,7 @@ class DonationValidator {
     }
 
     // Check for excessive decimal places (Stellar maximum precision is 7)
-    const decimals = amount.toString().split('.')[1];
-    if (decimals && decimals.length > 7) {
+    if (getDecimalPlaces(amount) > 7) {
       return {
         valid: false,
         error: 'Amount cannot have more than 7 decimal places (Stellar precision limit)',

--- a/src/utils/sanitizer.js
+++ b/src/utils/sanitizer.js
@@ -209,15 +209,15 @@ function sanitizeText(input, options = {}) {
   // Step 6: Remove script tags and dangerous event handlers
   sanitized = removeScriptTagsAndHandlers(sanitized);
 
-  // Step 7: HTML entity encoding for XSS prevention (if enabled)
-  if (encodeHtml) {
-    sanitized = encodeHtmlEntities(sanitized);
-  }
-
-  // Step 8: Optionally restrict to safe characters
+  // Step 7: Optionally restrict to safe characters
   if (!allowSpecialChars) {
     // Allow only alphanumeric, spaces, and basic punctuation
     sanitized = sanitized.replace(/[^a-zA-Z0-9\s\-_.@]/g, '');
+  }
+
+  // Step 8: HTML entity encoding for XSS prevention (if enabled and special chars allowed)
+  if (encodeHtml && allowSpecialChars) {
+    sanitized = encodeHtmlEntities(sanitized);
   }
 
   // Step 9: Truncate to maximum length

--- a/tests/donations/donation-boundary.test.js
+++ b/tests/donations/donation-boundary.test.js
@@ -283,7 +283,7 @@ describe('Donation Amount Boundary Tests', () => {
     it('should handle scientific notation (1e-8)', () => {
       const result = validator.validateAmount(1e-8);
       expect(result.valid).toBe(false);
-      expect(result.code).toBe('AMOUNT_BELOW_MINIMUM');
+      expect(result.code).toBe('INVALID_AMOUNT_PRECISION');
     });
 
     it('should handle scientific notation (1e2)', () => {

--- a/tests/middleware/schema-validation-strip-unknown.test.js
+++ b/tests/middleware/schema-validation-strip-unknown.test.js
@@ -110,4 +110,25 @@ describe('schemaValidation - unknown field stripping', () => {
     expect(res.body.body).not.toHaveProperty('role');
     expect(res.body.body).not.toHaveProperty('injected');
   });
+
+  test('trims field values when trim: true is specified in schema', async () => {
+    const schema = {
+      body: {
+        fields: {
+          name: { type: 'string', required: true, trim: true },
+          key: { type: 'string', required: true, trim: true },
+        },
+      },
+    };
+    const app = makeApp(schema);
+    const res = await request(app)
+      .post('/test')
+      .send({ name: '  Alice  ', key: '  GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H  ' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.body).toEqual({
+      name: 'Alice',
+      key: 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H',
+    });
+  });
 });

--- a/tests/utils/csv-serializer.test.js
+++ b/tests/utils/csv-serializer.test.js
@@ -40,8 +40,14 @@ describe('csvSerializer', () => {
       expect(escapeField('+1')).toBe("'+1");
     });
 
-    it('neutralizes - formula prefix', () => {
-      expect(escapeField('-1')).toBe("'-1");
+    it('does not neutralize legitimate negative numbers', () => {
+      expect(escapeField('-1')).toBe('-1');
+      expect(escapeField('-100.5')).toBe('-100.5');
+    });
+
+    it('neutralizes - formula prefix when payload contains injection characters', () => {
+      expect(escapeField('-2+3+cmd|')).toBe("'-2+3+cmd|");
+      expect(escapeField('-SUM(A1:A10)')).toBe("'-SUM(A1:A10)");
     });
 
     it('neutralizes @ formula prefix', () => {

--- a/tests/utils/sanitizer.test.js
+++ b/tests/utils/sanitizer.test.js
@@ -129,6 +129,11 @@ describe('Sanitizer Utility', () => {
       const stellarKey = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
       expect(sanitizeIdentifier(stellarKey)).toBe(stellarKey);
     });
+
+    test('should not leave HTML-entity residue when input has quotes or ampersands', () => {
+      expect(sanitizeIdentifier("O'Brien")).toBe('OBrien');
+      expect(sanitizeIdentifier("Tom & Jerry")).toBe('Tom  Jerry');
+    });
   });
 
   describe('sanitizeForLogging', () => {


### PR DESCRIPTION
Summary of fixes and implementations:

1. Fix CSV serializer corrupting legitimate negative numbers (#1338)
- Problem: escapeField() in src/utils/csvSerializer.js treated plain negative numbers (e.g. -100.5) as formula injection attempts because - was included unconditionally in FORMULA_PREFIXES.
- Solution: Updated escapeField to distinguish plain negative numeric values from formula injection attempts, avoiding prepending single quote neutralizers to genuine numbers.
- Closes #1338

2. Apply trim: true normalized values to req.body in schema validation (#1337)
- Problem: In src/middleware/schemaValidation.js, validateField() computed trimmed normalized strings for validation, but stripUnknown() copied the raw untrimmed values to req.body.
- Solution: Modified stripUnknown() to return value.trim() when rules.trim === true for string fields, ensuring downstream handlers receive normalized trimmed values on req.body, req.query, and req.params.
- Closes #1337

3. Fix HTML-entity residue in sanitizeText and sanitizeIdentifier (#1336)
- Problem: In src/utils/sanitizer.js, sanitizeText() executed HTML entity encoding before the safe character whitelist restriction. For strict modes (allowSpecialChars: false used by sanitizeIdentifier), characters like ' were encoded to &#x27;, and then punctuation &, #, ; were stripped, leaving residue like Ox27Brien.
- Solution: Reordered safe character restriction to run before HTML entity encoding and skipped entity encoding when allowSpecialChars is false.
- Closes #1336

4. Fix scientific-notation decimal precision check bypass in donation validator (#1335)
- Problem: In src/utils/donationValidator.js, validateAmount() split amount.toString() by . to count decimal places. Scientific notation strings like 1e-8 caused .split('.')[1] to return undefined, bypassing the 7-decimal precision limit check.
- Solution: Added getDecimalPlaces(num) helper that correctly parses exponential scientific notation (e.g. 1e-8 -> 8 decimal places) to enforce Stellar's 7-decimal place maximum precision.
- Closes #1335

closes #1338
closes #1337
closes #1336
closes #1335

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] `npm audit --audit-level=high` passes — or vulnerability triaged in `SECURITY.md`
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed
