### PR TITLE
Fix batch of 4 critical issues

### DIFF
--- a/src/services/FeeBumpService.js
+++ b/src/services/FeeBumpService.js
@@ -84,6 +84,9 @@ class FeeBumpService {
     let feeStroops = newFee;
     const feeSource = feeSourceSecret || this.feeSourceSecret;
 
+    // Increment attempt counter before attempting fee bump so failed attempts count toward the limit
+    const attemptCount = (tx.feeBumpCount || 0) + 1;
+
     try {
       if (feeStroops === null || feeStroops === undefined) {
         const feeEstimate = await this.stellarService.estimateFee(1);
@@ -108,10 +111,9 @@ class FeeBumpService {
       );
 
       const now = new Date().toISOString();
-      const newCount = (tx.feeBumpCount || 0) + 1;
 
       Transaction.updateFeeBumpData(transactionId, {
-        feeBumpCount: newCount,
+        feeBumpCount: attemptCount,
         currentFee: feeStroops,
         lastFeeBumpAt: now,
         envelopeXdr: result.envelopeXdr,
@@ -128,7 +130,7 @@ class FeeBumpService {
           transactionId,
           originalFee: tx.currentFee || tx.originalFee,
           newFee: feeStroops,
-          feeBumpCount: newCount,
+          feeBumpCount: attemptCount,
           stellarHash: result.hash,
         },
       }).catch(() => {});
@@ -137,7 +139,7 @@ class FeeBumpService {
         transactionId,
         originalFee: tx.currentFee || tx.originalFee,
         newFee: feeStroops,
-        attempt: newCount,
+        attempt: attemptCount,
       });
 
       return {
@@ -145,10 +147,19 @@ class FeeBumpService {
         transactionId,
         originalFee: tx.currentFee || tx.originalFee,
         newFee: feeStroops,
-        feeBumpCount: newCount,
+        feeBumpCount: attemptCount,
         hash: result.hash,
       };
     } catch (error) {
+      // Update fee bump count even on failure so failed attempts count toward the limit
+      Transaction.updateFeeBumpData(transactionId, {
+        feeBumpCount: attemptCount,
+        // Keep current fee unchanged on failure
+        lastFeeBumpAt: new Date().toISOString(),
+      }).catch(() => {
+        // Silently ignore DB update failures for failed fee bumps
+      });
+
       // Don't re-throw our own validation errors
       if (error.errorCode && error.errorCode.startsWith && error.errorCode.startsWith('FEE_BUMP_')) {
         throw error;
@@ -162,12 +173,14 @@ class FeeBumpService {
         details: {
           transactionId,
           attemptedFee: feeStroops,
+          feeBumpCount: attemptCount,
           error: error.message,
         },
       }).catch(() => {});
 
       log.error('FEE_BUMP', 'Fee bump failed', {
         transactionId,
+        attempt: attemptCount,
         error: error.message,
       });
 

--- a/src/services/PaymentStreamService.js
+++ b/src/services/PaymentStreamService.js
@@ -150,10 +150,22 @@ class PaymentStreamService {
           log.error('PAYMENT_STREAM', 'Error handling payment', { publicKey, error: err.message });
         });
       },
-      { cursor: liveOptions.cursor || 'now' }
+      { 
+        cursor: liveOptions.cursor || 'now',
+        onError: (error) => {
+          log.warn('PAYMENT_STREAM', 'Stream error, scheduling reconnect', { 
+            publicKey, 
+            error: error.message 
+          });
+          // Schedule reconnection with current options and cursor
+          const entry = this.activeStreams.get(publicKey);
+          const currentAttempt = entry && entry.reconnectAttempt !== undefined ? entry.reconnectAttempt : 0;
+          this._reconnect(publicKey, liveOptions, currentAttempt + 1);
+        }
+      }
     );
 
-    this.activeStreams.set(publicKey, { stop, reconnectTimer: null, options: liveOptions });
+    this.activeStreams.set(publicKey, { stop, reconnectTimer: null, reconnectAttempt: 0, options: liveOptions });
     this._persistStream(publicKey, liveOptions);
   }
 
@@ -239,6 +251,14 @@ class PaymentStreamService {
    * @param {number} [attempt=0]
    */
   _reconnect(publicKey, options, attempt = 0) {
+    const entry = this.activeStreams.get(publicKey);
+    
+    // Clear any existing reconnect timer to prevent multiple reconnections
+    if (entry && entry.reconnectTimer) {
+      clearTimeout(entry.reconnectTimer);
+      entry.reconnectTimer = null;
+    }
+
     if (attempt >= MAX_RECONNECT_ATTEMPTS) {
       log.error('PAYMENT_STREAM', 'Max reconnect attempts reached, giving up', { publicKey, attempt });
       this.activeStreams.delete(publicKey);
@@ -252,15 +272,16 @@ class PaymentStreamService {
     const timer = setTimeout(() => {
       log.info('PAYMENT_STREAM', 'Reconnecting stream', { publicKey, attempt });
       // Use the live options stored in the entry (has latest cursor)
-      const entry = this.activeStreams.get(publicKey);
-      this.subscribe(publicKey, entry ? entry.options : options);
+      const currentEntry = this.activeStreams.get(publicKey);
+      this.subscribe(publicKey, currentEntry ? currentEntry.options : options);
     }, delay);
 
-    const entry = this.activeStreams.get(publicKey);
     if (entry) {
       entry.reconnectTimer = timer;
+      // Track the attempt count in the entry
+      entry.reconnectAttempt = attempt;
     } else {
-      this.activeStreams.set(publicKey, { stop: null, reconnectTimer: timer, options });
+      this.activeStreams.set(publicKey, { stop: null, reconnectTimer: timer, reconnectAttempt: attempt, options });
     }
   }
 

--- a/src/services/stellar/payments.js
+++ b/src/services/stellar/payments.js
@@ -109,8 +109,14 @@ class StellarPayments {
           destination: destinationPublic,
           asset: paymentAsset,
           amount: amount.toString(),
-        }))
-        .setTimeout(30);
+        }));
+
+      // Only set default timeout when no explicit time bounds are requested
+      // (validAfter/validBefore are set as strings in timebounds above)
+      // We check if maxTime is non-zero (has explicit expiration)
+      if (!validBefore || validBefore === '0' || validBefore === 0) {
+        transaction.setTimeout(30);
+      }
 
       if (memo) {
         const MemoValidator = require('../../utils/memoValidator');
@@ -193,9 +199,19 @@ class StellarPayments {
       }
 
       const bestRecord = [...records].sort((left, right) => {
-        const leftDest = parseFloat(left.destination_amount || left.destination_amount_max || '0');
-        const rightDest = parseFloat(right.destination_amount || right.destination_amount_max || '0');
-        return rightDest - leftDest;
+        if (destAmount) {
+          // For strict-receive paths (fixed destination amount), sort by source_amount ascending
+          // to find the cheapest route for the sender
+          const leftSource = parseFloat(left.source_amount || '0');
+          const rightSource = parseFloat(right.source_amount || '0');
+          return leftSource - rightSource;
+        } else {
+          // For strict-send paths (fixed source amount), sort by destination_amount descending
+          // to find the best return for the sender
+          const leftDest = parseFloat(left.destination_amount || left.destination_amount_max || '0');
+          const rightDest = parseFloat(right.destination_amount || right.destination_amount_max || '0');
+          return rightDest - leftDest;
+        }
       })[0];
 
       const normalizedPath = (bestRecord.path || []).map(normalizeHorizonAsset);
@@ -337,7 +353,7 @@ class StellarPayments {
     }, 'getTransactionHistory');
   }
 
-  streamTransactions(publicKey, onTransaction, { cursor = 'now' } = {}) {
+  streamTransactions(publicKey, onTransaction, { cursor = 'now', onError = null } = {}) {
     const streamTimeout = this.service.timeouts.stream;
     let lastMessageTime = Date.now();
     let timeoutTimer = null;
@@ -379,6 +395,10 @@ class StellarPayments {
             error: error.message,
             publicKey
           });
+          // If an onError callback was provided, call it to allow for reconnection
+          if (onError && typeof onError === 'function') {
+            onError(error);
+          }
         },
       });
 


### PR DESCRIPTION
#1307: Fix StellarPayments.sendDonation() timeout conflict with time bounds
- Only call .setTimeout(30) when no explicit validBefore/validAfter time bounds are set
- Prevents 'TimeBounds.max_time has already been set' error when using scheduled/expiring transactions

#1308: Fix discoverBestPath() sorting for strict-receive quotes
- Sort by source_amount ascending for strict-receive paths (cheapest for sender)
- Sort by destination_amount descending for strict-send paths (best return for sender)
- Prevents users paying more than necessary for fixed-receive-amount donations

#1309: Fix PaymentStreamService dead code - implement auto-reconnect
- Add onError callback parameter to streamTransactions()
- Wire stream errors to _reconnect() with exponential backoff
- Streams now automatically recover from network disconnects as documented

#1310: Fix FeeBumpService.feeBump() failed attempt counting
- Increment feeBumpCount before attempting fee bump operation
- Failed attempts now count toward MAX_FEE_BUMP_ATTEMPTS limit
- Prevents infinite retry loops for systematically failing transactions

Closes #1307 
Closes #1308 
Closes #1309 
Closes #1310 
