### PR TITLE
feat(examples): make SignedApiClient a real HTTP client (fix #1429)

### DIFF
--- a/examples/signedClient.js
+++ b/examples/signedClient.js
@@ -1,19 +1,287 @@
 'use strict';
 
+/**
+ * SignedApiClient
+ * ----------------
+ * Minimal, runnable example client for the Stellar Micro-Donation API's
+ * HMAC-SHA256 request-signing feature (see src/utils/requestSigner.js and
+ * src/middleware/apiKey.js).
+ *
+ * Usage:
+ *
+ *   const SignedApiClient = require('./examples/signedClient');
+ *   const client = new SignedApiClient({
+ *     baseUrl:   'http://localhost:3000/api/v1',
+ *     apiKey:    process.env.API_KEY,
+ *     apiSecret: process.env.API_KEY_SECRET,
+ *   });
+ *   const res       = await client.get('/donations/recent?limit=10');
+ *   const created   = await client.post('/wallets', { address: 'G…', name: 'My wallet' });
+ *
+ * Behavior:
+ *   - Generates a fresh Unix-seconds timestamp per request
+ *   - Generates a fresh X-Nonce (UUID v4) per request to defeat replay attacks
+ *   - Builds the canonical signing string from METHOD + path+query + ts + sha256(body)
+ *     where `path+query` matches what the server sees as `req.originalUrl`
+ *     (e.g. '/api/v1/donations?limit=10')
+ *   - Attaches X-API-Key, X-Timestamp, X-Signature, X-Nonce headers
+ *   - Sends via the global `fetch` (Node >= 18). A custom fetch can be
+ *     injected via the `fetch` constructor option (useful for tests).
+ *
+ * Compatibility:
+ *   - The `_sign(method, path, timestamp, body)` method is preserved for
+ *     existing tests and consumers that want to compute a signature manually.
+ */
+
 const crypto = require('crypto');
-const { buildCanonicalString, hashBody } = require('../src/utils/requestSigner');
+const { sign: signerSign } = require('../src/utils/requestSigner');
+
+const SUPPORTED_METHODS = new Set([
+  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS',
+]);
+
+function generateNonce() {
+  // 16 random bytes hex-encoded gives us a 32-char nonce. The server only
+  // requires uniqueness, so any random string of sufficient entropy works.
+  return crypto.randomBytes(16).toString('hex');
+}
 
 class SignedApiClient {
-  constructor({ baseUrl, apiKey, apiSecret }) {
-    this.baseUrl = baseUrl;
+  /**
+   * @param {object} options
+   * @param {string} options.baseUrl     e.g. 'http://localhost:3000/api/v1'
+   * @param {string} options.apiKey      The X-API-Key value
+   * @param {string} options.apiSecret   The HMAC secret for signing
+   * @param {function} [options.fetch]   Optional fetch implementation (for testing)
+   * @param {object}   [options.defaultHeaders] Extra headers applied to every request
+   * @param {function} [options.generateNonce] Optional override for nonce generation
+   */
+  constructor({
+    baseUrl,
+    apiKey,
+    apiSecret,
+    fetch: fetchImpl,
+    defaultHeaders,
+    generateNonce: generateNonceImpl,
+  } = {}) {
+    this.baseUrl = (baseUrl || '').replace(/\/+$/, '');
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;
+    this.defaultHeaders = defaultHeaders || {};
+    this.generateNonce = typeof generateNonceImpl === 'function' ? generateNonceImpl : generateNonce;
+    this._fetch = fetchImpl || (typeof fetch !== 'undefined' ? fetch.bind(globalThis) : null);
   }
 
+  /**
+   * Produce a hex HMAC-SHA256 signature for a request.
+   *
+   * Method is upper-cased to match the server's canonical-string format.
+   * `body` is treated as the *raw* request body — JSON-stringify any object
+   * before passing.
+   *
+   * @param {string} method              HTTP method ('GET', 'POST', …)
+   * @param {string} path                Request path including query string
+   * @param {number|string} timestamp    Unix timestamp in seconds
+   * @param {string} [body='']           Raw request body string ('' for empty)
+   * @returns {string} lowercase hex signature
+   */
   _sign(method, path, timestamp, body = '') {
-    const canonical = buildCanonicalString(method, path, timestamp, hashBody(body));
-    return crypto.createHmac('sha256', this.apiSecret).update(canonical).digest('hex');
+    const { signature } = signerSign({
+      secret: this.apiSecret,
+      method,
+      path,
+      timestamp: String(timestamp),
+      body: typeof body === 'string' ? body : '',
+    });
+    return signature;
   }
+
+  /**
+   * Build the signed header set for a request.
+   * @private
+   */
+  _signedHeaders(method, pathWithQuery, rawBody, extraHeaders) {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const nonce = this.generateNonce();
+    const { signature } = signerSign({
+      secret: this.apiSecret,
+      method,
+      path: pathWithQuery,
+      timestamp,
+      body: rawBody,
+    });
+
+    const baseHeaders = { ...this.defaultHeaders, ...(extraHeaders || {}) };
+    return {
+      ...baseHeaders,
+      'X-API-Key': this.apiKey,
+      'X-Timestamp': timestamp,
+      'X-Signature': signature,
+      'X-Nonce': nonce,
+    };
+  }
+
+  /**
+   * Resolve a relative path into a fully-qualified URL.
+   * The baseUrl's mount prefix (path component) is preserved verbatim —
+   * standard URL resolution would replace it, which is wrong for our use
+   * case (the server signs `req.originalUrl`, which always includes the
+   * mount prefix like `/api/v1`).
+   * @private
+   */
+  _buildUrl(path, query) {
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) {
+      // Already absolute
+      const url = new URL(path);
+      this._applyQuery(url, query);
+      return url;
+    }
+    if (!this.baseUrl) {
+      throw new Error('SignedApiClient: baseUrl is required when path is relative');
+    }
+
+    const baseUrlObj = new URL(this.baseUrl);
+    const baseMount = baseUrlObj.pathname.replace(/\/+$/, '');
+    const relative = path.startsWith('/') ? path : `/${path}`;
+
+    // Protocol + host + baseMount + relative, with any redundant slashes removed.
+    const origin = `${baseUrlObj.protocol}//${baseUrlObj.host}`;
+    const pathComponent = `${baseMount}${relative}`.replace(/\/{2,}/g, '/');
+    const url = new URL(`${origin}${pathComponent}`);
+    this._applyQuery(url, query);
+    return url;
+  }
+
+  /**
+   * Apply a query object to a URL's searchParams.
+   * @private
+   */
+  _applyQuery(url, query) {
+    if (!query || typeof query !== 'object') return;
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined || v === null) continue;
+      if (Array.isArray(v)) {
+        for (const item of v) url.searchParams.append(k, String(item));
+      } else {
+        url.searchParams.set(k, String(v));
+      }
+    }
+  }
+
+  /**
+   * Serialize the request body and pick the Content-Type.
+   * @private
+   */
+  _serializeBody(opts) {
+    const { body, bodyRaw, headers } = opts;
+    const headersHasCT = headers && Object.keys(headers).some(
+      (k) => k.toLowerCase() === 'content-type'
+    );
+
+    if (bodyRaw !== undefined && bodyRaw !== null) {
+      if (typeof bodyRaw !== 'string') {
+        throw new TypeError('SignedApiClient: opts.bodyRaw must be a string');
+      }
+      return { rawBody: bodyRaw, contentType: headersHasCT ? null : 'application/json' };
+    }
+    if (body === undefined || body === null) {
+      return { rawBody: '', contentType: null };
+    }
+    if (typeof body === 'string') {
+      return { rawBody: body, contentType: headersHasCT ? null : 'text/plain' };
+    }
+    return { rawBody: JSON.stringify(body), contentType: headersHasCT ? null : 'application/json' };
+  }
+
+  /**
+   * Send a signed HTTP request and return the parsed response.
+   *
+   * @param {string} method   'GET' | 'POST' | …
+   * @param {string} path     relative path (e.g. '/donations') — may include
+   *                          a query string. If `opts.query` is provided it
+   *                          is merged on top.
+   * @param {object} [opts]
+   * @param {object} [opts.body]      Plain-object body to JSON-encode
+   * @param {string} [opts.bodyRaw]   Pre-serialized raw body string
+   * @param {object} [opts.query]     Query parameters
+   * @param {object} [opts.headers]   Extra request headers (X-* signing
+   *                                  headers cannot be overridden)
+   * @returns {Promise<{status:number, ok:boolean, headers:object, url:string, data:any}>}
+   */
+  async request(method, path, opts = {}) {
+    const upper = String(method || 'GET').toUpperCase();
+    if (!SUPPORTED_METHODS.has(upper)) {
+      throw new Error(`SignedApiClient: unsupported HTTP method "${method}"`);
+    }
+    if (!this._fetch) {
+      throw new Error(
+        'SignedApiClient: no fetch implementation available. ' +
+        'Use Node >= 18 or pass `fetch` in the constructor options.'
+      );
+    }
+
+    const { query, headers: extraHeaders } = opts;
+
+    // Build the URL up front so we can derive the signing path+query.
+    // The signing path is exactly `url.pathname + url.search`, which
+    // mirrors what the server reads from `req.originalUrl`.
+    const url = this._buildUrl(path, query);
+    const pathWithQuery = url.pathname + url.search;
+
+    const { rawBody, contentType } = this._serializeBody(opts);
+    const mergedHeaders = { ...(extraHeaders || {}) };
+    if (contentType && !Object.keys(mergedHeaders).some((k) => k.toLowerCase() === 'content-type')) {
+      mergedHeaders['Content-Type'] = contentType;
+    }
+
+    const headers = this._signedHeaders(upper, pathWithQuery, rawBody, mergedHeaders);
+
+    const fetchOpts = { method: upper, headers };
+    if (rawBody && upper !== 'GET' && upper !== 'HEAD') {
+      fetchOpts.body = rawBody;
+    }
+
+    const response = await this._fetch(url.toString(), fetchOpts);
+
+    // Parse the response body according to Content-Type
+    let data = null;
+    const headerStore = response.headers || new Headers();
+    const contentTypeHeader = (headerStore.get && headerStore.get('content-type')) || '';
+    if (contentTypeHeader.includes('application/json')) {
+      try {
+        data = await response.json();
+      } catch (_) {
+        data = null;
+      }
+    } else {
+      try {
+        data = await response.text();
+      } catch (_) {
+        data = null;
+      }
+    }
+
+    // Convert Headers to a plain object so consumers get JSON-serializable output
+    const plainHeaders = {};
+    if (typeof headerStore.forEach === 'function') {
+      headerStore.forEach((value, key) => { plainHeaders[key] = value; });
+    }
+
+    return {
+      status: response.status,
+      ok: !!response.ok,
+      headers: plainHeaders,
+      url: response.url || url.toString(),
+      data,
+    };
+  }
+
+  get(path, opts)              { return this.request('GET',    path, opts); }
+  delete(path, opts)           { return this.request('DELETE', path, opts); }
+  post(path, body, opts)       { return this.request('POST',   path, { ...(opts || {}), body }); }
+  put(path, body, opts)        { return this.request('PUT',    path, { ...(opts || {}), body }); }
+  patch(path, body, opts)      { return this.request('PATCH',  path, { ...(opts || {}), body }); }
+  head(path, opts)             { return this.request('HEAD',   path, opts); }
 }
 
 module.exports = SignedApiClient;

--- a/tests/middleware/request-signing-for-enhanced-api-securit.test.js
+++ b/tests/middleware/request-signing-for-enhanced-api-securit.test.js
@@ -340,11 +340,13 @@ describe('requireApiKey middleware with signing_required', () => {
   it('accepts a correctly signed GET request', async () => {
     const ts = String(nowSec());
     const { signature } = sign({ secret: signingSecret, method: 'GET', path: '/test', timestamp: ts });
+    const nonce = crypto.randomBytes(16).toString('hex');
     const res = await request(app)
       .get('/test')
       .set('x-api-key', signingKey)
       .set('x-timestamp', ts)
-      .set('x-signature', signature);
+      .set('x-signature', signature)
+      .set('x-nonce', nonce);
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
   });
@@ -353,11 +355,13 @@ describe('requireApiKey middleware with signing_required', () => {
     const body = JSON.stringify({ amount: '10' });
     const ts = String(nowSec());
     const { signature } = sign({ secret: signingSecret, method: 'POST', path: '/test', timestamp: ts, body });
+    const nonce = crypto.randomBytes(16).toString('hex');
     const res = await request(app)
       .post('/test')
       .set('x-api-key', signingKey)
       .set('x-timestamp', ts)
       .set('x-signature', signature)
+      .set('x-nonce', nonce)
       .set('Content-Type', 'application/json')
       .send(body);
     expect(res.status).toBe(200);
@@ -465,5 +469,221 @@ describe('SignedApiClient (examples/signedClient.js)', () => {
     const s1 = client._sign('GET', '/donations', ts, '');
     const s2 = client._sign('GET', '/wallets', ts, '');
     expect(s1).not.toBe(s2);
+  });
+});
+
+// ─── SignedApiClient — real HTTP request() integration ────────────────────────
+//
+// These tests inject a mock fetch and exercise SignedApiClient end-to-end:
+// they verify that the X-API-Key / X-Timestamp / X-Signature / X-Nonce
+// headers are attached, the signature is valid for the canonical string the
+// server would see, the body is JSON-serialized correctly, query params are
+// appended, and the response is parsed as JSON.
+describe('SignedApiClient (request() HTTP integration)', () => {
+  const SignedApiClient = require('../../examples/signedClient');
+
+  // Build a fake fetch that records every call and returns a configurable
+  // response. Returns { fetch, getCalls } where getCalls() is an array of
+  // { url, opts } pairs in invocation order.
+  function makeMockFetch(responseFactory) {
+    const calls = [];
+    const mockFetch = async (url, opts) => {
+      calls.push({ url, opts });
+      return {
+        status: 200,
+        ok: true,
+        url,
+        headers: {
+          get(name) { return name.toLowerCase() === 'content-type' ? 'application/json' : null; },
+          forEach(cb) { cb('application/json', 'content-type'); },
+        },
+        json: async () => responseFactory(calls),
+        text: async () => JSON.stringify(responseFactory(calls)),
+      };
+    };
+    return { fetch: mockFetch, getCalls: () => calls };
+  }
+
+  // Convenience: assert the first mock call has the expected property. Helps
+  // avoid subtle bugs where `getCalls[0]` accesses a character index on the
+  // function rather than the first invocation.
+  function firstCall(getCalls) {
+    const arr = getCalls();
+    expect(arr.length).toBeGreaterThan(0);
+    return arr[0];
+  }
+
+  it('sends GET with signed headers and a signature the server can verify', async () => {
+    const secret = makeSecret();
+    const apiKey = 'k_test';
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => ({ ok: true }));
+
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey,
+      apiSecret: secret,
+      fetch: mockFetch,
+    });
+    await client.get('/donations/recent?limit=5');
+
+    const calls = getCalls();
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+
+    // The full URL should include the mount prefix and the literal query string.
+    expect(call.url).toBe('http://localhost:3000/api/v1/donations/recent?limit=5');
+
+    // All 4 required signing headers must be attached.
+    expect(call.opts.method).toBe('GET');
+    expect(call.opts.headers['X-API-Key']).toBe(apiKey);
+    expect(call.opts.headers['X-Timestamp']).toMatch(/^\d{10}$/);
+    expect(call.opts.headers['X-Signature']).toMatch(/^[0-9a-f]{64}$/);
+    expect(call.opts.headers['X-Nonce']).toBeDefined();
+    expect(typeof call.opts.headers['X-Nonce']).toBe('string');
+    expect(call.opts.headers['X-Nonce'].length).toBeGreaterThanOrEqual(8);
+
+    // Signature must be valid for what the server would see as req.originalUrl.
+    const result = verify({
+      secret,
+      method: 'GET',
+      path: '/api/v1/donations/recent?limit=5',
+      timestamp: call.opts.headers['X-Timestamp'],
+      signature: call.opts.headers['X-Signature'],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('JSON-serializes a POST body and signs the exact raw bytes', async () => {
+    const secret = makeSecret();
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => ({ success: true }));
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: secret,
+      fetch: mockFetch,
+    });
+
+    const body = { recipientId: 'Gr…', senderId: 'Ga…', amount: '10' };
+    await client.post('/donations', body);
+
+    const call = getCalls()[0];
+    expect(call.opts.method).toBe('POST');
+    expect(call.opts.headers['Content-Type']).toBe('application/json');
+    expect(call.opts.body).toBe(JSON.stringify(body));
+
+    // The signature must be computed over the exact raw body the server receives.
+    const result = verify({
+      secret,
+      method: 'POST',
+      path: '/api/v1/donations',
+      timestamp: call.opts.headers['X-Timestamp'],
+      signature: call.opts.headers['X-Signature'],
+      body: JSON.stringify(body),
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('appends query parameters via opts.query and signs the resulting path+query', async () => {
+    const secret = makeSecret();
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => []);
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: secret,
+      fetch: mockFetch,
+    });
+    await client.get('/donations/recent', { query: { limit: 10, type: 'gift' } });
+
+    const call = getCalls()[0];
+    // URL.searchParams sorts by insertion order; here we inserted limit first.
+    expect(call.url).toContain('http://localhost:3000/api/v1/donations/recent');
+    expect(call.url).toContain('limit=10');
+    expect(call.url).toContain('type=gift');
+
+    const result = verify({
+      secret,
+      method: 'GET',
+      path: call.url.replace('http://localhost:3000', ''),
+      timestamp: call.opts.headers['X-Timestamp'],
+      signature: call.opts.headers['X-Signature'],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns parsed JSON data and a status flag', async () => {
+    const payload = { success: true, data: { id: 1 } };
+    const { fetch: mockFetch } = makeMockFetch(() => payload);
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: makeSecret(),
+      fetch: mockFetch,
+    });
+    const res = await client.get('/wallets');
+    expect(res.status).toBe(200);
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual(payload);
+  });
+
+  it('rejects unsupported HTTP methods', async () => {
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => ({}));
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: makeSecret(),
+      fetch: mockFetch,
+    });
+    await expect(client.request('FOO', '/x')).rejects.toThrow(/unsupported/i);
+    expect(getCalls()).toHaveLength(0);
+  });
+
+  it('supports the convenience wrappers get/post/put/patch/delete/head', async () => {
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => ({}));
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: makeSecret(),
+      fetch: mockFetch,
+    });
+    await client.get('/a');
+    await client.post('/a', { x: 1 });
+    await client.put('/a', { x: 2 });
+    await client.patch('/a', { x: 3 });
+    await client.delete('/a');
+    await client.head('/a');
+    expect(getCalls().map((c) => c.opts.method)).toEqual(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
+  });
+
+  it('generates a fresh nonce for each request (replay protection)', async () => {
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => ({}));
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: makeSecret(),
+      fetch: mockFetch,
+    });
+    await client.get('/a');
+    await client.get('/a');
+    const [a, b] = getCalls().map((c) => c.opts.headers['X-Nonce']);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+  });
+
+  it('allows custom defaultHeaders and a custom nonce generator (for deterministic tests)', async () => {
+    let counter = 0;
+    const { fetch: mockFetch, getCalls } = makeMockFetch(() => ({}));
+    const client = new SignedApiClient({
+      baseUrl: 'http://localhost:3000/api/v1',
+      apiKey: 'k',
+      apiSecret: makeSecret(),
+      fetch: mockFetch,
+      defaultHeaders: { 'X-Demo-Header': 'demo' },
+      generateNonce: () => `nonce-${++counter}`,
+    });
+    await client.get('/a');
+    const call = getCalls()[0];
+    expect(call.opts.headers['X-Demo-Header']).toBe('demo');
+    expect(call.opts.headers['X-Nonce']).toBe('nonce-1');
   });
 });


### PR DESCRIPTION
Closes #1429

`examples/signedClient.js` was presented as an example client for the request-signing feature but never actually sent an HTTP request — the entire file was a wrapper around the private signing helper. This PR rewrites it as a real, runnable minimal client and adds end-to-end tests with an injected `fetch`.

## What changed

* Adds a `request(method, path, opts)` method that signs and sends via Node ≥18 built-in `fetch`.
* Adds convenience wrappers `get / post / put / patch / delete / head(path, [body], [opts])`.
* Generates a fresh `X-Timestamp` (Unix seconds) **and** a random `X-Nonce` per request — matches what `src/middleware/apiKey.js` enforces (the `X-Nonce` enforcement was a previously-undocumented requirement; without it any sign-compatible client would have 401'd in production).
* The signing path mirrors `req.originalUrl` byte-for-byte: `baseUrl`'s mount prefix (e.g. `/api/v1`) is preserved verbatim, not collapsed by URL parsing.
* Supports JSON body, pre-serialized raw body (`opts.bodyRaw`), object query params, and custom request headers (signing headers cannot be overridden).

## Backward compatibility

* `_sign(method, path, timestamp, body)` is preserved so existing tests still pass.
* Constructor signature `{ baseUrl, apiKey, apiSecret }` unchanged.
* Default export name `SignedApiClient` unchanged.
* `fetch` can be injected via constructor options for tests.

## Also in this PR (defensive test fix)

The two pre-existing middleware integration tests in this file were failing because `requireApiKey` now requires `X-Nonce` for `signing_required` keys. Added the missing header so the suite is green. Companion branch #1428 applies the same fix.

## Tests

8 new tests under `describe('SignedApiClient (request() HTTP integration)')` exercising the full HTTP request flow with an injected mock `fetch`:

* `GET` — signed headers verified against `verify()` (the same function the middleware uses).
* `POST` with JSON body — signature computed over the exact raw bytes.
* Query parameters via `opts.query` (URL + signature both reflect them).
* Response JSON parsing + `status` / `ok` / `headers`.
* Unsupported HTTP method rejection.
* All convenience wrappers (`get/post/put/patch/delete/head`).
* Per-request nonce uniqueness (replay protection).
* Custom default headers + custom nonce generator for deterministic tests.

## Local verification

* `npx jest tests/middleware/request-signing-for-enhanced-api-securit.test.js` — 47/47 pass.
* `npx eslint examples/signedClient.js` — 0 errors (1 security-plugin warning is a false positive on a property lookup, the file uses safe destructuring patterns).
* End-to-end smoke against a local server can be done by:
  ```
  node -e 'const C=require("./examples/signedClient"); const c=new C({baseUrl:"http://localhost:3000/api/v1",apiKey:"...",apiSecret:"..."}); c.get("/wallets").then(console.log);'
  ```
