### PR TITLE
fix: address 4 security/correctness bugs in middleware and utils

### DIFF
--- a/src/middleware/blockCheck.js
+++ b/src/middleware/blockCheck.js
@@ -13,7 +13,11 @@ function blockCheck(req, res, next) {
     return next();
   }
 
-  const ip = req.ip || req.get('X-Forwarded-For')?.split(',')[0]?.trim() || req.connection.remoteAddress || 'unknown';
+  // Use only req.ip (set by Express based on trust proxy) — never fall back to
+  // the X-Forwarded-For header, which is client-controlled and can be spoofed.
+  // If req.ip is not available, fall through to 'unknown' and allow the request
+  // to proceed; a missing IP is not grounds for a hard block.
+  const ip = req.ip || 'unknown';
 
   if (abuseDetectionService.isBlocked(ip)) {
     log.warn('BLOCK_CHECK', 'Request blocked', { ip, path: req.path, method: req.method });

--- a/src/utils/currencyConversion.js
+++ b/src/utils/currencyConversion.js
@@ -53,14 +53,22 @@ function roundHalfEven(value, dp = XLM_DECIMAL_PLACES) {
   const floor   = Math.floor(shifted);
   const diff    = shifted - floor;
 
+  // IEEE-754 floating-point multiplication cannot reliably land on exactly 0.5
+  // even when the true mathematical value is halfway.  We use an epsilon of
+  // 1e-10 (many orders of magnitude smaller than the 7-dp precision we care
+  // about) to detect "close enough to 0.5" without treating non-halfway values
+  // as halfway.
+  const EPSILON = 1e-10;
+  const isHalfway = Math.abs(diff - 0.5) < EPSILON;
+
   let rounded;
-  if (diff < 0.5) {
-    rounded = floor;
-  } else if (diff > 0.5) {
-    rounded = floor + 1;
-  } else {
-    // Exactly halfway — round to even
+  if (isHalfway) {
+    // Exactly halfway — round to even (banker's rounding)
     rounded = floor % 2 === 0 ? floor : floor + 1;
+  } else if (diff < 0.5) {
+    rounded = floor;
+  } else {
+    rounded = floor + 1;
   }
 
   return rounded / factor;

--- a/src/utils/ipAllowlist.js
+++ b/src/utils/ipAllowlist.js
@@ -12,6 +12,29 @@
 const { isIPv4, isIPv6 } = require('net');
 
 /**
+ * Normalize an IP address to a canonical form for comparison.
+ *
+ * Node's networking stack, dual-stack sockets, and various proxies may represent
+ * an IPv4 address as an IPv4-mapped IPv6 address (e.g. "::ffff:1.2.3.4").  Both
+ * forms refer to the same underlying address.  Without normalization, string or
+ * CIDR comparisons against a plain-IPv4 allowlist entry would incorrectly fail
+ * for the mapped form, causing legitimate callers to be denied.
+ *
+ * This function strips the "::ffff:" prefix so that "::ffff:1.2.3.4" and
+ * "::FFFF:1.2.3.4" are both reduced to "1.2.3.4" before any comparison.
+ *
+ * @param {string} ip - Raw IP string (IPv4 or IPv6, possibly IPv4-mapped)
+ * @returns {string} Canonical IP string
+ */
+function normalizeIp(ip) {
+  if (!ip) return ip;
+  // Match ::ffff: prefix (case-insensitive) followed by an IPv4 address
+  const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mapped) return mapped[1];
+  return ip;
+}
+
+/**
  * Converts an IPv4 address string to a 32-bit unsigned integer.
  * @param {string} ip - IPv4 address (e.g. "192.168.1.1")
  * @returns {number}
@@ -39,6 +62,8 @@ function ipv6ToBigInt(ip) {
 
 /**
  * Checks whether `clientIp` falls within the given CIDR range.
+ * Both `clientIp` and the network address of the CIDR are normalized before
+ * comparison so that IPv4-mapped IPv6 addresses match plain-IPv4 CIDR entries.
  * @param {string} clientIp
  * @param {string} cidr - e.g. "10.0.0.0/8" or "2001:db8::/32"
  * @returns {boolean}
@@ -47,14 +72,17 @@ function isInCidr(clientIp, cidr) {
   const [network, prefixStr] = cidr.split('/');
   const prefix = parseInt(prefixStr, 10);
 
-  if (isIPv4(network) && isIPv4(clientIp)) {
+  const normClient  = normalizeIp(clientIp);
+  const normNetwork = normalizeIp(network);
+
+  if (isIPv4(normNetwork) && isIPv4(normClient)) {
     const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
-    return (ipv4ToInt(clientIp) & mask) === (ipv4ToInt(network) & mask);
+    return (ipv4ToInt(normClient) & mask) === (ipv4ToInt(normNetwork) & mask);
   }
 
-  if (isIPv6(network) && isIPv6(clientIp)) {
+  if (isIPv6(normNetwork) && isIPv6(normClient)) {
     const mask = prefix === 0 ? 0n : (~0n << BigInt(128 - prefix)) & ((1n << 128n) - 1n);
-    return (ipv6ToBigInt(clientIp) & mask) === (ipv6ToBigInt(network) & mask);
+    return (ipv6ToBigInt(normClient) & mask) === (ipv6ToBigInt(normNetwork) & mask);
   }
 
   return false;
@@ -70,6 +98,10 @@ function isInCidr(clientIp, cidr) {
  *
  * Returns `true` (allow all) when `allowedIps` is null, undefined, or empty.
  *
+ * IPv4-mapped IPv6 addresses (e.g. "::ffff:1.2.3.4") are normalized to their
+ * plain IPv4 form before any comparison so that a dual-stack socket or proxy
+ * reporting the mapped form still matches a plain-IPv4 allowlist entry.
+ *
  * @param {string} clientIp - The client's IP address
  * @param {string[]|null|undefined} allowedIps - The allowlist configured on the API key
  * @returns {boolean}
@@ -78,10 +110,16 @@ function isIpAllowed(clientIp, allowedIps) {
   if (!allowedIps || allowedIps.length === 0) return true;
   if (!clientIp) return false;
 
+  const normClient = normalizeIp(clientIp);
+
   for (const entry of allowedIps) {
+    const normEntry = normalizeIp(entry.includes('/') ? entry.split('/')[0] : entry);
+
     if (entry.includes('/')) {
-      if (isInCidr(clientIp, entry)) return true;
-    } else if (entry === clientIp) {
+      // Re-assemble CIDR with normalized network address for isInCidr
+      const prefix = entry.split('/')[1];
+      if (isInCidr(normClient, `${normEntry}/${prefix}`)) return true;
+    } else if (normEntry === normClient) {
       return true;
     }
   }

--- a/src/utils/replayDetector.js
+++ b/src/utils/replayDetector.js
@@ -177,16 +177,35 @@ function sortKeys(obj) {
 }
 
 /**
- * Compute a unique fingerprint for a request
- * Uses SHA-256 hash of JSON-serialized {method, path, body}
+ * Compute a unique fingerprint for a request.
+ * Uses SHA-256 hash of JSON-serialized {method, path, query, body, callerId}.
+ *
+ * Including `query` prevents two requests that differ only in query parameters
+ * from colliding into the same fingerprint bucket.
+ *
+ * Including `callerId` (API key ID or user ID when available) prevents
+ * concurrent legitimate requests from different callers that happen to share
+ * method/path/body/query from being mis-identified as a replay of each other.
+ *
  * @param {Object} req - Express request object
  * @returns {string} 64-character hex string (SHA-256 hash)
  */
 function computeFingerprint(req) {
+  // Resolve caller identifier: prefer authenticated key/user ID, then
+  // fall back to IP so there is always some per-caller differentiation.
+  const callerId =
+    (req.apiKey && req.apiKey.id) ||
+    (req.user   && req.user.id)   ||
+    req.clientIp ||
+    req.ip       ||
+    'anonymous';
+
   const components = {
-    method: req.method,
-    path: req.path,
-    body: req.body || ''
+    method:   req.method,
+    path:     req.path,
+    query:    req.query  || {},
+    body:     req.body   || '',
+    callerId,
   };
   
   // Sort keys recursively for stable serialization


### PR DESCRIPTION
- blockCheck.js: remove X-Forwarded-For fallback; use only req.ip to prevent IP spoofing via client-controlled headers (Closes #1344)

- replayDetector.js: include req.query and callerId in computeFingerprint() to prevent false-positive replay collisions across different callers or requests that differ only in query parameters (Closes #1348)

- currencyConversion.js: use epsilon-based halfway detection in roundHalfEven() so IEEE-754 values that cannot land exactly on 0.5 are still correctly routed through the banker's rounding branch, preserving the documented ROUND_HALF_EVEN guarantee (Closes #1346)

- ipAllowlist.js: add normalizeIp() to strip ::ffff: prefix from IPv4-mapped IPv6 addresses before any comparison, so dual-stack sockets and proxies that surface the mapped form still match plain-IPv4 allowlist entries and CIDR ranges (Closes #1345)

## Summary

<!-- Describe what this PR changes and why. -->

## Linked Issue

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests
- [ ] CI / tooling

## Test Evidence

<!-- Paste relevant test output, screenshots, or commands you ran to verify the change. -->

```
npm test
```

## Checklist

- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] `openapi:check` passes (`npm run openapi:check`) — or N/A
- [ ] `npm audit --audit-level=high` passes — or vulnerability triaged in `SECURITY.md`
- [ ] Database migration included if schema changed
- [ ] Documentation updated if behaviour changed
