### PR TITLE
Fix critical issues #1315-1318

### DIFF
--- a/src/migrations/029_pledge_webhook_sent_at.js
+++ b/src/migrations/029_pledge_webhook_sent_at.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Migration 029: Add webhook_sent_at column to pledges table
+ *
+ * This column tracks when webhooks were sent for pledge status changes
+ * (fulfilled or expired) to prevent duplicate webhook deliveries.
+ */
+
+exports.name = '029_pledge_webhook_sent_at';
+
+exports.up = async (db) => {
+  // Add webhook_sent_at column only if missing
+  const columns = await db.all('PRAGMA table_info(pledges)');
+  const hasColumn = columns.some(c => c.name === 'webhook_sent_at');
+
+  if (!hasColumn) {
+    await db.run('ALTER TABLE pledges ADD COLUMN webhook_sent_at DATETIME');
+  }
+
+  // Create index for efficient querying of unsent webhooks
+  await db.run(`
+    CREATE INDEX IF NOT EXISTS idx_pledges_webhook_sent_at
+    ON pledges(webhook_sent_at)
+    WHERE webhook_sent_at IS NULL
+  `);
+};
+
+exports.down = async (db) => {
+  // Note: SQLite does not support DROP COLUMN on older versions
+  // The column will remain but won't be used if migration is rolled back
+  await db.run('DROP INDEX IF EXISTS idx_pledges_webhook_sent_at');
+};

--- a/src/migrations/030_corporate_match_ratio_float.js
+++ b/src/migrations/030_corporate_match_ratio_float.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * Migration 030: Change matchRatio from INTEGER to REAL to support fractional match ratios
+ *
+ * Corporate donation-matching programs commonly use fractional rates like
+ * 0.5x (50%), 1.5x (150%), etc. The current INTEGER type prevents this.
+ */
+
+exports.name = '030_corporate_match_ratio_float';
+
+exports.up = async (db) => {
+  // SQLite doesn't support ALTER COLUMN type directly
+  // We need to recreate the table with the new column type
+  const columns = await db.all('PRAGMA table_info(corporate_employers)');
+  const matchRatioColumn = columns.find(c => c.name === 'matchRatio');
+  
+  if (matchRatioColumn && matchRatioColumn.type.toUpperCase() === 'INTEGER') {
+    // Create temporary table with REAL matchRatio
+    await db.run(`
+      CREATE TABLE corporate_employers_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        matchRatio REAL NOT NULL,
+        annualCap REAL NOT NULL,
+        addedAt TEXT NOT NULL
+      )
+    `);
+    
+    // Copy data from old table
+    await db.run(`
+      INSERT INTO corporate_employers_new (id, name, matchRatio, annualCap, addedAt)
+      SELECT id, name, CAST(matchRatio AS REAL), annualCap, addedAt
+      FROM corporate_employers
+    `);
+    
+    // Drop old table
+    await db.run('DROP TABLE corporate_employers');
+    
+    // Rename new table
+    await db.run('ALTER TABLE corporate_employers_new RENAME TO corporate_employers');
+  }
+  
+  // Ensure indexes exist
+  await db.run('CREATE INDEX IF NOT EXISTS idx_corporate_employers_id ON corporate_employers(id)');
+};
+
+exports.down = async (db) => {
+  // Revert back to INTEGER type if needed
+  const columns = await db.all('PRAGMA table_info(corporate_employers)');
+  const matchRatioColumn = columns.find(c => c.name === 'matchRatio');
+  
+  if (matchRatioColumn && matchRatioColumn.type.toUpperCase() === 'REAL') {
+    // Create temporary table with INTEGER matchRatio
+    await db.run(`
+      CREATE TABLE corporate_employers_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        matchRatio INTEGER NOT NULL,
+        annualCap REAL NOT NULL,
+        addedAt TEXT NOT NULL
+      )
+    `);
+    
+    // Copy data from old table, rounding matchRatio to nearest integer
+    await db.run(`
+      INSERT INTO corporate_employers_new (id, name, matchRatio, annualCap, addedAt)
+      SELECT id, name, ROUND(matchRatio), annualCap, addedAt
+      FROM corporate_employers
+    `);
+    
+    // Drop old table
+    await db.run('DROP TABLE corporate_employers');
+    
+    // Rename new table
+    await db.run('ALTER TABLE corporate_employers_new RENAME TO corporate_employers');
+  }
+};

--- a/src/models/Pledge.js
+++ b/src/models/Pledge.js
@@ -18,6 +18,7 @@ const TABLE = `
     expires_at      DATETIME NOT NULL,
     cancel_reason   TEXT,
     cancelled_at    DATETIME,
+    webhook_sent_at DATETIME,
     created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (campaign_id) REFERENCES campaigns(id)
   )
@@ -28,6 +29,7 @@ async function initTable() {
   await Database.run(`CREATE INDEX IF NOT EXISTS idx_pledges_campaign ON pledges(campaign_id)`);
   await Database.run(`CREATE INDEX IF NOT EXISTS idx_pledges_status   ON pledges(status)`);
   await Database.run(`CREATE INDEX IF NOT EXISTS idx_pledges_expires  ON pledges(expires_at)`);
+  await Database.run(`CREATE INDEX IF NOT EXISTS idx_pledges_webhook_sent_at ON pledges(webhook_sent_at) WHERE webhook_sent_at IS NULL`);
 }
 
 async function create({ campaign_id, donor_wallet_id, amount, expires_at }) {
@@ -71,6 +73,48 @@ async function getExpiredPledges(now = new Date().toISOString()) {
   return Database.query(
     `SELECT * FROM pledges WHERE status = 'expired' AND expires_at < ?`,
     [now]
+  );
+}
+
+/**
+ * Get pledges that have expired but haven't had webhooks sent yet
+ * @param {string} now - ISO timestamp
+ * @returns {Promise<Object[]>}
+ */
+async function getNewlyExpiredPledges(now = new Date().toISOString()) {
+  return Database.query(
+    `SELECT * FROM pledges 
+     WHERE status = 'expired' 
+       AND expires_at < ?
+       AND webhook_sent_at IS NULL`,
+    [now]
+  );
+}
+
+/**
+ * Get pledges that have been fulfilled but haven't had webhooks sent yet
+ * @param {number} campaignId
+ * @returns {Promise<Object[]>}
+ */
+async function getNewlyFulfilledPledges(campaignId) {
+  return Database.query(
+    `SELECT * FROM pledges 
+     WHERE campaign_id = ? 
+       AND status = 'fulfilled'
+       AND webhook_sent_at IS NULL`,
+    [campaignId]
+  );
+}
+
+/**
+ * Mark webhook as sent for a pledge
+ * @param {string} pledgeId
+ * @returns {Promise<void>}
+ */
+async function markWebhookSent(pledgeId) {
+  await Database.run(
+    `UPDATE pledges SET webhook_sent_at = CURRENT_TIMESTAMP WHERE id = ?`,
+    [pledgeId]
   );
 }
 
@@ -122,6 +166,9 @@ module.exports = {
   fulfillAll,
   expireOverdue,
   getExpiredPledges,
+  getNewlyExpiredPledges,
+  getNewlyFulfilledPledges,
+  markWebhookSent,
   findById,
   listAll,
   cancel,

--- a/src/services/AccountMonitorService.js
+++ b/src/services/AccountMonitorService.js
@@ -232,8 +232,7 @@ class AccountMonitorService {
           timeout: 5000,
         });
       } else if (monitor.alertConfig.channel === 'email') {
-        // Placeholder — wire up nodemailer / SES in production
-        log.info('ACCOUNT_MONITOR_SERVICE', 'EMAIL alert queued', { email: monitor.alertConfig.email, payload });
+        await this._sendEmailAlert(monitor.alertConfig.email, monitor, alert);
       }
       logEntry.delivered = true;
     } catch (err) {
@@ -242,6 +241,103 @@ class AccountMonitorService {
     }
 
     this._alertLog.push(logEntry);
+  }
+
+  /**
+   * Send email alert using nodemailer
+   * @private
+   * @param {string} email - Recipient email address
+   * @param {object} monitor - Monitor configuration
+   * @param {object} alert - Alert details
+   */
+  async _sendEmailAlert(email, monitor, alert) {
+    // Check if SMTP is configured
+    if (!process.env.SMTP_HOST || !process.env.SMTP_PORT) {
+      log.warn('ACCOUNT_MONITOR_SERVICE', 'SMTP not configured, skipping email alert', { email });
+      throw new Error('SMTP configuration is required for email alerts');
+    }
+
+    // Initialize nodemailer transporter
+    const nodemailer = require('nodemailer');
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || '587', 10),
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: process.env.SMTP_USER ? {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      } : undefined,
+    });
+
+    // Create email subject and body based on alert condition
+    let subject, text, html;
+    
+    switch (alert.condition) {
+      case 'incoming_transaction':
+        subject = `Stellar Alert: Incoming transaction to ${monitor.accountId}`;
+        text = `An incoming transaction of ${alert.tx.amount} XLM was detected on account ${monitor.accountId}.`;
+        html = `<h2>Incoming Transaction Alert</h2>
+                <p>An incoming transaction was detected on account <strong>${monitor.accountId}</strong>.</p>
+                <ul>
+                  <li><strong>Amount:</strong> ${alert.tx.amount} XLM</li>
+                  <li><strong>From:</strong> ${alert.tx.source || 'Unknown'}</li>
+                  <li><strong>Timestamp:</strong> ${new Date().toISOString()}</li>
+                  <li><strong>Monitor ID:</strong> ${monitor.id}</li>
+                </ul>`;
+        break;
+        
+      case 'low_balance':
+        subject = `Stellar Alert: Low balance on ${monitor.accountId}`;
+        text = `Account ${monitor.accountId} balance (${alert.balance} XLM) is below threshold (${monitor.balanceThreshold} XLM).`;
+        html = `<h2>Low Balance Alert</h2>
+                <p>Account <strong>${monitor.accountId}</strong> has a low balance.</p>
+                <ul>
+                  <li><strong>Current Balance:</strong> ${alert.balance} XLM</li>
+                  <li><strong>Threshold:</strong> ${monitor.balanceThreshold} XLM</li>
+                  <li><strong>Timestamp:</strong> ${new Date().toISOString()}</li>
+                  <li><strong>Monitor ID:</strong> ${monitor.id}</li>
+                </ul>`;
+        break;
+        
+      case 'large_transaction':
+        subject = `Stellar Alert: Large transaction on ${monitor.accountId}`;
+        text = `A large transaction of ${alert.tx.amount} XLM was detected on account ${monitor.accountId}.`;
+        html = `<h2>Large Transaction Alert</h2>
+                <p>A large transaction was detected on account <strong>${monitor.accountId}</strong>.</p>
+                <ul>
+                  <li><strong>Amount:</strong> ${alert.tx.amount} XLM</li>
+                  <li><strong>Threshold:</strong> ${monitor.amountThreshold} XLM</li>
+                  <li><strong>Timestamp:</strong> ${new Date().toISOString()}</li>
+                  <li><strong>Monitor ID:</strong> ${monitor.id}</li>
+                </ul>`;
+        break;
+        
+      default:
+        subject = `Stellar Alert: ${alert.condition} on ${monitor.accountId}`;
+        text = `Alert condition "${alert.condition}" triggered on account ${monitor.accountId}.`;
+        html = `<h2>Account Alert</h2>
+                <p>Alert condition <strong>${alert.condition}</strong> was triggered on account <strong>${monitor.accountId}</strong>.</p>`;
+    }
+
+    const mailOptions = {
+      from: process.env.SMTP_FROM || 'alerts@stellar-donations.org',
+      to: email,
+      subject,
+      text,
+      html,
+    };
+
+    try {
+      await transporter.sendMail(mailOptions);
+      log.info('ACCOUNT_MONITOR_SERVICE', 'Email alert sent successfully', { email, monitorId: monitor.id });
+    } catch (error) {
+      log.error('ACCOUNT_MONITOR_SERVICE', 'Failed to send email alert', { 
+        email, 
+        monitorId: monitor.id,
+        error: error.message 
+      });
+      throw error;
+    }
   }
 }
 

--- a/src/services/CorporateMatchingService.js
+++ b/src/services/CorporateMatchingService.js
@@ -16,7 +16,9 @@ class CorporateMatchingService {
 
   async addEmployer(employerId, name, matchRatio, annualCap) {
     if (!employerId || !name) throw new Error('employerId and name are required');
-    if (![1, 2, 3].includes(matchRatio)) throw new Error('matchRatio must be 1, 2, or 3');
+    if (typeof matchRatio !== 'number' || matchRatio <= 0 || matchRatio > 10) {
+      throw new Error('matchRatio must be a positive number between 0.01 and 10');
+    }
     if (!annualCap || annualCap <= 0) throw new Error('annualCap must be a positive number');
 
     const addedAt = new Date().toISOString();

--- a/src/services/PledgeFulfillmentService.js
+++ b/src/services/PledgeFulfillmentService.js
@@ -37,17 +37,22 @@ async function checkAndFulfill(campaignId) {
     [campaignId]
   );
 
-  const fulfilled = await Database.query(
-    `SELECT * FROM pledges WHERE campaign_id = ? AND status = 'fulfilled'`,
-    [campaignId]
-  );
+  // Get only newly fulfilled pledges (those without webhook_sent_at)
+  const newlyFulfilled = await Pledge.getNewlyFulfilledPledges(campaignId);
 
-  for (const pledge of fulfilled) {
-    WebhookService.deliver('pledge.fulfilled', { pledge }).catch(() => {});
+  // Send webhooks and mark them as sent
+  for (const pledge of newlyFulfilled) {
+    try {
+      await WebhookService.deliver('pledge.fulfilled', { pledge });
+      await Pledge.markWebhookSent(pledge.id);
+    } catch (error) {
+      log.error('PLEDGE', `Failed to deliver webhook for pledge ${pledge.id}: ${error.message}`);
+      // Don't mark as sent if delivery failed
+    }
   }
 
-  log.info('PLEDGE', `Fulfilled ${fulfilled.length} pledges for campaign ${campaignId}`);
-  return { fulfilled: fulfilled.length };
+  log.info('PLEDGE', `Fulfilled ${newlyFulfilled.length} pledges for campaign ${campaignId}`);
+  return { fulfilled: newlyFulfilled.length };
 }
 
 /**
@@ -61,11 +66,21 @@ async function expireOverdue(now = new Date().toISOString()) {
   const changed = await Pledge.expireOverdue(now);
 
   if (changed > 0) {
-    const expired = await Pledge.getExpiredPledges(now);
-    for (const pledge of expired) {
-      WebhookService.deliver('pledge.expired', { pledge }).catch(() => {});
+    // Get only newly expired pledges (those without webhook_sent_at)
+    const newlyExpired = await Pledge.getNewlyExpiredPledges(now);
+    
+    // Send webhooks and mark them as sent
+    for (const pledge of newlyExpired) {
+      try {
+        await WebhookService.deliver('pledge.expired', { pledge });
+        await Pledge.markWebhookSent(pledge.id);
+      } catch (error) {
+        log.error('PLEDGE', `Failed to deliver webhook for expired pledge ${pledge.id}: ${error.message}`);
+        // Don't mark as sent if delivery failed
+      }
     }
-    log.info('PLEDGE', `Expired ${changed} overdue pledges`);
+    
+    log.info('PLEDGE', `Expired ${changed} overdue pledges, sent ${newlyExpired.length} webhooks`);
   }
 
   return { expired: changed };

--- a/src/services/TaxReceiptService.js
+++ b/src/services/TaxReceiptService.js
@@ -140,6 +140,7 @@ class TaxReceiptService {
         t.xlm_usd_rate,
         t.fair_market_value_usd,
         t.stellar_tx_id,
+        t.status,
         sender.publicKey as donorPublicKey,
         receiver.publicKey as recipientPublicKey
       FROM transactions t
@@ -151,6 +152,16 @@ class TaxReceiptService {
 
     if (!donation) {
       throw new NotFoundError('Donation not found', ERROR_CODES.DONATION_NOT_FOUND);
+    }
+
+    // Check if donation is in a valid state for tax receipt generation
+    const invalidStatuses = ['refunded', 'failed', 'cancelled'];
+    if (donation.status && invalidStatuses.includes(donation.status.toLowerCase())) {
+      throw new ValidationError(
+        `Cannot generate tax receipt for a donation with status "${donation.status}"`,
+        null,
+        ERROR_CODES.INVALID_REQUEST
+      );
     }
 
     return donation;
@@ -321,10 +332,12 @@ class TaxReceiptService {
         t.xlm_usd_rate,
         t.fair_market_value_usd,
         t.tax_receipt_generated,
+        t.status,
         sender.publicKey as donorPublicKey
       FROM transactions t
       LEFT JOIN users sender ON t.senderId = sender.id
       WHERE 1=1
+      AND t.status NOT IN ('refunded', 'failed', 'cancelled')
     `;
     const params = [];
 

--- a/tests/corporate-matching-extended.test.js
+++ b/tests/corporate-matching-extended.test.js
@@ -35,7 +35,23 @@ describe('POST /admin/corporate-matching/employers', () => {
   });
 
   it('rejects invalid matchRatio', async () => {
-    const res = await addEmployer({ matchRatio: 5 });
+    // Test with value outside valid range (0.01-10)
+    const res = await addEmployer({ matchRatio: 15 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects zero matchRatio', async () => {
+    const res = await addEmployer({ matchRatio: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects negative matchRatio', async () => {
+    const res = await addEmployer({ matchRatio: -1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-numeric matchRatio', async () => {
+    const res = await addEmployer({ matchRatio: 'not-a-number' });
     expect(res.status).toBe(400);
   });
 
@@ -49,6 +65,26 @@ describe('POST /admin/corporate-matching/employers', () => {
     const res = await addEmployer({ matchRatio: 3, annualCap: 2000 });
     expect(res.status).toBe(201);
     expect(res.body.data.matchRatio).toBe(3);
+  });
+
+  it('accepts fractional matchRatio', async () => {
+    const res = await addEmployer({ matchRatio: 0.5 });
+    expect(res.status).toBe(201);
+    expect(res.body.data.matchRatio).toBe(0.5);
+  });
+
+  it('calculates correct match with fractional ratio', async () => {
+    // Add employer with 0.5x match ratio
+    await addEmployer({ matchRatio: 0.5 });
+    
+    // Submit a claim
+    const res = await request(app)
+      .post('/corporate-matching/claim')
+      .send({ donorId: 'donor1', employerId: 'acme', donationAmount: 100 });
+    
+    expect(res.status).toBe(201);
+    // 100 * 0.5 = 50
+    expect(res.body.data.matchAmount).toBe(50);
   });
 });
 


### PR DESCRIPTION
#1315: PledgeFulfillmentService re-delivers webhooks for already-fulfilled/expired pledges
- Added webhook_sent_at column to pledges table via migration 029
- Modified PledgeFulfillmentService.checkAndFulfill() and expireOverdue() to only send webhooks for pledges without webhook_sent_at
- Added getNewlyFulfilledPledges(), getNewlyExpiredPledges(), and markWebhookSent() methods to Pledge model
- Added database index for efficient querying of unsent webhooks

#1316: CorporateMatchingService.addEmployer() can't represent fractional match ratios
- Changed matchRatio column from INTEGER to REAL via migration 030
- Updated CorporateMatchingService.addEmployer() to accept any positive number (0.01-10) instead of just integer enum
- The downstream calculation logic already supported arbitrary positive numbers

#1317: TaxReceiptService can generate IRS tax receipts for refunded donations
- Added status field to getDonationForReceipt() SELECT query
- Added validation to reject receipt generation for donations with status 'refunded', 'failed', or 'cancelled'
- Updated getEligibleDonations() to exclude refunded/failed/cancelled donations
- Added clear error message when attempting to generate receipt for invalid status

#1318: AccountMonitorService's email alert channel is a no-op that reports success anyway
- Implemented _sendEmailAlert() method with actual nodemailer integration
- Added proper email templates for different alert conditions (incoming_transaction, low_balance, large_transaction)
- Added SMTP configuration check and validation
- Email alerts now only marked as delivered when sendMail() succeeds
- Added comprehensive error handling and logging

All fixes include appropriate data validation, error handling, and follow existing code patterns.

Closes #1315 
Closes #1316 
Closes #1317 
Closes #1318 