### PR TITLE
fix: apply filter and projection in TranslationDoc.find

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "stellar-micro-donation-api",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.12.0",
         "csv-parse": "^6.2.1",
@@ -24,7 +25,7 @@
         "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "sqlite3": "^6.0.1",
-        "stellar-sdk": "^11.0.0",
+        "stellar-sdk": "^13.0.0",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.1",
@@ -32,7 +33,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.29.7",
-        "eslint": "^8.57.1",
+        "eslint": "8.57.1",
         "eslint-plugin-local": "file:./eslint-rules",
         "eslint-plugin-no-secrets": "^2.3.3",
         "eslint-plugin-security": "^4.0.0",
@@ -3192,20 +3193,24 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-11.0.1.tgz",
-      "integrity": "sha512-VQh+1KEtFjegD6spx08+lENt8tQOkQQQZoLtqExjpRXyWlqDhEe+bXMlBTYKDc5MIynHyD42RPEib27UG17trA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
+      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/js-xdr": "^3.1.1",
+        "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
         "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
         "sha.js": "^2.3.6",
         "tweetnacl": "^1.0.3"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      },
       "optionalDependencies": {
-        "sodium-native": "^4.0.10"
+        "sodium-native": "^4.3.3"
       }
     },
     "node_modules/@swc/helpers": {
@@ -4439,9 +4444,9 @@
       "license": "MIT"
     },
     "node_modules/bare-addon-resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
-      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4458,9 +4463,9 @@
       }
     },
     "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -4476,9 +4481,9 @@
       }
     },
     "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
-      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -4827,14 +4832,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -6365,6 +6370,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7389,6 +7403,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -11361,19 +11387,23 @@
       }
     },
     "node_modules/stellar-sdk": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-11.3.0.tgz",
-      "integrity": "sha512-xOp2zpQm5TIbgJi7wJhAmJh+Uy0ew5GbGtj1kZv6HEWHgSvW95xYMxGaw6MWM9r2YPUSQySboE6JwDc9jdx53A==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
+      "integrity": "sha512-jAA3+U7oAUueldoS4kuEhcym+DigElWq9isPxt7tjMrE7kTJ2vvY29waavUb2FSfQIWwGbuwAJTYddy2BeyJsw==",
       "deprecated": "⚠️ This package has moved to @stellar/stellar-sdk! 🚚",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^11.0.1",
-        "axios": "^1.6.8",
-        "bignumber.js": "^9.1.2",
+        "@stellar/stellar-base": "^13.1.0",
+        "axios": "^1.8.4",
+        "bignumber.js": "^9.3.0",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/stream-to-array": {
@@ -12435,13 +12465,13 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/src/models/translation.js
+++ b/src/models/translation.js
@@ -36,7 +36,39 @@ class TranslationDoc {
 
   static async find(filter = {}, projection) {
     await initTable();
-    const rows = await Database.all(`SELECT * FROM translations`);
+
+    const allowedColumns = ['key', 'translations', 'updated_at'];
+    let selectClause = '*';
+
+    if (projection) {
+      let fields = [];
+      if (Array.isArray(projection)) {
+        fields = projection.filter(field => allowedColumns.includes(field));
+      } else if (typeof projection === 'object' && projection !== null) {
+        fields = Object.keys(projection).filter(
+          field => allowedColumns.includes(field) && projection[field] !== 0
+        );
+      } else if (typeof projection === 'string' && allowedColumns.includes(projection)) {
+        fields = [projection];
+      }
+
+      if (fields.length > 0) {
+        selectClause = fields.map(field => `"${field}"`).join(', ');
+      }
+    }
+
+    const filterEntries = Object.entries(filter || {}).filter(([, value]) => value !== undefined);
+    const whereClauses = [];
+    const params = [];
+
+    for (const [field, value] of filterEntries) {
+      if (!allowedColumns.includes(field)) continue;
+      whereClauses.push(`"${field}" = ?`);
+      params.push(value);
+    }
+
+    const sql = `SELECT ${selectClause} FROM translations${whereClauses.length ? ` WHERE ${whereClauses.join(' AND ')}` : ''}`;
+    const rows = await Database.all(sql, params);
     return (rows || []).map(r => new TranslationDoc(r));
   }
 

--- a/tests/translation-doc.test.js
+++ b/tests/translation-doc.test.js
@@ -1,0 +1,42 @@
+const Database = require('../src/utils/database');
+const TranslationDoc = require('../src/models/translation');
+
+describe('TranslationDoc.find', () => {
+  afterEach(async () => {
+    await Database.run('DELETE FROM translations WHERE key IN (?, ?)', ['en', 'fr']);
+  });
+
+  test('applies filter and returns only matching rows', async () => {
+    const enTranslation = new TranslationDoc({
+      key: 'en',
+      translations: { hello: 'Hello' },
+    });
+    const frTranslation = new TranslationDoc({
+      key: 'fr',
+      translations: { hello: 'Bonjour' },
+    });
+
+    await enTranslation.save();
+    await frTranslation.save();
+
+    const results = await TranslationDoc.find({ key: 'en' });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].key).toBe('en');
+    expect(results[0].translations.get('hello')).toBe('Hello');
+  });
+
+  test('supports projection to limit returned columns', async () => {
+    const enTranslation = new TranslationDoc({
+      key: 'en',
+      translations: { hello: 'Hello' },
+    });
+    await enTranslation.save();
+
+    const results = await TranslationDoc.find({ key: 'en' }, ['key']);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].key).toBe('en');
+    expect(results[0].translations.size).toBe(0);
+  });
+});


### PR DESCRIPTION
This pull request fixes `TranslationDoc.find()` so that it correctly applies the provided `filter` and `projection` arguments.

Changes

* Implemented filtering by translating the provided filter object into a parameterised SQL `WHERE` clause.
* Implemented column projection instead of always selecting all columns with `SELECT *`.
* Preserved the existing method signature while making its behaviour consistent with its documented API.
* Added tests to verify that filtering returns only matching records and that projections return only the requested columns.

Testing

* Added unit tests for filtered queries.
* Added unit tests for projected queries.
* Verified that existing functionality remains unchanged.

Closes #1361 
