### PR TITLE
fix: strengthen Stellar secret key validation in securityConfig.js

### DIFF
--- a/src/config/securityConfig.js
+++ b/src/config/securityConfig.js
@@ -114,8 +114,14 @@ const SECURITY_CONFIGS = {
     validator: (value) => {
       if (!value || !value.trim()) return null;
       const trimmed = value.trim();
-      // Basic Stellar secret key validation
-      if (trimmed.startsWith('S') && trimmed.length >= 56) {
+      // Stellar secret keys must start with 'S', be exactly 56 characters,
+      // and contain only uppercase letters A-Z and digits 2-7 (base32 alphabet).
+      // This matches the isValidStellarSecretKey() pattern used elsewhere in
+      // the codebase (src/utils/validators.js) and rejects keys that merely
+      // start with 'S' and are >= 56 chars — an overly permissive check that
+      // would accept invalid characters or incorrect lengths beyond 56.
+      const stellarSecretKeyRegex = /^S[A-Z2-7]{55}$/;
+      if (stellarSecretKeyRegex.test(trimmed)) {
         return trimmed;
       }
       log.warn('SECURITY_CONFIG', 'Invalid Stellar secret key format, ignoring', {


### PR DESCRIPTION
## Summary

The `SERVICE_SECRET_KEY` and `STELLAR_SECRET` validators in `src/config/securityConfig.js` used a loose guard:

```js
if (trimmed.startsWith('S') && trimmed.length >= 56)
```

This accepted:
- Keys longer than the correct 56 characters
- Lowercase letters and characters outside the valid base32 alphabet (A–Z, 2–7)

A malformed value that started with `S` and was ≥ 56 chars would pass config load-time validation silently, only failing deep inside the Stellar SDK at transaction time — far removed from the real misconfiguration.

## Fix

Replace the loose guards with the strict regex already used by `isValidStellarSecretKey()` in `src/utils/validators.js`:

```js
const stellarSecretKeyRegex = /^S[A-Z2-7]{55}$/;
```

This enforces:
- Exactly 56 characters total
- Starts with `S`
- Only base32 alphabet characters (`A-Z`, `2-7`) for the remaining 55

Invalid keys are now rejected at config load time with a warning log, before any Stellar SDK call is attempted.

Closes #1347