### PR TITLE
Fix/donations store check constraint circuit breaker pk

### DIFF
--- a/src/migrations/019_donations_store.js
+++ b/src/migrations/019_donations_store.js
@@ -10,8 +10,8 @@ exports.up = async (db) => {
   await db.run(`
     CREATE TABLE IF NOT EXISTS donations_store (
       id TEXT PRIMARY KEY,
-      donor TEXT,
-      recipient TEXT,
+      donor TEXT CHECK (donor IS NULL OR (length(donor) = 56 AND donor GLOB 'G*')),
+      recipient TEXT CHECK (recipient IS NULL OR (length(recipient) = 56 AND recipient GLOB 'G*')),
       amount_stroops INTEGER,
       amount_text TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'pending',

--- a/src/migrations/025_circuit_breaker_probe.js
+++ b/src/migrations/025_circuit_breaker_probe.js
@@ -18,13 +18,24 @@ exports.up = async (db) => {
 
 exports.down = async (db) => {
   // SQLite does not support DROP COLUMN before 3.35.0; recreate the table.
+  // Use CREATE TABLE + INSERT + DROP + RENAME so that the PRIMARY KEY
+  // constraint on `name` is preserved in the restored table.
+  // (The previous CREATE TABLE … AS SELECT pattern silently dropped all
+  // column constraints including PRIMARY KEY — see issue #1356.)
   await db.run(`
-    CREATE TABLE IF NOT EXISTS circuit_breaker_state_backup AS
+    CREATE TABLE IF NOT EXISTS circuit_breaker_state_new (
+      name TEXT PRIMARY KEY,
+      state TEXT NOT NULL DEFAULT 'closed',
+      failureCount INTEGER NOT NULL DEFAULT 0,
+      lastFailureAt INTEGER,
+      openedAt INTEGER
+    )
+  `);
+  await db.run(`
+    INSERT INTO circuit_breaker_state_new (name, state, failureCount, lastFailureAt, openedAt)
       SELECT name, state, failureCount, lastFailureAt, openedAt
       FROM circuit_breaker_state
   `);
   await db.run('DROP TABLE IF EXISTS circuit_breaker_state');
-  await db.run(`
-    ALTER TABLE circuit_breaker_state_backup RENAME TO circuit_breaker_state
-  `);
+  await db.run('ALTER TABLE circuit_breaker_state_new RENAME TO circuit_breaker_state');
 };


### PR DESCRIPTION
Fix schema integrity gaps in two migrations
  
  Summary
  
  Two independent migration issues introduced silent correctness holes — one in the donations_store table schema, one in the
  circuit_breaker_state rollback. Both are fixed in this PR.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Fix 1 — donations_store donor/recipient have no format validation Closes #1359 
  
  Problem
  
  019_donations_store.js declared donor and recipient as plain TEXT with no constraints. Any value — empty string, malformed key,
  arbitrary garbage — could be written into these two critical columns and the database would accept it silently. 100% of the
  correctness burden fell on application-layer validation, with no defense-in-depth if that validation was buggy or bypassed.
  
  Fix

  
  Added CHECK constraints that enforce the Stellar Ed25519 public key format at the schema level:
  
  donor     TEXT CHECK (donor     IS NULL OR (length(donor)     = 56 AND donor     GLOB 'G*')),
  recipient TEXT CHECK (recipient IS NULL OR (length(recipient) = 56 AND recipient GLOB 'G*')),
  
  NULL is still permitted for donations where the key is not yet known. Any non-NULL value must be exactly 56 characters and start
  with G. The database now rejects bad data at the point of write rather than relying solely on application code.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Fix 2 — circuit_breaker_state rollback silently drops PRIMARY KEY Closes #1356
  
  Problem
  
  025_circuit_breaker_probe.js's down() used the anti-pattern:
  
  CREATE TABLE circuit_breaker_state_backup AS
    SELECT name, state, failureCount, lastFailureAt, openedAt
    FROM circuit_breaker_state
  
  CREATE TABLE … AS SELECT copies rows but silently drops all column constraints, including the name TEXT PRIMARY KEY that the
  circuit breaker depends on to enforce one-row-per-service. After this rollback ran, the table accepted duplicate rows for the
  same service name — breaking the fundamental invariant the circuit breaker relies on to correctly track failure state.
  
  Fix
  
  Replaced the lossy pattern with the correct SQLite column-removal procedure:
  
  -- 1. Create replacement table with full schema (PRIMARY KEY preserved)
  CREATE TABLE circuit_breaker_state_new (
    name TEXT PRIMARY KEY,
    state TEXT NOT NULL DEFAULT 'closed',
    failureCount INTEGER NOT NULL DEFAULT 0,
    lastFailureAt INTEGER,
    openedAt INTEGER
  );
  -- 2. Copy data
  INSERT INTO circuit_breaker_state_new SELECT name, state, failureCount, lastFailureAt, openedAt FROM circuit_breaker_state;
  -- 3. Swap
  DROP TABLE circuit_breaker_state;
  ALTER TABLE circuit_breaker_state_new RENAME TO circuit_breaker_state;
  
  The restored table is now structurally identical to the one created by 019_circuit_breaker_state.js.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  - tests/migration/migration-runner.test.js — 9/9 pass
  - tests/security/circuit-breaker.test.js — 17/17 pass
  - Both migration files pass node --check syntax validation
  
  Files changed
  
  ┌─────────────────────────────────────────────┬─────────────────────────────────────────────────────────────┐
  │ File                                        │ Change                                                      │
  ├─────────────────────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ src/migrations/019_donations_store.js       │ Added CHECK constraints on donor and recipient columns      │
  ├─────────────────────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ src/migrations/025_circuit_breaker_probe.js │ Rewrote down() to use CREATE TABLE + INSERT + DROP + RENAME │
  └─────────────────────────────────────────────┴─────────────────────────────────────────────────────────────┘
