### PR TITLE
fix: add missing scopes column to api_keys table

### DIFF
--- a/src/migrations/003_api_keys.js
+++ b/src/migrations/003_api_keys.js
@@ -22,6 +22,7 @@ exports.up = async (db) => {
       rotated_to_id INTEGER,
       signing_required INTEGER NOT NULL DEFAULT 0,
       key_secret TEXT,
+      scopes TEXT,
       allowed_ips TEXT,
       monthly_quota INTEGER,
       quota_used INTEGER NOT NULL DEFAULT 0,

--- a/src/migrations/039_api_keys_add_scopes.js
+++ b/src/migrations/039_api_keys_add_scopes.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Migration 039: Add missing `scopes` column to api_keys table (#1351)
+ *
+ * The authoritative api_keys CREATE TABLE in migration 003_api_keys.js does not
+ * include a `scopes` column, but src/models/apiKeys.js unconditionally references
+ * it in createApiKey(), validateApiKey(), listApiKeys(), and rotateApiKey().
+ *
+ * Because initializeApiKeysTable() uses CREATE TABLE IF NOT EXISTS, its own
+ * CREATE_TABLE_SQL (which includes scopes TEXT) is a no-op once the real
+ * migration has already created the table — the column is never added, and
+ * every call to the above functions fails with:
+ *
+ *   SQLITE_ERROR: table api_keys has no column named scopes
+ *
+ * This migration adds the column via ALTER TABLE (idempotent — silently skips
+ * if the column already exists, e.g. on databases bootstrapped from the model's
+ * own fallback schema rather than the migration runner).
+ */
+
+exports.name = '039_api_keys_add_scopes';
+
+exports.up = async (db) => {
+  try {
+    await db.run(`ALTER TABLE api_keys ADD COLUMN scopes TEXT`);
+  } catch (err) {
+    // Column already exists — safe to ignore (e.g. databases bootstrapped via
+    // the model's own CREATE_TABLE_SQL fallback before this migration ran).
+    if (!err.message.includes('duplicate column')) throw err;
+  }
+};
+
+exports.down = async (db) => {
+  // SQLite does not support DROP COLUMN before version 3.35.0.
+  // Recreate the table without the scopes column to support rollback on older
+  // SQLite versions while faithfully preserving all constraints and indexes.
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS api_keys_no_scopes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      key_hash TEXT NOT NULL UNIQUE,
+      key_prefix TEXT NOT NULL,
+      name TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'user',
+      status TEXT NOT NULL DEFAULT 'active',
+      created_by TEXT,
+      metadata TEXT,
+      expires_at INTEGER,
+      last_used_at INTEGER,
+      deprecated_at INTEGER,
+      revoked_at INTEGER,
+      created_at INTEGER NOT NULL,
+      grace_period_days INTEGER NOT NULL DEFAULT 30,
+      rotated_to_id INTEGER,
+      signing_required INTEGER NOT NULL DEFAULT 0,
+      key_secret TEXT,
+      allowed_ips TEXT,
+      monthly_quota INTEGER,
+      quota_used INTEGER NOT NULL DEFAULT 0,
+      quota_reset_at INTEGER,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      notification_email TEXT,
+      last_expiry_notification_sent_at INTEGER
+    )
+  `);
+  await db.run(`
+    INSERT INTO api_keys_no_scopes (
+      id, key_hash, key_prefix, name, role, status, created_by, metadata,
+      expires_at, last_used_at, deprecated_at, revoked_at, created_at,
+      grace_period_days, rotated_to_id, signing_required, key_secret,
+      allowed_ips, monthly_quota, quota_used, quota_reset_at, tenant_id,
+      notification_email, last_expiry_notification_sent_at
+    )
+    SELECT
+      id, key_hash, key_prefix, name, role, status, created_by, metadata,
+      expires_at, last_used_at, deprecated_at, revoked_at, created_at,
+      grace_period_days, rotated_to_id, signing_required, key_secret,
+      allowed_ips, monthly_quota, quota_used, quota_reset_at, tenant_id,
+      notification_email, last_expiry_notification_sent_at
+    FROM api_keys
+  `);
+  await db.run(`DROP TABLE api_keys`);
+  await db.run(`ALTER TABLE api_keys_no_scopes RENAME TO api_keys`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash)`);
+  await db.run(`CREATE INDEX IF NOT EXISTS idx_api_keys_status ON api_keys(status)`);
+};


### PR DESCRIPTION
## Summary

`src/models/apiKeys.js` unconditionally references a `scopes` column in `createApiKey()`, `validateApiKey()`, `listApiKeys()`, and `rotateApiKey()`. The authoritative `CREATE TABLE` in `003_api_keys.js` did not include this column, and no later migration added it via `ALTER TABLE`.

Because `initializeApiKeysTable()` uses `CREATE TABLE IF NOT EXISTS`, the model's own `CREATE_TABLE_SQL` fallback (which includes `scopes TEXT`) is a no-op once the real migration has already created the table. The column is never added, and every API key operation fails with:

```
SQLITE_ERROR: table api_keys has no column named scopes
```

This breaks API key creation — a foundational operation — on every environment bootstrapped via `npm run migrate` (CI, fresh local installs, any real deployment).

## Fix

Two changes:

1. **New migration `039_api_keys_add_scopes.js`** — runs `ALTER TABLE api_keys ADD COLUMN scopes TEXT` for existing databases. Idempotent: silently skips if the column already exists (e.g. databases bootstrapped from the model's own fallback schema before this migration ran).

2. **`003_api_keys.js`** — added `scopes TEXT` to the `CREATE TABLE` statement so completely fresh bootstraps from the migration itself also include the column without needing migration 039.

Closes #1351