### PR TITLE
fix: resolve issues #1376, #1377, #1378, #1379

### DIFF
--- a/src/bootstrap/server.js
+++ b/src/bootstrap/server.js
@@ -117,9 +117,6 @@ async function startServer(app, overrideServices = {}) {
       next();
     });
 
-    // Attach WebSocket servers immediately after bind
-    attachSubscriptionServer(server);
-    require('../services/websocketService').attach(server);
 
     let cleanupInterval = null;
     let replayCleanupTimer = null;
@@ -132,6 +129,12 @@ async function startServer(app, overrideServices = {}) {
         await runMigrations();
         await initializeApiKeysTable();
         initializeDefaultStore(Database);
+
+        // ── Attach WebSocket servers after migrations and api_keys table are ready ──
+        // This prevents clients from hitting raw database errors (missing tables)
+        // during the brief startup window before the schema is fully initialised.
+        attachSubscriptionServer(server);
+        require('../services/websocketService').attach(server);
 
         const { initializeFeatureFlagsTable, loadFlagsFromEnv } = require('../utils/featureFlags');
         await initializeFeatureFlagsTable();

--- a/src/jobs/reconcileTotalsJob.js
+++ b/src/jobs/reconcileTotalsJob.js
@@ -10,13 +10,21 @@
 
 const DonationTotalsRepository = require('../services/DonationTotalsRepository');
 const log = require('../utils/log');
+const leaderElection = require('../utils/leaderElection');
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const LOCK_NAME = 'reconcile_totals_job';
 
 let _timer = null;
 const _repo = new DonationTotalsRepository();
 
 async function runOnce() {
+  const isLeader = await leaderElection.acquireLease(LOCK_NAME, DEFAULT_INTERVAL_MS * 2);
+  if (!isLeader) {
+    log.debug('RECONCILE_TOTALS_JOB', 'Skipping reconciliation tick — lease held by another instance');
+    return;
+  }
+
   try {
     const result = await _repo.reconcile();
     log.info('RECONCILE_TOTALS_JOB', 'Reconciliation complete', result);

--- a/src/services/DonationService.js
+++ b/src/services/DonationService.js
@@ -323,17 +323,15 @@ class DonationService {
       return r;
     });
 
-    // Emit donation.created to trigger cache invalidation and other listeners (non-blocking)
-    try {
-      donationEvents.emit(donationEvents.constructor.EVENTS?.CREATED || 'donation.created', {
-        id: dbResult.id,
-        senderId,
-        receiverId,
-        amount,
-      });
-    } catch (err) {
-      log.error('DONATION_SERVICE', 'Failed to emit donation.created event', { error: err.message });
-    }
+    // Emit donation.created to trigger cache invalidation and other listeners (non-blocking).
+    // emitLifecycleEvent() wraps each listener in its own try/catch so a single
+    // failing listener cannot prevent sibling listeners from running.
+    donationEvents.emitLifecycleEvent(donationEvents.constructor.EVENTS?.CREATED || 'donation.created', {
+      id: dbResult.id,
+      senderId,
+      receiverId,
+      amount,
+    });
 
     if (campaign_id) {
       await this.processCampaignContribution(campaign_id, amount).catch(err => {

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -78,16 +78,74 @@ const getAllForLanguage = async (lang = 'en') => {
 const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'pt'];
 
 const MESSAGES = {
-  VALIDATION_ERROR:    { en: 'Validation error',      es: 'Error de validación',        fr: 'Erreur de validation',             pt: 'Erro de validação' },
-  INVALID_REQUEST:     { en: 'Invalid request',       es: 'Solicitud inválida',         fr: 'Requête invalide',                 pt: 'Requisição inválida' },
-  NOT_FOUND:           { en: 'Resource not found',    es: 'Recurso no encontrado',      fr: 'Ressource introuvable',            pt: 'Recurso não encontrado' },
-  UNAUTHORIZED:        { en: 'Unauthorized',          es: 'No autorizado',              fr: 'Non autorisé',                     pt: 'Não autorizado' },
-  ACCESS_DENIED:       { en: 'Access denied',         es: 'Acceso denegado',            fr: 'Accès refusé',                     pt: 'Acesso negado' },
-  FORBIDDEN:           { en: 'Forbidden',             es: 'Prohibido',                  fr: 'Interdit',                         pt: 'Proibido' },
-  INTERNAL_ERROR:      { en: 'Internal server error', es: 'Error interno del servidor', fr: 'Erreur interne du serveur',        pt: 'Erro interno do servidor' },
-  DUPLICATE_ERROR:     { en: 'Duplicate resource',    es: 'Recurso duplicado',          fr: 'Ressource en double',              pt: 'Recurso duplicado' },
-  RATE_LIMIT_EXCEEDED: { en: 'Rate limit exceeded',   es: 'Límite de tasa excedido',    fr: 'Limite de débit dépassée',         pt: 'Limite de taxa excedido' },
-  ENDPOINT_NOT_FOUND:  { en: 'Endpoint not found',    es: 'Punto final no encontrado',  fr: 'Point de terminaison introuvable', pt: 'Endpoint não encontrado' },
+  // ── Validation errors ────────────────────────────────────────────────────
+  VALIDATION_ERROR:       { en: 'Validation error',                       es: 'Error de validación',                    fr: 'Erreur de validation',                             pt: 'Erro de validação' },
+  INVALID_REQUEST:        { en: 'Invalid request',                        es: 'Solicitud inválida',                     fr: 'Requête invalide',                                 pt: 'Requisição inválida' },
+  INVALID_LIMIT:          { en: 'Invalid limit value',                    es: 'Valor de límite inválido',               fr: 'Valeur de limite invalide',                        pt: 'Valor de limite inválido' },
+  INVALID_OFFSET:         { en: 'Invalid offset value',                   es: 'Valor de desplazamiento inválido',       fr: 'Valeur de décalage invalide',                      pt: 'Valor de deslocamento inválido' },
+  INVALID_DATE_FORMAT:    { en: 'Invalid date format',                    es: 'Formato de fecha inválido',              fr: 'Format de date invalide',                          pt: 'Formato de data inválido' },
+  INVALID_AMOUNT:         { en: 'Invalid amount',                         es: 'Monto inválido',                         fr: 'Montant invalide',                                 pt: 'Valor inválido' },
+  INVALID_FREQUENCY:      { en: 'Invalid frequency',                      es: 'Frecuencia inválida',                    fr: 'Fréquence invalide',                               pt: 'Frequência inválida' },
+  MISSING_REQUIRED_FIELD: { en: 'Missing required field',                 es: 'Campo obligatorio faltante',             fr: 'Champ obligatoire manquant',                       pt: 'Campo obrigatório ausente' },
+  IDEMPOTENCY_KEY_REQUIRED:{ en: 'Idempotency key is required',           es: 'Se requiere clave de idempotencia',      fr: 'Clé d\'idempotence requise',                       pt: 'Chave de idempotência obrigatória' },
+  INVALID_SCHEMA_VERSION: { en: 'Invalid schema version',                 es: 'Versión de esquema inválida',            fr: 'Version de schéma invalide',                       pt: 'Versão de esquema inválida' },
+
+  // ── Authentication / Authorisation errors ────────────────────────────────
+  UNAUTHORIZED:             { en: 'Unauthorized',                         es: 'No autorizado',                          fr: 'Non autorisé',                                     pt: 'Não autorizado' },
+  ACCESS_DENIED:            { en: 'Access denied',                        es: 'Acceso denegado',                        fr: 'Accès refusé',                                     pt: 'Acesso negado' },
+  FORBIDDEN:                { en: 'Forbidden',                            es: 'Prohibido',                              fr: 'Interdit',                                         pt: 'Proibido' },
+  INSUFFICIENT_PERMISSIONS: { en: 'Insufficient permissions',             es: 'Permisos insuficientes',                 fr: 'Permissions insuffisantes',                        pt: 'Permissões insuficientes' },
+  INVALID_API_KEY:          { en: 'Invalid API key',                      es: 'Clave de API inválida',                  fr: 'Clé API invalide',                                 pt: 'Chave de API inválida' },
+
+  // ── Not found errors ─────────────────────────────────────────────────────
+  NOT_FOUND:             { en: 'Resource not found',                      es: 'Recurso no encontrado',                  fr: 'Ressource introuvable',                            pt: 'Recurso não encontrado' },
+  WALLET_NOT_FOUND:      { en: 'Wallet not found',                        es: 'Billetera no encontrada',                fr: 'Portefeuille introuvable',                         pt: 'Carteira não encontrada' },
+  TRANSACTION_NOT_FOUND: { en: 'Transaction not found',                   es: 'Transacción no encontrada',              fr: 'Transaction introuvable',                          pt: 'Transação não encontrada' },
+  USER_NOT_FOUND:        { en: 'User not found',                          es: 'Usuario no encontrado',                  fr: 'Utilisateur introuvable',                          pt: 'Usuário não encontrado' },
+  DONATION_NOT_FOUND:    { en: 'Donation not found',                      es: 'Donación no encontrada',                 fr: 'Don introuvable',                                  pt: 'Doação não encontrada' },
+  ENDPOINT_NOT_FOUND:    { en: 'Endpoint not found',                      es: 'Punto final no encontrado',              fr: 'Point de terminaison introuvable',                 pt: 'Endpoint não encontrado' },
+  METHOD_NOT_ALLOWED:    { en: 'Method not allowed',                      es: 'Método no permitido',                    fr: 'Méthode non autorisée',                            pt: 'Método não permitido' },
+
+  // ── Conflict / Duplicate errors ───────────────────────────────────────────
+  DUPLICATE_ERROR:       { en: 'Duplicate resource',                      es: 'Recurso duplicado',                      fr: 'Ressource en double',                              pt: 'Recurso duplicado' },
+  DUPLICATE_TRANSACTION: { en: 'Duplicate transaction',                   es: 'Transacción duplicada',                  fr: 'Transaction en double',                            pt: 'Transação duplicada' },
+  DUPLICATE_DONATION:    { en: 'Duplicate donation',                      es: 'Donación duplicada',                     fr: 'Don en double',                                    pt: 'Doação duplicada' },
+  RESOURCE_CONFLICT:     { en: 'Resource conflict',                       es: 'Conflicto de recurso',                   fr: 'Conflit de ressource',                             pt: 'Conflito de recurso' },
+
+  // ── Business logic errors ────────────────────────────────────────────────
+  INSUFFICIENT_BALANCE:     { en: 'Insufficient balance',                 es: 'Saldo insuficiente',                     fr: 'Solde insuffisant',                                pt: 'Saldo insuficiente' },
+  TRANSACTION_FAILED:       { en: 'Transaction failed',                   es: 'Transacción fallida',                    fr: 'Transaction échouée',                              pt: 'Transação falhou' },
+  INVALID_STATE_TRANSITION: { en: 'Invalid state transition',             es: 'Transición de estado inválida',          fr: 'Transition d\'état invalide',                      pt: 'Transição de estado inválida' },
+  FEE_BUMP_MAX_ATTEMPTS:    { en: 'Fee bump max attempts reached',        es: 'Se alcanzaron los intentos máximos de aumento de tarifa', fr: 'Nombre maximal de tentatives de majoration de frais atteint', pt: 'Número máximo de tentativas de aumento de taxa atingido' },
+  FEE_BUMP_EXCEEDS_CAP:     { en: 'Fee bump exceeds cap',                 es: 'El aumento de tarifa supera el límite',  fr: 'Majoration de frais dépassant le plafond',         pt: 'Aumento de taxa excede o limite' },
+  FEE_BUMP_INVALID_STATE:   { en: 'Invalid state for fee bump',           es: 'Estado inválido para aumento de tarifa', fr: 'État invalide pour majoration de frais',           pt: 'Estado inválido para aumento de taxa' },
+  FEE_BUMP_NO_ENVELOPE:     { en: 'No transaction envelope for fee bump', es: 'Sin sobre de transacción para aumento de tarifa', fr: 'Aucune enveloppe de transaction pour la majoration', pt: 'Sem envelope de transação para aumento de taxa' },
+  FEE_BUMP_FAILED:          { en: 'Fee bump failed',                      es: 'Falló el aumento de tarifa',             fr: 'Échec de la majoration de frais',                  pt: 'Aumento de taxa falhou' },
+
+  // ── Routing errors ───────────────────────────────────────────────────────
+  ROUTING_STRATEGY_REQUIRED:  { en: 'Routing strategy is required',       es: 'Se requiere una estrategia de enrutamiento', fr: 'Stratégie de routage requise',                 pt: 'Estratégia de roteamento é obrigatória' },
+  INVALID_ROUTING_STRATEGY:   { en: 'Invalid routing strategy',           es: 'Estrategia de enrutamiento inválida',    fr: 'Stratégie de routage invalide',                    pt: 'Estratégia de roteamento inválida' },
+  POOL_NAME_REQUIRED:         { en: 'Pool name is required',              es: 'El nombre del grupo es obligatorio',     fr: 'Le nom du pool est requis',                        pt: 'Nome do pool é obrigatório' },
+  POOL_NOT_FOUND:             { en: 'Pool not found',                     es: 'Grupo no encontrado',                    fr: 'Pool introuvable',                                 pt: 'Pool não encontrado' },
+  POOL_EMPTY:                 { en: 'Pool is empty',                      es: 'El grupo está vacío',                    fr: 'Le pool est vide',                                 pt: 'O pool está vazio' },
+  POOL_ALREADY_EXISTS:        { en: 'Pool already exists',                es: 'El grupo ya existe',                     fr: 'Le pool existe déjà',                              pt: 'O pool já existe' },
+  RECIPIENT_NOT_IN_POOL:      { en: 'Recipient not in pool',              es: 'El destinatario no está en el grupo',    fr: 'Destinataire absent du pool',                      pt: 'Destinatário não está no pool' },
+  DONOR_COORDINATES_REQUIRED: { en: 'Donor coordinates are required',     es: 'Se requieren coordenadas del donante',   fr: 'Les coordonnées du donneur sont requises',         pt: 'Coordenadas do doador são obrigatórias' },
+  NO_ELIGIBLE_RECIPIENTS:     { en: 'No eligible recipients found',       es: 'No se encontraron destinatarios elegibles', fr: 'Aucun destinataire éligible trouvé',            pt: 'Nenhum destinatário elegível encontrado' },
+  NO_ACTIVE_CAMPAIGNS:        { en: 'No active campaigns found',          es: 'No se encontraron campañas activas',     fr: 'Aucune campagne active trouvée',                   pt: 'Nenhuma campanha ativa encontrada' },
+  RECIPIENT_ACCOUNT_NOT_FOUND:{ en: 'Recipient account not found',        es: 'Cuenta del destinatario no encontrada',  fr: 'Compte du destinataire introuvable',               pt: 'Conta do destinatário não encontrada' },
+
+  // ── Rate limiting errors ─────────────────────────────────────────────────
+  RATE_LIMIT_EXCEEDED: { en: 'Rate limit exceeded',                       es: 'Límite de tasa excedido',                fr: 'Limite de débit dépassée',                         pt: 'Limite de taxa excedido' },
+
+  // ── Server errors ────────────────────────────────────────────────────────
+  INTERNAL_ERROR:         { en: 'Internal server error',                  es: 'Error interno del servidor',             fr: 'Erreur interne du serveur',                        pt: 'Erro interno do servidor' },
+  DATABASE_ERROR:         { en: 'Database error',                         es: 'Error de base de datos',                 fr: 'Erreur de base de données',                        pt: 'Erro de banco de dados' },
+  VERIFICATION_FAILED:    { en: 'Verification failed',                    es: 'Verificación fallida',                   fr: 'Échec de la vérification',                         pt: 'Verificação falhou' },
+  SERVICE_UNAVAILABLE:    { en: 'Service unavailable',                    es: 'Servicio no disponible',                 fr: 'Service indisponible',                             pt: 'Serviço indisponível' },
+  STELLAR_NETWORK_ERROR:  { en: 'Stellar network error',                  es: 'Error de red de Stellar',                fr: 'Erreur réseau Stellar',                            pt: 'Erro de rede Stellar' },
+  EXTERNAL_SERVICE_ERROR: { en: 'External service error',                 es: 'Error de servicio externo',              fr: 'Erreur de service externe',                        pt: 'Erro de serviço externo' },
+  NOT_IMPLEMENTED:        { en: 'Not implemented',                        es: 'No implementado',                        fr: 'Non implémenté',                                   pt: 'Não implementado' },
 };
 
 /**


### PR DESCRIPTION
## Fix: Multi-instance coordination, event listener safety, WebSocket startup race, and i18n coverage

Closes #1376
Closes #1377
Closes #1378
Closes #1379

---

## Summary

Four independent bugs addressed in a single patch, all related to correctness and reliability gaps that were present but not exercised under single-instance development conditions.

---

## Changes

### #1376 — `reconcileTotalsJob` runs uncoordinated in multi-node deployments

**File:** `src/jobs/reconcileTotalsJob.js`

`runOnce()` called the reconciliation repository directly with no leader-election guard, meaning every replica in a multi-node deployment independently rewrote the `donation_totals` table on every 5-minute tick — the exact data races the job exists to prevent.

Added `leaderElection.acquireLease('reconcile_totals_job', ...)` at the top of `runOnce()`, consistent with the pattern already used by `cleanupJob`, `quotaResetJob`, and `expiryWorker`. Only the lease-holding instance now performs reconciliation on any given tick; all others log a debug skip and return early.

---

### #1377 — Direct `donationEvents.emit()` lets a throwing listener silently kill sibling listeners

**File:** `src/services/DonationService.js`

The `donation.created` event was emitted via raw `EventEmitter.emit()`, bypassing the `emitLifecycleEvent()` helper defined specifically to wrap each listener in its own try/catch. Node's `EventEmitter` is synchronous — a single throwing listener aborts the remainder of the listener loop, so any of the six modules registered after the failing one (`stream.js`, `websocketService.js`, `LeaderboardSSE.js`, `StatsService.js`, etc.) would silently stop receiving events.

Replaced the `donationEvents.emit(...)` call with `donationEvents.emitLifecycleEvent(...)`. The safe wrapper already exists and was already being used for `donation.submitted/confirmed/failed`; this aligns `donation.created` with the same pattern.

---

### #1378 — WebSocket servers accept connections before migrations and `api_keys` table are ready

**File:** `src/bootstrap/server.js`

`attachSubscriptionServer(server)` and `websocketService.attach(server)` ran synchronously right after `server.listen()`, before the `setImmediate` block that runs database migrations and initialises the `api_keys` table. Any client connecting in that window — common for eager clients at deployment time — would hit raw SQLite errors (`no such table: api_keys`) instead of a clean authentication rejection.

Moved both calls into the `setImmediate` async block, directly after `await initializeApiKeysTable()`. WebSocket connections are now only accepted once the schema is fully ready.

---

### #1379 — 41 of 51 error codes have no i18n translations — `Accept-Language` silently ignored

**File:** `src/utils/i18n.js`

The static `MESSAGES` catalogue consumed by `errorHandler.js` to localise API error responses only covered 10 generic keys. All 41 domain-specific codes (`WALLET_NOT_FOUND`, `INSUFFICIENT_BALANCE`, `FEE_BUMP_FAILED`, routing errors, etc.) returned `null` from `getMessage()`, causing the error handler to fall back to the original English string regardless of what language the client requested.

Added translations for all 51 error codes across all four supported languages (`en`, `es`, `fr`, `pt`). Every entry in `ERROR_CODES` in `src/utils/errors.js` now has a corresponding entry in `MESSAGES`.

---

## Files changed

| File | Change |
|---|---|
| `src/jobs/reconcileTotalsJob.js` | Added `leaderElection.acquireLease()` guard to `runOnce()` |
| `src/services/DonationService.js` | Replaced `donationEvents.emit()` with `donationEvents.emitLifecycleEvent()` |
| `src/bootstrap/server.js` | Moved WebSocket attachment inside `setImmediate` block, after migrations |
| `src/utils/i18n.js` | Expanded `MESSAGES` from 10 to 51 error code entries (all 4 languages) |

---

## Testing

- Existing test suites cover leader election behaviour, event emission isolation, WebSocket startup, and error handler localisation — no new test infrastructure required.
- The `emitLifecycleEvent` safe-wrapper path is already exercised by tests for `donation.submitted/confirmed/failed`; `donation.created` now follows the same path.
- i18n coverage can be verified by checking that every key in `ERROR_CODES` has a matching entry in `MESSAGES` — this can be enforced in CI with a script that diffs the two sets.
