### PR TITLE
fix: renumber duplicate migration prefixes to unique sequential numbers

### DIFF
--- a/src/migrations/031_api_key_rate_limit.js
+++ b/src/migrations/031_api_key_rate_limit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.name = '018_api_key_rate_limit';
+exports.name = '031_api_key_rate_limit';
 
 exports.up = async (db) => {
   await db.run(`

--- a/src/migrations/032_wallets_table.js
+++ b/src/migrations/032_wallets_table.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.name = '018_wallets_table';
+exports.name = '032_wallets_table';
 
 exports.up = async (db) => {
   await db.run(`

--- a/src/migrations/033_donations_store.js
+++ b/src/migrations/033_donations_store.js
@@ -4,7 +4,7 @@
 // It stores the full donation record as a JSON blob alongside indexed columns
 // for efficient querying, avoiding any float coercion of stroop amounts.
 
-exports.name = '019_donations_store';
+exports.name = '033_donations_store';
 
 exports.up = async (db) => {
   await db.run(`

--- a/src/migrations/034_payment_streams.js
+++ b/src/migrations/034_payment_streams.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.name = '024_payment_streams';
+exports.name = '034_payment_streams';
 
 exports.up = async (db) => {
   await db.run(`

--- a/src/migrations/035_scheduler_locks.js
+++ b/src/migrations/035_scheduler_locks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.name = '024_scheduler_locks';
+exports.name = '035_scheduler_locks';
 
 exports.up = async (db) => {
   await db.run(`

--- a/src/migrations/036_circuit_breaker_probe.js
+++ b/src/migrations/036_circuit_breaker_probe.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.name = '025_circuit_breaker_probe';
+exports.name = '036_circuit_breaker_probe';
 
 exports.up = async (db) => {
   // Add probeHolder for cross-instance half-open probe coordination.

--- a/src/migrations/037_pledge_webhook_sent_at.js
+++ b/src/migrations/037_pledge_webhook_sent_at.js
@@ -7,7 +7,7 @@
  * (fulfilled or expired) to prevent duplicate webhook deliveries.
  */
 
-exports.name = '029_pledge_webhook_sent_at';
+exports.name = '037_pledge_webhook_sent_at';
 
 exports.up = async (db) => {
   // Add webhook_sent_at column only if missing

--- a/src/migrations/038_pledges_amount_stroops.js
+++ b/src/migrations/038_pledges_amount_stroops.js
@@ -9,7 +9,7 @@
 
 const STROOPS_PER_XLM = 10_000_000;
 
-exports.name = '029_pledges_amount_stroops';
+exports.name = '038_pledges_amount_stroops';
 
 exports.up = async (db) => {
   try {


### PR DESCRIPTION
## Summary

`loadMigrationFiles()` in `src/utils/migrationRunner.js` detects duplicate numeric prefixes and prevents `runMigrations()` from executing — blocking fresh database bootstrap in CI and new environments entirely.

The duplicates were:
- `018` × 3: `018_api_key_rate_limit.js`, `018_idempotency_enhancements.js`, `018_wallets_table.js`
- `019` × 2: `019_circuit_breaker_state.js`, `019_donations_store.js`
- `024` × 3: `024_corporate_matching_and_sep10_challenges.js`, `024_payment_streams.js`, `024_scheduler_locks.js`
- `025` × 2: `025_anomaly_detection_state.js`, `025_circuit_breaker_probe.js`
- `029` × 3: `029_check_constraints_monetary.js`, `029_pledge_webhook_sent_at.js`, `029_pledges_amount_stroops.js`

## Fix

The extra files in each duplicate group are renamed to the next available numbers (031–038) and their internal `exports.name` fields are updated to match:

| Old name | New name |
|---|---|
| `018_api_key_rate_limit.js` | `031_api_key_rate_limit.js` |
| `018_wallets_table.js` | `032_wallets_table.js` |
| `019_donations_store.js` | `033_donations_store.js` |
| `024_payment_streams.js` | `034_payment_streams.js` |
| `024_scheduler_locks.js` | `035_scheduler_locks.js` |
| `025_circuit_breaker_probe.js` | `036_circuit_breaker_probe.js` |
| `029_pledge_webhook_sent_at.js` | `037_pledge_webhook_sent_at.js` |
| `029_pledges_amount_stroops.js` | `038_pledges_amount_stroops.js` |

The canonical file at each original prefix is left in place. All 38 migration prefixes are now unique and sequential.

Closes #1349