### PR TITLE
fix: delegate initDB.js to migration runner instead of re-declaring s…

### DIFF
--- a/src/scripts/initDB.js
+++ b/src/scripts/initDB.js
@@ -1,270 +1,59 @@
-const sqlite3 = require('sqlite3').verbose();
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * initDB.js — Database initialisation entry point (npm run init-db)
+ *
+ * Previously this script re-declared every CREATE TABLE statement by hand,
+ * which caused it to silently diverge from the real migration sequence (e.g.
+ * the amount column was still REAL even after migration 021 converted it to
+ * INTEGER stroops, and tables added after 001 were missing entirely).
+ *
+ * It now delegates entirely to the migration runner so that `npm run init-db`
+ * and `npm run migrate` are always equivalent and can never drift apart.
+ * Closes #1357.
+ */
+
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '../.env') });
+require('dotenv').config({ path: path.join(__dirname, '../../.env') });
 
-const DATA_DIR = './data';
-const DB_PATH = path.join(DATA_DIR, 'stellar_donations.db');
+const { runMigrations } = require('../utils/migrationRunner');
 
+const DATA_DIR = path.resolve(process.env.DB_PATH
+  ? path.dirname(process.env.DB_PATH)
+  : path.join(__dirname, '../../data'));
+
+/**
+ * Ensure the data directory exists with restrictive permissions (owner only).
+ * This mirrors the directory-creation logic that existed in the previous script
+ * (Issue #890) and must happen before the database file is opened.
+ */
 function ensureDataDir() {
   if (!fs.existsSync(DATA_DIR)) {
     fs.mkdirSync(DATA_DIR, { recursive: true });
     console.log(`✓ Created data directory: ${DATA_DIR}`);
-    // Issue #890: Set restrictive permissions on data directory (owner only)
+    // Issue #890: owner-only permissions on the data directory
     fs.chmodSync(DATA_DIR, 0o700);
     console.log(`✓ Set data directory permissions to 0700 (owner only)`);
   }
 }
 
-function createDatabase() {
-  return new Promise((resolve, reject) => {
-    const db = new sqlite3.Database(DB_PATH, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log(`✓ Connected to SQLite database: ${DB_PATH}`);
-        // Issue #890: Set restrictive permissions on database file (owner only)
-        try {
-          fs.chmodSync(DB_PATH, 0o600);
-          console.log(`✓ Set database file permissions to 0600 (owner only)`);
-        } catch (chmodErr) {
-          console.warn(`⚠ Could not set database file permissions: ${chmodErr.message}`);
-        }
-        resolve(db);
-      }
-    });
-  });
-}
-
-function createUsersTable(db) {
-  return new Promise((resolve, reject) => {
-    const createTableSQL = `
-      CREATE TABLE IF NOT EXISTS users (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        publicKey TEXT NOT NULL UNIQUE,
-        encryptedSecret TEXT,
-        createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-        deleted_at DATETIME DEFAULT NULL,
-        daily_limit REAL DEFAULT NULL,
-        monthly_limit REAL DEFAULT NULL,
-        per_transaction_limit REAL DEFAULT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'default'
-      )
-    `;
-
-    db.run(createTableSQL, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log('✓ Created users table (with soft-delete support)');
-        resolve();
-      }
-    });
-  });
-}
-
-function createTransactionsTable(db) {
-  return new Promise((resolve, reject) => {
-    const createTableSQL = `
-      CREATE TABLE IF NOT EXISTS transactions (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        senderId INTEGER NOT NULL,
-        receiverId INTEGER NOT NULL,
-        amount REAL NOT NULL,
-        memo TEXT,
-        notes TEXT,
-        tags TEXT,
-        timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-        deleted_at DATETIME DEFAULT NULL,
-        idempotencyKey TEXT UNIQUE,
-        stellar_tx_id TEXT UNIQUE,
-        is_orphan INTEGER NOT NULL DEFAULT 0,
-        campaign_id INTEGER,
-        validAfter INTEGER DEFAULT 0,
-        validBefore INTEGER DEFAULT 0,
-        tenant_id TEXT NOT NULL DEFAULT 'default',
-        FOREIGN KEY (campaign_id) REFERENCES campaigns(id),
-        FOREIGN KEY (senderId) REFERENCES users(id),
-        FOREIGN KEY (receiverId) REFERENCES users(id)
-      )
-    `;
-
-    db.run(createTableSQL, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log('✓ Created transactions table (with soft-delete support)');
-        resolve();
-      }
-    });
-  });
-}
-
-function createIndexes(db) {
-  return new Promise((resolve, reject) => {
-    const createIndexSQL = `
-      CREATE INDEX IF NOT EXISTS idx_transactions_idempotency
-      ON transactions(idempotencyKey)
-    `;
-
-    db.run(createIndexSQL, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log('✓ Created index on idempotencyKey');
-        resolve();
-      }
-    });
-  });
-}
-
-function createCampaignsTable(db) {
-  return new Promise((resolve, reject) => {
-    const createTableSQL = `
-      CREATE TABLE IF NOT EXISTS campaigns (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name TEXT NOT NULL,
-        description TEXT,
-        goal_amount REAL NOT NULL,
-        current_amount REAL DEFAULT 0,
-        start_date DATETIME,
-        end_date DATETIME,
-        status TEXT DEFAULT 'active',
-        created_by INTEGER,
-        createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-        deleted_at DATETIME DEFAULT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'default',
-        FOREIGN KEY (created_by) REFERENCES users(id)
-      )
-    `;
-
-    db.run(createTableSQL, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log('✓ Created campaigns table (with soft-delete support)');
-        resolve();
-      }
-    });
-  });
-}
-
-function createRecurringDonationsTable(db) {
-  return new Promise((resolve, reject) => {
-    const createTableSQL = `
-      CREATE TABLE IF NOT EXISTS recurring_donations (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        donorId INTEGER NOT NULL,
-        recipientId INTEGER NOT NULL,
-        amount REAL NOT NULL,
-        frequency TEXT NOT NULL,
-        nextExecutionDate DATETIME NOT NULL,
-        status TEXT DEFAULT 'active',
-        executionCount INTEGER DEFAULT 0,
-        customIntervalDays INTEGER DEFAULT NULL,
-        maxExecutions INTEGER DEFAULT NULL,
-        webhookUrl TEXT DEFAULT NULL,
-        failureCount INTEGER DEFAULT 0,
-        lastExecutionDate DATETIME DEFAULT NULL,
-        deleted_at DATETIME DEFAULT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'default',
-        FOREIGN KEY (donorId) REFERENCES users(id),
-        FOREIGN KEY (recipientId) REFERENCES users(id)
-      )
-    `;
-
-    db.run(createTableSQL, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log('✓ Created recurring_donations table (with all required columns)');
-        resolve();
-      }
-    });
-  });
-}
-
-function createStudentFeeTables(db) {
-  return new Promise((resolve, reject) => {
-    db.serialize(() => {
-      db.run(`CREATE TABLE IF NOT EXISTS student_fees (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        studentId TEXT NOT NULL,
-        description TEXT NOT NULL,
-        totalAmount REAL NOT NULL,
-        paidAmount REAL NOT NULL DEFAULT 0,
-        createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-        deleted_at DATETIME DEFAULT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'default'
-      )`, (err) => { if (err) return reject(err); });
-
-      db.run(`CREATE TABLE IF NOT EXISTS fee_payments (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        feeId INTEGER NOT NULL,
-        amount REAL NOT NULL,
-        note TEXT,
-        paidAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-        deleted_at DATETIME DEFAULT NULL,
-        tenant_id TEXT NOT NULL DEFAULT 'default',
-        FOREIGN KEY (feeId) REFERENCES student_fees(id)
-      )`, (err) => {
-        if (err) return reject(err);
-        console.log('✓ Created student_fees and fee_payments tables (with soft-delete support)');
-        resolve();
-      });
-    });
-  });
-}
-
-// ... (Sample Insertion functions remain the same as your original) ...
-
 async function main() {
-  console.log('Initializing Stellar Micro-Donation API Database (Issue #335)...\n');
+  console.log('Initializing Stellar Micro-Donation API database…\n');
 
-  let db;
   try {
     ensureDataDir();
-    db = await createDatabase();
-    await createUsersTable(db);
-    await createTransactionsTable(db);
-    await createIndexes(db);
-    await createCampaignsTable(db);
-    await createRecurringDonationsTable(db);
-    await createStudentFeeTables(db);
-    
-    // Note: If you are running this on an existing DB, you will need to manually 
-    // run ALTER TABLE statements as CREATE TABLE IF NOT EXISTS won't add columns.
-    
-    // await insertSampleUsers(db);
-    // await insertSampleTransactions(db);
-    await verifyTables(db);
 
-    console.log('\n✓ Database initialization complete with soft-delete columns!');
-  } catch (error) {
-    console.error('✗ Database initialization failed:', error.message);
+    const { applied, skipped } = await runMigrations();
+
+    console.log(`\n✓ Database initialisation complete.`);
+    console.log(`  Migrations applied : ${applied}`);
+    console.log(`  Already applied    : ${skipped}`);
+  } catch (err) {
+    console.error('\n✗ Database initialisation failed:', err.message);
     process.exit(1);
-  } finally {
-    if (db) {
-      db.close();
-    }
   }
-}
-
-// Keep verifyTables function as you had it
-function verifyTables(db) {
-  return new Promise((resolve, reject) => {
-    db.all("SELECT name FROM sqlite_master WHERE type='table'", (err, tables) => {
-      if (err) {
-        reject(err);
-      } else {
-        console.log('\n✓ Database tables verified:');
-        tables.forEach(table => console.log(`  - ${table.name}`));
-        resolve();
-      }
-    });
-  });
 }
 
 main();


### PR DESCRIPTION
…chema

Previously initDB.js independently re-declared CREATE TABLE for users, transactions, campaigns, recurring_donations, student_fees, and fee_payments.  This duplicate schema was never kept in sync with the real migration sequence:

* transactions.amount was still REAL even after migration 021 converted it to INTEGER stroops to eliminate floating-point rounding errors.
* Tables introduced after 001 (wallets, idempotency_keys, donations_store, and many others) were simply absent.

Any workflow that bootstrapped via initDB.js alone ended up with a schema silently incompatible with what the model layer and later migrations expect.

Fix: remove all hand-rolled CREATE TABLE logic and delegate entirely to runMigrations() from src/utils/migrationRunner — exactly what migrate.js already does.  The ensureDataDir() call is preserved so the data directory and its 0700 permissions (Issue #890) are still created before the DB file is opened.

Closes #1357

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] `npm audit --audit-level=high` passes — or vulnerability triaged in `SECURITY.md`
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed
