### PR TITLE
fix: resolve issues #1319, #1320, #1321, and #1322

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,7 @@ function createApp() {
   const recurringDonationScheduler = serviceContainer.getRecurringDonationScheduler();
   const networkStatusService = serviceContainer.getNetworkStatusService();
   const transactionSyncScheduler = serviceContainer.getTransactionSyncScheduler();
+  const feeBumpService = serviceContainer.getFeeBumpService();
 
   const { setService: setNetworkService } = require('./routes/network');
   setNetworkService(networkStatusService);
@@ -46,6 +47,7 @@ function createApp() {
     recurringDonationScheduler,
     networkStatusService,
     transactionSyncScheduler,
+    feeBumpService,
   });
 
   return app;

--- a/src/bootstrap/routes.js
+++ b/src/bootstrap/routes.js
@@ -71,6 +71,8 @@ const ADMIN_ROUTES = [
   ['/admin/geo-rules',                require('../routes/admin/geoRules')],
   ['/admin/payment-channels',         require('../routes/admin/paymentChannels')],
   ['/admin/system-info',              require('../routes/admin/systemInfo')],
+  ['/admin/feature-flags',            require('../routes/admin/featureFlags')],
+  ['/admin',                          require('../routes/admin')],
   ['/admin',                          require('../routes/admin/backup')],
   ['/admin/audit-logs/export',        require('../routes/admin/auditLogExport')],
   ['/admin/security/scan',            require('../routes/admin/securityScan')],
@@ -130,6 +132,7 @@ function mountRoutes(app, services = {}) {
     networkStatusService,
     recurringDonationScheduler,
     transactionSyncScheduler,
+    feeBumpService,
   } = services;
 
   // Network route needs a service reference injected at mount time
@@ -329,6 +332,12 @@ function mountRoutes(app, services = {}) {
 
   for (const [path, router] of ADMIN_ROUTES) {
     app.use(path, router);
+  }
+
+  const effectiveFeeBumpService = feeBumpService || (require('../config/serviceContainer').getFeeBumpService ? require('../config/serviceContainer').getFeeBumpService() : null);
+  if (effectiveFeeBumpService) {
+    const createFeeBumpRouter = require('../routes/admin/feeBump');
+    app.use('/admin/transactions', createFeeBumpRouter(effectiveFeeBumpService));
   }
 
   app.use('/admin/totp', requireApiKey, require('../routes/admin/totp'));

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,22 @@
+/**
+ * Auth Middleware
+ *
+ * RESPONSIBILITY: Provide admin verification and general authentication middleware.
+ * DEPENDENCIES: rbac middleware
+ */
+
+'use strict';
+
+const rbac = require('./rbac');
+
+/**
+ * Verify admin authorization middleware.
+ */
+const verifyAdmin = (req, res, next) => {
+  return rbac.requireAdmin()(req, res, next);
+};
+
+module.exports = {
+  verifyAdmin,
+  requireAdmin: verifyAdmin,
+};

--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -1859,14 +1859,26 @@ class DonationService {
       reverseTxId: reverseResult.transactionId
     });
 
+    const actualFee = reverseResult.feePaid !== undefined
+      ? reverseResult.feePaid
+      : (reverseResult.fee !== undefined ? reverseResult.fee : (reverseResult.fee_charged !== undefined ? reverseResult.fee_charged : 100));
+    const networkFeeDeducted = typeof actualFee === 'number' && actualFee >= 100 ? actualFee / STROOPS_PER_XLM : Number(actualFee || 0);
+
+    const analyticsFeePercentage = donation.analyticsFeePercentage !== undefined ? donation.analyticsFeePercentage : 0;
+    const analyticsFee = donation.analyticsFee !== undefined
+      ? donation.analyticsFee
+      : (donation.amount * analyticsFeePercentage) / 100;
+    const refundedAmount = donation.amount - analyticsFee;
+
     return {
       refundId: pendingRecord.id,
       originalDonationId: donationId,
       reverseTxId: reverseResult.transactionId,
       reverseLedger: reverseResult.ledger,
       amount: donation.amount,
-      refundedAmount: donation.amount,
-      networkFeeDeducted: 0,
+      refundedAmount: refundedAmount > 0 ? refundedAmount : donation.amount,
+      analyticsFeeRetained: analyticsFee,
+      networkFeeDeducted,
       reason,
       notes: notes || null,
       refundedAt: new Date().toISOString(),


### PR DESCRIPTION
Detailed summary of resolution for all 4 issues:

1. Fix #1322 - Mount admin manual fee-bump endpoint for stuck transactions
   - Problem: src/routes/admin/feeBump.js exported createFeeBumpRouter(feeBumpService) implementing POST /admin/transactions/:id/fee-bump, but was unmounted.
   - Solution: Extracted feeBumpService from serviceContainer in src/app.js and passed it to mountRoutes(). In src/bootstrap/routes.js, mounted createFeeBumpRouter(feeBumpService) under /admin/transactions.

2. Fix #1321 - Mount entire admin feature-flags CRUD API
   - Problem: src/routes/admin/featureFlags.js fully implemented feature flags management endpoints but was missing from ADMIN_ROUTES.
   - Solution: Added ['/admin/feature-flags', require('../routes/admin/featureFlags')] to ADMIN_ROUTES in src/bootstrap/routes.js.

3. Fix #1320 - Implement auth middleware and mount admin i18n router
   - Problem: src/routes/admin.js required a non-existent src/middleware/auth.js module (verifyAdmin) and was unmounted.
   - Solution: Created src/middleware/auth.js delegating verifyAdmin to rbac.requireAdmin(). Added ['/admin', require('../routes/admin')] to ADMIN_ROUTES in src/bootstrap/routes.js.

4. Fix #1319 - Populate networkFeeDeducted and reconcile analytics fee on refund
   - Problem: DonationService.refundDonation() hardcoded networkFeeDeducted: 0 and ignored original platform analytics fees.
   - Solution: Updated refundDonation() in src/services/DonationService.js to extract actual transaction fee from reverseResult, populate networkFeeDeducted, calculate analyticsFeeRetained, and adjust refundedAmount accordingly.

Closes #1319, Closes #1320, Closes #1321, Closes #1322

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] `npm audit --audit-level=high` passes — or vulnerability triaged in `SECURITY.md`
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed
