### PR TITLE
fix(routing): prevent TypeError when pool shrinks between round-robin rotations

### DIFF
--- a/src/services/RoundRobinStateRepository.js
+++ b/src/services/RoundRobinStateRepository.js
@@ -31,14 +31,18 @@ class RoundRobinStateRepository {
    */
   async incrementAndWrap(poolName, poolSize) {
     const current = await this.getIndex(poolName);
-    const next = (current + 1) % poolSize;
+    // If the pool has shrunk since the last rotation, the persisted index may
+    // be out of range. Wrap it against the current poolSize so we never return
+    // an index >= poolSize (which would cause an out-of-bounds access later).
+    const used = current % poolSize;
+    const next = (used + 1) % poolSize;
     await Database.run(
       `INSERT INTO round_robin_state (pool_name, next_index, updatedAt)
        VALUES (?, ?, CURRENT_TIMESTAMP)
        ON CONFLICT(pool_name) DO UPDATE SET next_index = excluded.next_index, updatedAt = excluded.updatedAt`,
       [poolName, next]
     );
-    return current;
+    return used;
   }
 
   /**

--- a/src/services/routing/RoundRobinStrategy.js
+++ b/src/services/routing/RoundRobinStrategy.js
@@ -12,7 +12,11 @@ class RoundRobinStrategy {
    * @returns {{ selectedId: string, excludedIds: string[] }}
    */
   select(pool, { currentIndex }) {
-    const recipient = pool[currentIndex];
+    // Defensive bounds check: if the stored index is out of range (e.g., the
+    // pool shrank between rotations), wrap back to 0 so we never index into
+    // undefined and crash with a TypeError.
+    const safeIndex = currentIndex >= pool.length ? 0 : currentIndex;
+    const recipient = pool[safeIndex];
     return { selectedId: recipient.id, excludedIds: [] };
   }
 }

--- a/tests/smart-donation-routing.test.js
+++ b/tests/smart-donation-routing.test.js
@@ -138,6 +138,24 @@ describe('RoundRobinStrategy', () => {
     expect(strategy.select(pool, { currentIndex: 0 }).excludedIds).toEqual([]);
   });
 
+  it('wraps to 0 when currentIndex is out of bounds (pool shrank)', () => {
+    // Simulate a pool that had 5 members at last rotation but now only has 3.
+    const shrunkPool = [{ id: 'A' }, { id: 'B' }, { id: 'C' }];
+    // A stale index of 4 would crash without the fix.
+    expect(strategy.select(shrunkPool, { currentIndex: 4 }).selectedId).toBe('A');
+    expect(strategy.select(shrunkPool, { currentIndex: 3 }).selectedId).toBe('A');
+    // Indices that are still in range should work unchanged.
+    expect(strategy.select(shrunkPool, { currentIndex: 2 }).selectedId).toBe('C');
+  });
+
+  it('wraps to 0 when pool is smaller than stored index (edge: single recipient)', () => {
+    const singlePool = [{ id: 'Only' }];
+    // Stale index of 5 should wrap to 0.
+    expect(strategy.select(singlePool, { currentIndex: 5 }).selectedId).toBe('Only');
+    // Index 0 still works.
+    expect(strategy.select(singlePool, { currentIndex: 0 }).selectedId).toBe('Only');
+  });
+
   it('distributes evenly across recipients via DonationRouter', async () => {
     await Database.initialize();
     await ensureRoutingTables();


### PR DESCRIPTION
Closes #1424

## Summary

Fixes a production crash path where `RoundRobinStrategy.select()` throws an unhandled `TypeError: Cannot read properties of undefined (reading 'id')` when a donation pool shrinks between round-robin rotations and the persisted `next_index` falls out of range.

## Problem

`RoundRobinStateRepository.incrementAndWrap(poolName, poolSize)` reads the persisted `next_index` and returns it untouched:

```javascript
const current = await this.getIndex(poolName);   // e.g., 4
const next = (current + 1) % poolSize;            // wraps correctly for DB
return current;                                   // returns raw 4 — never clamped
```

When pool membership shrinks (e.g., from 5 recipients to 3), the stale index `4` reaches `RoundRobinStrategy.select()`:

```javascript
const recipient = pool[4];  // undefined — pool only has indices 0–2
return { selectedId: recipient.id };  // TypeError!
```

This crashes the donation routing request instead of gracefully wrapping the index back into range.

## Changes

### `src/services/RoundRobinStateRepository.js`

**`incrementAndWrap()`** — clamps the returned index against the current `poolSize`:

```javascript
const used = current % poolSize;        // clamp to current pool size
const next = (used + 1) % poolSize;
// ... store next ...
return used;                            // always valid for current poolSize
```

When the pool shrank from 5 to 3, `current = 4, poolSize = 3, used = 1` — the caller now receives a valid index.

### `src/services/routing/RoundRobinStrategy.js`

**`select()`** — added a defensive bounds check as a second layer of defense:

```javascript
const safeIndex = currentIndex >= pool.length ? 0 : currentIndex;
const recipient = pool[safeIndex];
```

If an out-of-range index somehow reaches `select()` (e.g., from a different code path), it wraps to 0 rather than crashing.

### `tests/smart-donation-routing.test.js`

Two new unit tests:

| Test | What it verifies |
|---|---|
| `wraps to 0 when currentIndex is out of bounds (pool shrank)` | Stale index 4 on pool of 3 → wraps to 0 and selects 'A'. In-range index 2 still selects 'C'. |
| `wraps to 0 when pool is smaller than stored index (edge: single recipient)` | Stale index 5 on pool of 1 → wraps to 0 and selects 'Only'. |

## Defense-in-depth

Both layers together ensure no crash path exists:

1. **Primary fix**: `incrementAndWrap()` returns a clamped index — the caller never sees a stale value when the pool has shrunk.
2. **Safety net**: `select()` wraps out-of-range indices to 0 — catches any other code path that might pass a bad index.

## Backward Compatibility

- Normal operation (pool unchanged between rotations): `current % poolSize === current` — zero behavioral change.
- Pool grew: `current % poolSize` still equals `current` since current < poolSize for the stored value — no change.
- Only changed behavior: when the pool shrinks, the returned index is now valid instead of crashing.
