### PR TITLE
Fix issues #1311-1314: Comprehensive donation service improvements

### DIFF
--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -40,6 +40,7 @@ const {
   serializeAsset,
 } = require('../utils/stellarAsset');
 const donationEvents = require('../events/donationEvents');
+const Cache = require('../utils/cache');
 
 const DEFAULT_DESTINATION_ASSET = {
   type: 'native',
@@ -47,12 +48,24 @@ const DEFAULT_DESTINATION_ASSET = {
   issuer: null,
 };
 
-const RECIPIENT_ACCOUNT_CACHE_TTL_MS = 60 * 1000;
-const _recipientAccountCache = new Map();
+// Cache constants
+const RECIPIENT_ACCOUNT_CACHE_KEY_PREFIX = 'recipient_account:';
+const POSITIVE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes for accounts that exist
+const NEGATIVE_CACHE_TTL_MS = 30 * 1000; // 30 seconds for accounts that don't exist (shorter to allow for funding)
 
 class DonationService {
   constructor(stellarService) {
     this.stellarService = stellarService;
+  }
+
+  /**
+   * Invalidate recipient account cache for a specific public key.
+   * Call this when a wallet is created/funded to prevent stale negative cache.
+   * @param {string} publicKey - Stellar public key to invalidate cache for
+   */
+  static invalidateRecipientAccountCache(publicKey) {
+    const cacheKey = `${RECIPIENT_ACCOUNT_CACHE_KEY_PREFIX}${publicKey}`;
+    Cache.delete(cacheKey);
   }
 
   /**
@@ -68,22 +81,28 @@ class DonationService {
       return;
     }
 
-    const now = Date.now();
-    const cached = _recipientAccountCache.get(publicKey);
-    if (cached && now < cached.expiresAt) {
-      if (!cached.exists) {
+    // Check cache first
+    const cacheKey = `${RECIPIENT_ACCOUNT_CACHE_KEY_PREFIX}${publicKey}`;
+    const cachedResult = Cache.get(cacheKey);
+    
+    if (cachedResult !== null) {
+      // Cache hit - check if result indicates account exists
+      if (cachedResult === false) {
         throw new BusinessLogicError(
           ERROR_CODES.RECIPIENT_ACCOUNT_NOT_FOUND,
           'Recipient account does not exist on the Stellar network. The recipient must fund their account with at least 1 XLM before receiving donations.'
         );
       }
-      return;
+      return; // Account exists
     }
 
+    // Cache miss - check with Stellar network
     const info = await this.stellarService.getAccountInfo(publicKey);
     const exists = !info.notFound && !info.error;
 
-    _recipientAccountCache.set(publicKey, { exists, expiresAt: now + RECIPIENT_ACCOUNT_CACHE_TTL_MS });
+    // Cache the result with appropriate TTL
+    const ttlMs = exists ? POSITIVE_CACHE_TTL_MS : NEGATIVE_CACHE_TTL_MS;
+    Cache.set(cacheKey, exists, ttlMs);
 
     if (!exists) {
       throw new BusinessLogicError(
@@ -218,6 +237,11 @@ class DonationService {
     // Get sender and receiver
     const sender = await this.getUserById(senderId, 'Sender');
     const receiver = await this.getUserById(receiverId, 'Receiver');
+
+    // Validate sender and receiver are different (prevent self-donation)
+    if (sender.publicKey === receiver.publicKey) {
+      throw new ValidationError('Sender and recipient cannot be the same wallet', null, ERROR_CODES.INVALID_REQUEST);
+    }
 
     log.debug('DONATION_SERVICE', 'Users retrieved', {
       requestId,
@@ -1085,6 +1109,54 @@ class DonationService {
   }
 
   /**
+   * Process follow-up actions for batch donations (campaign, matching, corporate matching)
+   * This is a shared helper used by processBatch() to ensure consistent processing
+   * @param {Object} transaction - Created transaction object
+   * @param {number} campaignId - Campaign ID (optional)
+   * @param {string} donorPublicKey - Donor's public key
+   */
+  async processBatchDonationFollowUp(transaction, campaignId, donorPublicKey) {
+    // Process campaign contribution if campaign_id is provided
+    if (campaignId) {
+      await this.processCampaignContribution(campaignId, transaction.amount).catch(err => {
+        log.error('DONATION_SERVICE', 'Failed to update campaign contribution', { error: err.message });
+      });
+    }
+
+    // Process donation matching programs (non-blocking)
+    try {
+      const matchingDonations = await MatchingProgramService.processMatchingDonation({
+        id: transaction.id,
+        amount: parseFloat(transaction.amount),
+        campaign_id: campaignId || null
+      });
+      if (matchingDonations.length > 0) {
+        transaction.matchingDonations = matchingDonations;
+      }
+    } catch (err) {
+      log.error('DONATION_SERVICE', 'Failed to process donation matching', { error: err.message });
+    }
+
+    // Process corporate matching programs (non-blocking)
+    try {
+      // Get sender user ID from public key
+      const senderUser = await Database.get('SELECT id FROM users WHERE publicKey = ?', [donorPublicKey]);
+      if (senderUser) {
+        const corporateMatchingResults = await CorporateMatchingService.processCorporateMatching({
+          id: transaction.id,
+          amount: transaction.amount,
+          senderId: senderUser.id
+        });
+        if (corporateMatchingResults.length > 0) {
+          transaction.corporateMatchingDonations = corporateMatchingResults;
+        }
+      }
+    } catch (err) {
+      log.error('DONATION_SERVICE', 'Failed to process corporate matching', { error: err.message });
+    }
+  }
+
+  /**
    * Update campaign progress with milestone detection and webhook dispatch
    * @param {number} campaignId - Campaign ID
    * @param {number} amount - Donation amount
@@ -1211,7 +1283,8 @@ class DonationService {
   /**
    * Process a batch of donations (up to 100).
    * Donations sharing the same donor are grouped into a single multi-operation Stellar transaction.
-   * @param {Array<{amount, currency, donor, recipient, memo, idempotencyKey}>} donations
+   * If batch transaction fails, falls back to processing donations individually.
+   * @param {Array<{amount, currency, donor, recipient, memo, idempotencyKey, campaign_id?}>} donations
    * @returns {Promise<Array<{index, success, data?, error?}>>}
    */
   async processBatch(donations) {
@@ -1250,11 +1323,13 @@ class DonationService {
 
       if (prepared.length === 0) return;
 
-      // Attempt multi-op Stellar transaction for the whole group
+      // First attempt: multi-op Stellar transaction for the whole group
+      let batchSuccess = false;
+      let stellarResult = null;
+      
       try {
         const sender = await this.getUserById(prepared[0].sanitizedDonor, 'Donor').catch(() => null);
-        let stellarResult = null;
-
+        
         if (sender && sender.encryptedSecret) {
           const secret = encryption.decrypt(sender.encryptedSecret);
           const payments = prepared.map(p => ({
@@ -1263,8 +1338,19 @@ class DonationService {
             memo: p.memo,
           }));
           stellarResult = await this.stellarService.sendBatchDonations(secret, payments);
+          batchSuccess = true;
         }
+      } catch (batchError) {
+        log.warn('DONATION_SERVICE', 'Batch transaction failed, falling back to individual donations', {
+          donor: prepared[0].sanitizedDonor,
+          error: batchError.message,
+          donationCount: prepared.length
+        });
+        batchSuccess = false;
+      }
 
+      // If batch succeeded, process all donations as successful
+      if (batchSuccess) {
         for (const p of prepared) {
           const feeCalc = calculateAnalyticsFee(p.xlmAmount);
           const transaction = Transaction.create({
@@ -1279,12 +1365,69 @@ class DonationService {
             analyticsFeePercentage: feeCalc.feePercentage,
             ...(stellarResult ? { stellarTxId: stellarResult.transactionId, stellarLedger: stellarResult.ledger } : {}),
           });
+          
+          // Process campaign, matching, and corporate matching for batch donations
+          await this.processBatchDonationFollowUp(transaction, p.d.campaign_id, p.sanitizedDonor).catch(err => {
+            log.error('DONATION_SERVICE', 'Failed to process batch donation follow-up', {
+              donationIndex: p.d.index,
+              error: err.message
+            });
+          });
+          
           results[p.d.index] = { index: p.d.index, success: true, data: transaction };
         }
-      } catch (err) {
-        for (const p of prepared) {
-          results[p.d.index] = { index: p.d.index, success: false, error: { code: err.code || 'TRANSACTION_FAILED', message: err.message } };
-        }
+      } else {
+        // Batch failed - fall back to processing donations individually
+        await Promise.all(prepared.map(async (p) => {
+          try {
+            const sender = await this.getUserById(p.sanitizedDonor, 'Donor').catch(() => null);
+            let individualStellarResult = null;
+
+            if (sender && sender.encryptedSecret) {
+              const secret = encryption.decrypt(sender.encryptedSecret);
+              individualStellarResult = await this.stellarService.sendDonation({
+                sourceSecret: secret,
+                destinationPublic: p.sanitizedRecipient,
+                amount: p.xlmAmount.toString(),
+                memo: p.memo
+              });
+            }
+
+            const feeCalc = calculateAnalyticsFee(p.xlmAmount);
+            const transaction = Transaction.create({
+              amount: p.xlmAmount,
+              originalAmount: (p.d.currency || 'XLM').toUpperCase() !== 'XLM' ? p.d.amount : undefined,
+              originalCurrency: (p.d.currency || 'XLM').toUpperCase() !== 'XLM' ? (p.d.currency).toUpperCase() : undefined,
+              donor: p.sanitizedDonor,
+              recipient: p.sanitizedRecipient,
+              memo: p.memo,
+              idempotencyKey: p.d.idempotencyKey,
+              analyticsFee: feeCalc.fee,
+              analyticsFeePercentage: feeCalc.feePercentage,
+              ...(individualStellarResult ? { stellarTxId: individualStellarResult.transactionId, stellarLedger: individualStellarResult.ledger } : {}),
+            });
+            
+            // Process campaign, matching, and corporate matching for individual donations
+            await this.processBatchDonationFollowUp(transaction, p.d.campaign_id, p.sanitizedDonor).catch(err => {
+              log.error('DONATION_SERVICE', 'Failed to process individual donation follow-up', {
+                donationIndex: p.d.index,
+                error: err.message
+              });
+            });
+            
+            results[p.d.index] = { index: p.d.index, success: true, data: transaction };
+          } catch (individualError) {
+            results[p.d.index] = { 
+              index: p.d.index, 
+              success: false, 
+              error: { 
+                code: individualError.code || 'TRANSACTION_FAILED', 
+                message: individualError.message,
+                fallback: true // Indicate this was a fallback attempt
+              } 
+            };
+          }
+        }));
       }
     }));
 

--- a/src/services/WalletService.js
+++ b/src/services/WalletService.js
@@ -15,6 +15,7 @@ const { sanitizeLabel, sanitizeName, sanitizeStellarAddress } = require('../util
 const { ValidationError, NotFoundError, ERROR_CODES } = require('../utils/errors');
 const { paginateCollection } = require('../utils/pagination');
 const log = require('../utils/log');
+const DonationService = require('./DonationService');
 
 class WalletService {
   constructor(stellarService = null) {
@@ -83,6 +84,22 @@ class WalletService {
             reason: fundResult.error || 'non-testnet network'
           });
         }
+      }
+    }
+
+    // Invalidate recipient account cache to prevent stale negative cache entries
+    // This allows donations to succeed immediately after wallet creation
+    if (funded) {
+      try {
+        DonationService.invalidateRecipientAccountCache(sanitizedAddress);
+        log.debug('WALLET_SERVICE', 'Invalidated recipient account cache after funding', {
+          address: sanitizedAddress
+        });
+      } catch (err) {
+        log.warn('WALLET_SERVICE', 'Failed to invalidate recipient account cache', {
+          address: sanitizedAddress,
+          error: err.message
+        });
       }
     }
 

--- a/tests/issues/issues-1311-1312-1313-1314.test.js
+++ b/tests/issues/issues-1311-1312-1313-1314.test.js
@@ -1,0 +1,652 @@
+/**
+ * Tests for Issues #1311, #1312, #1313, #1314
+ * 
+ * #1311 - sendCustodialDonation() doesn't reject self-donation
+ * #1312 - checkRecipientAccountExists() caching issues
+ * #1313 - processBatch() all-or-nothing failure
+ * #1314 - processBatch() silent skip of campaign/matching processing
+ */
+
+const DonationService = require('../../src/services/DonationService');
+const WalletService = require('../../src/services/WalletService');
+const Database = require('../../src/utils/database');
+const Cache = require('../../src/utils/cache');
+const { ValidationError, BusinessLogicError } = require('../../src/utils/errors');
+
+// Mock dependencies
+jest.mock('../../src/utils/database');
+jest.mock('../../src/utils/cache');
+jest.mock('../../src/services/StellarService');
+jest.mock('../../src/services/PriceOracleService');
+
+describe('Issues #1311-1314: Donation Service Improvements', () => {
+  let donationService;
+  let walletService;
+  let mockStellarService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Create mock Stellar service
+    mockStellarService = {
+      getAccountInfo: jest.fn(),
+      sendDonation: jest.fn(),
+      sendBatchDonations: jest.fn(),
+      fundWithFriendbot: jest.fn(),
+      getBalance: jest.fn()
+    };
+
+    donationService = new DonationService(mockStellarService);
+    walletService = new WalletService(mockStellarService);
+    
+    // Reset Cache before each test
+    Cache.get.mockReturnValue(null);
+    Cache.set.mockImplementation(() => {});
+    Cache.delete.mockImplementation(() => {});
+  });
+
+  describe('#1311: sendCustodialDonation() self-donation validation', () => {
+    test('should reject self-donation in sendCustodialDonation()', async () => {
+      // Mock users with same public key
+      const samePublicKey = 'GABC123';
+      
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE id = ?')) {
+          return Promise.resolve({ 
+            id: params[0], 
+            publicKey: samePublicKey,
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      Database.runTransaction.mockImplementation(async (callback) => {
+        const mockTx = {
+          run: jest.fn().mockResolvedValue({ id: 999 })
+        };
+        return callback(mockTx);
+      });
+
+      // Mock other dependencies
+      const mockLimitService = {
+        checkLimits: jest.fn().mockResolvedValue(),
+        getRemainingLimits: jest.fn().mockResolvedValue({ dailyRemaining: 1000, monthlyRemaining: 10000 })
+      };
+      
+      const mockDonationVelocityService = {
+        checkVelocityLimits: jest.fn().mockResolvedValue(),
+        recordDonation: jest.fn().mockResolvedValue()
+      };
+
+      // Replace with mocks
+      require('../../src/services/DonationService').LimitService = mockLimitService;
+      require('../../src/services/DonationService').DonationVelocityService = mockDonationVelocityService;
+
+      // Mock Stellar service to simulate successful transaction
+      mockStellarService.sendDonation.mockResolvedValue({
+        hash: 'tx123',
+        transactionId: 'tx123',
+        ledger: 12345
+      });
+
+      mockStellarService.getBalance.mockResolvedValue({
+        balance: '1000'
+      });
+
+      // Expect ValidationError for self-donation
+      await expect(
+        donationService.sendCustodialDonation({
+          senderId: 1,
+          receiverId: 2, // Different IDs but same public key
+          amount: 10,
+          memo: 'test',
+          idempotencyKey: 'test-key',
+          requestId: 'test-request'
+        })
+      ).rejects.toThrow('Sender and recipient cannot be the same wallet');
+    });
+
+    test('should accept valid donation with different sender/receiver', async () => {
+      // Mock users with different public keys
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE id = ?')) {
+          const isSender = params[0] === 1;
+          return Promise.resolve({ 
+            id: params[0], 
+            publicKey: isSender ? 'GABC123' : 'GDEF456', // Different public keys
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      Database.runTransaction.mockImplementation(async (callback) => {
+        const mockTx = {
+          run: jest.fn().mockResolvedValue({ id: 999 })
+        };
+        return callback(mockTx);
+      });
+
+      // Mock other dependencies
+      const mockLimitService = {
+        checkLimits: jest.fn().mockResolvedValue(),
+        getRemainingLimits: jest.fn().mockResolvedValue({ dailyRemaining: 1000, monthlyRemaining: 10000 })
+      };
+      
+      const mockDonationVelocityService = {
+        checkVelocityLimits: jest.fn().mockResolvedValue(),
+        recordDonation: jest.fn().mockResolvedValue()
+      };
+
+      // Replace with mocks
+      require('../../src/services/DonationService').LimitService = mockLimitService;
+      require('../../src/services/DonationService').DonationVelocityService = mockDonationVelocityService;
+
+      // Mock Stellar service to simulate successful transaction
+      mockStellarService.sendDonation.mockResolvedValue({
+        hash: 'tx123',
+        transactionId: 'tx123',
+        ledger: 12345
+      });
+
+      mockStellarService.getBalance.mockResolvedValue({
+        balance: '1000'
+      });
+
+      const result = await donationService.sendCustodialDonation({
+        senderId: 1,
+        receiverId: 2,
+        amount: 10,
+        memo: 'test',
+        idempotencyKey: 'test-key',
+        requestId: 'test-request'
+      });
+
+      expect(result.success).toBeUndefined(); // Not batch, so no success field
+      expect(result.id).toBe(999);
+      expect(result.stellarTxId).toBe('tx123');
+    });
+  });
+
+  describe('#1312: checkRecipientAccountExists() caching improvements', () => {
+    test('should use positive cache TTL for existing accounts', async () => {
+      const publicKey = 'GEXIST123';
+      
+      // Mock account exists
+      mockStellarService.getAccountInfo.mockResolvedValue({
+        notFound: false,
+        error: null
+      });
+
+      // First call - should cache
+      await donationService.checkRecipientAccountExists(publicKey);
+      
+      expect(Cache.set).toHaveBeenCalledWith(
+        `recipient_account:${publicKey}`,
+        true,
+        5 * 60 * 1000 // 5 minutes positive TTL
+      );
+    });
+
+    test('should use negative cache TTL for non-existing accounts', async () => {
+      const publicKey = 'GNONEXIST123';
+      
+      // Mock account doesn't exist
+      mockStellarService.getAccountInfo.mockResolvedValue({
+        notFound: true,
+        error: null
+      });
+
+      // Should throw and cache negative result
+      await expect(
+        donationService.checkRecipientAccountExists(publicKey)
+      ).rejects.toThrow(BusinessLogicError);
+      
+      expect(Cache.set).toHaveBeenCalledWith(
+        `recipient_account:${publicKey}`,
+        false,
+        30 * 1000 // 30 seconds negative TTL
+      );
+    });
+
+    test('should invalidate cache when called', () => {
+      const publicKey = 'GTEST123';
+      
+      DonationService.invalidateRecipientAccountCache(publicKey);
+      
+      expect(Cache.delete).toHaveBeenCalledWith(
+        `recipient_account:${publicKey}`
+      );
+    });
+
+    test('should use cached result for existing accounts', async () => {
+      const publicKey = 'GCACHED123';
+      
+      // Mock cache hit for existing account
+      Cache.get.mockReturnValue(true);
+      
+      // Should not call Stellar service
+      await donationService.checkRecipientAccountExists(publicKey);
+      
+      expect(mockStellarService.getAccountInfo).not.toHaveBeenCalled();
+    });
+
+    test('should use cached result for non-existing accounts and throw', async () => {
+      const publicKey = 'GCACHEDNEG123';
+      
+      // Mock cache hit for non-existing account
+      Cache.get.mockReturnValue(false);
+      
+      // Should throw without calling Stellar service
+      await expect(
+        donationService.checkRecipientAccountExists(publicKey)
+      ).rejects.toThrow(BusinessLogicError);
+      
+      expect(mockStellarService.getAccountInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#1313: processBatch() fallback logic', () => {
+    test('should fall back to individual donations when batch fails', async () => {
+      const donations = [
+        { donor: 'GDONOR1', recipient: 'GRECIPIENT1', amount: 10, memo: 'test1', idempotencyKey: 'key1' },
+        { donor: 'GDONOR1', recipient: 'GRECIPIENT2', amount: 20, memo: 'test2', idempotencyKey: 'key2' }
+      ];
+
+      // Mock database queries
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ 
+            id: 1, 
+            publicKey: params[0],
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // Mock batch transaction failure
+      mockStellarService.sendBatchDonations.mockRejectedValue(
+        new Error('Batch transaction failed')
+      );
+
+      // Mock successful individual transactions
+      mockStellarService.sendDonation.mockResolvedValue({
+        hash: 'tx-individual',
+        transactionId: 'tx-individual',
+        ledger: 12345
+      });
+
+      // Mock price oracle
+      const mockPriceOracle = {
+        convertToXLM: jest.fn().mockImplementation((amount) => Promise.resolve(amount))
+      };
+      require('../../src/services/PriceOracleService').default = mockPriceOracle;
+
+      const results = await donationService.processBatch(donations);
+
+      // Verify batch was attempted
+      expect(mockStellarService.sendBatchDonations).toHaveBeenCalled();
+      
+      // Verify individual fallback was attempted for both donations
+      expect(mockStellarService.sendDonation).toHaveBeenCalledTimes(2);
+      
+      // Both should succeed with fallback
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(true);
+      expect(results[0].error).toBeUndefined();
+      expect(results[1].error).toBeUndefined();
+    });
+
+    test('should handle mixed success/failure in fallback mode', async () => {
+      const donations = [
+        { donor: 'GDONOR1', recipient: 'GRECIPIENT1', amount: 10, memo: 'test1', idempotencyKey: 'key1' },
+        { donor: 'GDONOR1', recipient: 'GRECIPIENT2', amount: 20, memo: 'test2', idempotencyKey: 'key2' }
+      ];
+
+      // Mock database queries
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ 
+            id: 1, 
+            publicKey: params[0],
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // Mock batch transaction failure
+      mockStellarService.sendBatchDonations.mockRejectedValue(
+        new Error('Batch transaction failed')
+      );
+
+      // Mock mixed individual transaction results
+      mockStellarService.sendDonation
+        .mockResolvedValueOnce({
+          hash: 'tx-success',
+          transactionId: 'tx-success',
+          ledger: 12345
+        })
+        .mockRejectedValueOnce(new Error('Individual transaction failed'));
+
+      // Mock price oracle
+      const mockPriceOracle = {
+        convertToXLM: jest.fn().mockImplementation((amount) => Promise.resolve(amount))
+      };
+      require('../../src/services/PriceOracleService').default = mockPriceOracle;
+
+      const results = await donationService.processBatch(donations);
+
+      // Verify mixed results
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(false);
+      expect(results[1].error).toBeDefined();
+      expect(results[1].error.fallback).toBe(true); // Should indicate fallback attempt
+    });
+
+    test('should succeed with batch transaction when possible', async () => {
+      const donations = [
+        { donor: 'GDONOR1', recipient: 'GRECIPIENT1', amount: 10, memo: 'test1', idempotencyKey: 'key1' },
+        { donor: 'GDONOR1', recipient: 'GRECIPIENT2', amount: 20, memo: 'test2', idempotencyKey: 'key2' }
+      ];
+
+      // Mock database queries
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ 
+            id: 1, 
+            publicKey: params[0],
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // Mock successful batch transaction
+      mockStellarService.sendBatchDonations.mockResolvedValue({
+        hash: 'tx-batch',
+        transactionId: 'tx-batch',
+        ledger: 12345
+      });
+
+      // Mock price oracle
+      const mockPriceOracle = {
+        convertToXLM: jest.fn().mockImplementation((amount) => Promise.resolve(amount))
+      };
+      require('../../src/services/PriceOracleService').default = mockPriceOracle;
+
+      const results = await donationService.processBatch(donations);
+
+      // Verify batch was used
+      expect(mockStellarService.sendBatchDonations).toHaveBeenCalled();
+      
+      // Individual transactions should not be called
+      expect(mockStellarService.sendDonation).not.toHaveBeenCalled();
+      
+      // Both should succeed
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(true);
+    });
+  });
+
+  describe('#1314: processBatch() campaign/matching processing', () => {
+    test('should process campaign contributions for batch donations', async () => {
+      const donations = [
+        { 
+          donor: 'GDONOR1', 
+          recipient: 'GRECIPIENT1', 
+          amount: 10, 
+          memo: 'test1', 
+          idempotencyKey: 'key1',
+          campaign_id: 123
+        }
+      ];
+
+      // Mock dependencies
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ 
+            id: 1, 
+            publicKey: params[0],
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      Database.run.mockResolvedValue({ changes: 1 });
+
+      // Mock successful batch transaction
+      mockStellarService.sendBatchDonations.mockResolvedValue({
+        hash: 'tx-batch',
+        transactionId: 'tx-batch',
+        ledger: 12345
+      });
+
+      // Mock price oracle
+      const mockPriceOracle = {
+        convertToXLM: jest.fn().mockImplementation((amount) => Promise.resolve(amount))
+      };
+      require('../../src/services/PriceOracleService').default = mockPriceOracle;
+
+      // Mock campaign processing services
+      const mockMatchingProgramService = {
+        processMatchingDonation: jest.fn().mockResolvedValue([])
+      };
+      const mockCorporateMatchingService = {
+        processCorporateMatching: jest.fn().mockResolvedValue([])
+      };
+
+      // Replace with mocks
+      require('../../src/services/DonationService').MatchingProgramService = mockMatchingProgramService;
+      require('../../src/services/DonationService').CorporateMatchingService = mockCorporateMatchingService;
+
+      const results = await donationService.processBatch(donations);
+
+      // Verify batch was processed successfully
+      expect(results[0].success).toBe(true);
+      
+      // Campaign processing should be called
+      expect(Database.run).toHaveBeenCalled(); // Campaign update query
+      
+      // Matching program processing should be attempted
+      expect(mockMatchingProgramService.processMatchingDonation).toHaveBeenCalledWith({
+        id: expect.any(String),
+        amount: 10,
+        campaign_id: 123
+      });
+    });
+
+    test('should handle donation matching programs for batch donations', async () => {
+      const donations = [
+        { 
+          donor: 'GDONOR1', 
+          recipient: 'GRECIPIENT1', 
+          amount: 10, 
+          memo: 'test1', 
+          idempotencyKey: 'key1',
+          campaign_id: 123
+        }
+      ];
+
+      // Mock dependencies
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ 
+            id: 1, 
+            publicKey: params[0],
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        if (query.includes('SELECT id FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ id: 1 });
+        }
+        return Promise.resolve(null);
+      });
+
+      Database.run.mockResolvedValue({ changes: 1 });
+
+      // Mock successful batch transaction
+      mockStellarService.sendBatchDonations.mockResolvedValue({
+        hash: 'tx-batch',
+        transactionId: 'tx-batch',
+        ledger: 12345
+      });
+
+      // Mock price oracle
+      const mockPriceOracle = {
+        convertToXLM: jest.fn().mockImplementation((amount) => Promise.resolve(amount))
+      };
+      require('../../src/services/PriceOracleService').default = mockPriceOracle;
+
+      // Mock matching results
+      const mockMatchingDonations = [
+        { id: 'match1', amount: 5, program: 'test-program' }
+      ];
+      const mockCorporateMatchingResults = [
+        { id: 'corp1', amount: 3, company: 'test-corp' }
+      ];
+
+      const mockMatchingProgramService = {
+        processMatchingDonation: jest.fn().mockResolvedValue(mockMatchingDonations)
+      };
+      const mockCorporateMatchingService = {
+        processCorporateMatching: jest.fn().mockResolvedValue(mockCorporateMatchingResults)
+      };
+
+      // Replace with mocks
+      require('../../src/services/DonationService').MatchingProgramService = mockMatchingProgramService;
+      require('../../src/services/DonationService').CorporateMatchingService = mockCorporateMatchingService;
+
+      const results = await donationService.processBatch(donations);
+
+      // Verify batch was processed successfully
+      expect(results[0].success).toBe(true);
+      expect(results[0].data).toBeDefined();
+      
+      // Matching program processing should be called
+      expect(mockMatchingProgramService.processMatchingDonation).toHaveBeenCalled();
+      expect(mockCorporateMatchingService.processCorporateMatching).toHaveBeenCalled();
+    });
+  });
+
+  describe('Integration: All issues together', () => {
+    test('comprehensive test covering all four issues', async () => {
+      // Setup test data covering all scenarios
+      const testData = {
+        // Issue #1311: Different sender/receiver
+        senderId: 1,
+        receiverId: 2,
+        amount: 10,
+        
+        // Issue #1312: Caching
+        publicKey: 'GTESTINT123',
+        
+        // Issue #1313: Batch donations  
+        batchDonations: [
+          { donor: 'GDONOR1', recipient: 'GRECIPIENT1', amount: 10, memo: 'test1', idempotencyKey: 'key1', campaign_id: 123 },
+          { donor: 'GDONOR1', recipient: 'GRECIPIENT2', amount: 20, memo: 'test2', idempotencyKey: 'key2', campaign_id: 123 }
+        ]
+      };
+
+      // Test Issue #1311
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE id = ?')) {
+          const isSender = params[0] === testData.senderId;
+          return Promise.resolve({ 
+            id: params[0], 
+            publicKey: isSender ? 'GSENDER123' : 'GRECEIVER456', // Different keys
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      // Should not throw for self-donation (different public keys)
+      await expect(
+        donationService.sendCustodialDonation({
+          senderId: testData.senderId,
+          receiverId: testData.receiverId,
+          amount: testData.amount,
+          memo: 'test',
+          idempotencyKey: 'test-key',
+          requestId: 'test-request'
+        })
+      ).resolves.not.toThrow('Sender and recipient cannot be the same wallet');
+
+      // Test Issue #1312
+      Cache.get.mockReturnValue(null);
+      mockStellarService.getAccountInfo.mockResolvedValue({
+        notFound: false,
+        error: null
+      });
+
+      await donationService.checkRecipientAccountExists(testData.publicKey);
+      expect(Cache.set).toHaveBeenCalledWith(
+        `recipient_account:${testData.publicKey}`,
+        true,
+        5 * 60 * 1000
+      );
+
+      // Test cache invalidation
+      DonationService.invalidateRecipientAccountCache(testData.publicKey);
+      expect(Cache.delete).toHaveBeenCalledWith(
+        `recipient_account:${testData.publicKey}`
+      );
+
+      // Test Issues #1313 and #1314 with batch processing
+      Database.get.mockImplementation((query, params) => {
+        if (query.includes('SELECT * FROM users WHERE publicKey = ?')) {
+          return Promise.resolve({ 
+            id: 1, 
+            publicKey: params[0],
+            encryptedSecret: 'encrypted-secret-123'
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      Database.run.mockResolvedValue({ changes: 1 });
+
+      // Mock batch failure with fallback
+      mockStellarService.sendBatchDonations.mockRejectedValue(new Error('Batch failed'));
+      mockStellarService.sendDonation.mockResolvedValue({
+        hash: 'tx-individual',
+        transactionId: 'tx-individual',
+        ledger: 12345
+      });
+
+      // Mock price oracle
+      const mockPriceOracle = {
+        convertToXLM: jest.fn().mockImplementation((amount) => Promise.resolve(amount))
+      };
+      require('../../src/services/PriceOracleService').default = mockPriceOracle;
+
+      // Mock matching services
+      const mockMatchingProgramService = {
+        processMatchingDonation: jest.fn().mockResolvedValue([])
+      };
+      const mockCorporateMatchingService = {
+        processCorporateMatching: jest.fn().mockResolvedValue([])
+      };
+
+      require('../../src/services/DonationService').MatchingProgramService = mockMatchingProgramService;
+      require('../../src/services/DonationService').CorporateMatchingService = mockCorporateMatchingService;
+
+      const results = await donationService.processBatch(testData.batchDonations);
+
+      // Verify fallback was used (Issue #1313)
+      expect(mockStellarService.sendDonation).toHaveBeenCalledTimes(2);
+      
+      // Verify campaign/matching processing was attempted (Issue #1314)
+      expect(Database.run).toHaveBeenCalled(); // Campaign update
+      expect(mockMatchingProgramService.processMatchingDonation).toHaveBeenCalled();
+      
+      // Verify all donations succeeded
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
#1311 - sendCustodialDonation() self-donation validation
- Added validation to prevent self-donation in sendCustodialDonation()
- Checks sender.publicKey !== receiver.publicKey before processing
- Uses same error message/code as createDonationRecord() for consistency

#1312 - checkRecipientAccountExists() caching improvements
- Replaced unbounded Map with Cache utility for memory management
- Positive cache TTL: 5 minutes for existing accounts
- Negative cache TTL: 30 seconds for non-existing accounts (shorter to allow funding)
- Added static invalidateRecipientAccountCache() method
- WalletService invalidates cache after funding new wallets
- Prevents stale negative cache when accounts are newly funded

#1313 - processBatch() fallback logic for partial failures
- Added two-phase batch processing: batch attempt → individual fallback
- On batch transaction failure, falls back to processing donations individually
- Each donation gets independent success/failure status
- Failed individual donations marked with 'fallback: true' indicator
- Prevents all-or-nothing failure cascades across unrelated donations

#1314 - processBatch() campaign and matching program processing
- Added processBatchDonationFollowUp() helper method
- Handles campaign contributions, matching programs, and corporate matching
- Called for both batch successes and individual fallback donations
- Ensures batch donations get same downstream processing as single donations
- Campaign milestones, webhooks, and matching programs work for batch submissions

Testing:
- Created comprehensive test file tests/issues/issues-1311-1312-1313-1314.test.js
- Unit tests for each issue with mock dependencies
- Integration tests covering all four issues together
- Verifies self-donation rejection, caching behavior, batch fallback, and campaign processing

All fixes ensure consistency between custodial/non-custodial and single/batch donation paths.

Closes #1311 
Closes #1312 
Closes #1313 
Closes #1314 
