### PR TITLE
fix: correct example BASE_URL from /api to /api/v1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ to go from a fresh clone to an open PR.
 4. [Linting & Security](#4-linting--security)
 5. [Database Migrations](#5-database-migrations)
 6. [OpenAPI Spec](#6-openapi-spec)
-7. [Branch & Commit Conventions](#7-branch--commit-conventions)
-8. [Pre-PR Checklist](#8-pre-pr-checklist)
+7. [Keeping Example Base URLs in Sync](#7-keeping-example-base-urls-in-sync)
+8. [Branch & Commit Conventions](#8-branch--commit-conventions)
+9. [Pre-PR Checklist](#9-pre-pr-checklist)
 
 ---
 
@@ -156,7 +157,29 @@ and will fail if the spec is stale.
 
 ---
 
-## 7. Branch & Commit Conventions
+## 7. Keeping Example Base URLs in Sync
+
+The base URL used in all copy-paste onboarding material must always match the
+versioned mount prefix in `src/bootstrap/routes.js`.
+
+**Current mount prefix:** `/api/v1`  
+**Required base URL in examples:** `http://localhost:3000/api/v1`
+
+Files that hardcode this value:
+
+| File | Location |
+|------|----------|
+| `examples/API_CURL_EXAMPLES.md` | `BASE_URL` variable (two occurrences) |
+| `examples/Stellar-Micro-Donation-API.postman_collection.json` | `BASE_URL` collection variable |
+
+**Rule:** Any PR that changes the mount prefix in `src/bootstrap/routes.js` **must**
+update both example files in the same commit. CI should (and eventually will) grep
+for the old prefix and fail if a stale value is found. Until that check exists,
+confirm the values are consistent as part of the [Pre-PR Checklist](#9-pre-pr-checklist).
+
+---
+
+## 8. Branch & Commit Conventions
 
 **Branches**
 
@@ -180,7 +203,7 @@ Breaking changes must include a `BREAKING CHANGE:` footer in the commit body.
 
 ---
 
-## 8. Pre-PR Checklist
+## 9. Pre-PR Checklist
 
 Before pushing and opening a PR, run through this list:
 
@@ -203,7 +226,7 @@ When the PR is ready:
 
 ---
 
-## 9. Security
+## 10. Security
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
@@ -215,7 +238,7 @@ See **[SECURITY.md](../SECURITY.md)** for:
 
 ---
 
-## 10. Key Documentation
+## 11. Key Documentation
 
 When working on a feature, these docs will save you time:
 

--- a/examples/API_CURL_EXAMPLES.md
+++ b/examples/API_CURL_EXAMPLES.md
@@ -7,7 +7,7 @@ This guide provides copy-paste curl commands to test the core donation API flows
 ```bash
 # Set your environment variables
 export API_KEY="your-api-key-here"
-export BASE_URL="http://localhost:3000/api"
+export BASE_URL="http://localhost:3000/api/v1"
 export DONOR_PUBLIC_KEY="GBUQWP3BOUZX34ULNQG23RQ6F4BWFIРЕQCLMNZ4QSY47PCNQRICKS57"
 export RECIPIENT_PUBLIC_KEY="GCEZWJG7SSHQUUP7IBRN23JQCQR53ROE44TSBROAM4TOBJOJJU5YV2Z2"
 ```
@@ -215,7 +215,7 @@ set -e  # Exit on error
 
 # Set variables
 export API_KEY="dev-key"
-export BASE_URL="http://localhost:3000/api"
+export BASE_URL="http://localhost:3000/api/v1"
 export DONOR="GBUQWP3BOUZX34ULNQG23RQ6F4BWFIРЕQCLMNZ4QSY47PCNQRICKS57"
 export RECIPIENT="GCEZWJG7SSHQUUP7IBRN23JQCQR53ROE44TSBROAM4TOBJOJJU5YV2Z2"
 

--- a/examples/Stellar-Micro-Donation-API.postman_collection.json
+++ b/examples/Stellar-Micro-Donation-API.postman_collection.json
@@ -337,7 +337,7 @@
   "variable": [
     {
       "key": "BASE_URL",
-      "value": "http://localhost:3000/api",
+      "value": "http://localhost:3000/api/v1",
       "type": "string"
     },
     {


### PR DESCRIPTION
## Summary

Fixes the broken onboarding examples reported in #1427.

Both `examples/API_CURL_EXAMPLES.md` and `examples/Stellar-Micro-Donation-API.postman_collection.json` hardcoded `http://localhost:3000/api` as the base URL. The app only mounts routes at `/api/v1` (`src/bootstrap/routes.js` line 185); `/api/wallets` matches neither the versioned mount nor the `UNVERSIONED_PATHS` redirect list, so every example request returned 404.

## Changes

| File | Change |
|------|--------|
| `examples/API_CURL_EXAMPLES.md` | Fixed `BASE_URL` in the Setup block and Example Full Flow script (two occurrences) |
| `examples/Stellar-Micro-Donation-API.postman_collection.json` | Fixed `BASE_URL` collection variable value |
| `CONTRIBUTING.md` | Added section 7 *Keeping Example Base URLs in Sync* — documents the rule that example base URLs must stay in sync with the mount prefix in `src/bootstrap/routes.js` whenever it changes |

## Testing

All curl examples and Postman requests now resolve correctly against the running server. No code logic was changed.

Closes #1427