### PR TITLE
test: add missing coverage for issues #1387 #1388 #1389 #1390

### DIFF
--- a/tests/admin/i18nController.test.js
+++ b/tests/admin/i18nController.test.js
@@ -1,0 +1,405 @@
+'use strict';
+
+/**
+ * Tests: src/controllers/admin/i18nController.js (issue #1388)
+ *
+ * Unit-tests each exported controller function by calling it directly with
+ * a synthetic req/res pair. The Translation model is fully mocked so no
+ * database or network calls are made.
+ *
+ * Covers:
+ *  getAllMessages
+ *    - returns all translation keys with their translations from the cache
+ *    - re-fetches from Translation model when the cache is stale
+ *    - returns 500 on model error
+ *
+ *  updateTranslation
+ *    - updates an existing translation document
+ *    - creates a new document when the key does not exist
+ *    - returns 400 when value is missing
+ *    - returns 500 on model error
+ *    - clears the cache so the next request reloads from storage
+ *
+ *  addLanguage
+ *    - seeds all existing keys with the new language code
+ *    - uses provided translation values when available, empty string otherwise
+ *    - skips keys that already have the language code set
+ *    - returns 400 when code is missing
+ *    - returns 400 when name is missing
+ *    - returns 500 on model error
+ */
+
+// ─── Mock the Translation model before loading the controller ─────────────────
+
+const mockSave = jest.fn();
+const mockFind = jest.fn();
+const mockFindOne = jest.fn();
+
+// We need a constructor mock so `new Translation(...)` works
+const MockTranslation = jest.fn().mockImplementation(({ key, translations = {} }) => ({
+  key,
+  translations: new Map(Object.entries(translations)),
+  updatedAt: Date.now(),
+  save: mockSave,
+}));
+MockTranslation.find = mockFind;
+MockTranslation.findOne = mockFindOne;
+
+jest.mock('../../src/models/translation', () => MockTranslation);
+
+// ─── Load the controller AFTER the mock is registered ────────────────────────
+
+const controller = require('../../src/controllers/admin/i18nController');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal Express-like req object.
+ */
+function makeReq({ params = {}, body = {}, query = {} } = {}) {
+  return { params, body, query };
+}
+
+/**
+ * Build a minimal Express-like res object that captures calls.
+ */
+function makeRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+  };
+  return res;
+}
+
+/**
+ * Build a TranslationDoc-like object the way the real model returns it.
+ */
+function makeDoc(key, translationsObj = {}) {
+  return {
+    key,
+    translations: new Map(Object.entries(translationsObj)),
+    updatedAt: Date.now(),
+    save: mockSave,
+  };
+}
+
+// ─── Before / after hooks ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSave.mockResolvedValue(undefined);
+});
+
+// ─── getAllMessages ────────────────────────────────────────────────────────────
+
+describe('getAllMessages', () => {
+  it('returns 200 with all translation keys and their translations', async () => {
+    mockFind.mockResolvedValue([
+      makeDoc('errors.notFound', { en: 'Not found', es: 'No encontrado' }),
+      makeDoc('errors.unauthorized', { en: 'Unauthorized' }),
+    ]);
+
+    const req = makeReq();
+    const res = makeRes();
+
+    await controller.getAllMessages(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body.success).toBe(true);
+    expect(Array.isArray(res._body.messages)).toBe(true);
+    expect(res._body.messages).toHaveLength(2);
+
+    const keys = res._body.messages.map(m => m.key);
+    expect(keys).toContain('errors.notFound');
+    expect(keys).toContain('errors.unauthorized');
+  });
+
+  it('includes translations object for each message entry', async () => {
+    mockFind.mockResolvedValue([
+      makeDoc('welcome', { en: 'Welcome', fr: 'Bienvenue' }),
+    ]);
+
+    const req = makeReq();
+    const res = makeRes();
+
+    await controller.getAllMessages(req, res);
+
+    const entry = res._body.messages[0];
+    expect(entry.key).toBe('welcome');
+    expect(entry.translations).toBeDefined();
+  });
+
+  it('returns 200 with empty messages array when no translations exist', async () => {
+    mockFind.mockResolvedValue([]);
+
+    const req = makeReq();
+    const res = makeRes();
+
+    await controller.getAllMessages(req, res);
+
+    expect(res._body.success).toBe(true);
+    expect(res._body.messages).toHaveLength(0);
+  });
+
+  it('returns 500 when the Translation model throws', async () => {
+    mockFind.mockRejectedValue(new Error('DB unavailable'));
+
+    const req = makeReq();
+    const res = makeRes();
+
+    await controller.getAllMessages(req, res);
+
+    expect(res._status).toBe(500);
+    expect(res._body.success).toBe(false);
+    expect(res._body.error).toMatch('DB unavailable');
+  });
+});
+
+// ─── updateTranslation ────────────────────────────────────────────────────────
+
+describe('updateTranslation', () => {
+  it('returns 400 when value is missing from request body', async () => {
+    const req = makeReq({
+      params: { lang: 'en', key: 'errors.notFound' },
+      body: {},  // no value
+    });
+    const res = makeRes();
+
+    await controller.updateTranslation(req, res);
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toMatch(/value is required/i);
+  });
+
+  it('updates an existing translation document and returns 200', async () => {
+    const existingDoc = makeDoc('errors.notFound', { en: 'Not found' });
+    mockFindOne.mockResolvedValue(existingDoc);
+
+    const req = makeReq({
+      params: { lang: 'en', key: 'errors.notFound' },
+      body: { value: 'Resource not found' },
+    });
+    const res = makeRes();
+
+    await controller.updateTranslation(req, res);
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(res._status).toBe(200);
+    expect(res._body.success).toBe(true);
+    expect(res._body.updated).toEqual({
+      key: 'errors.notFound',
+      lang: 'en',
+      value: 'Resource not found',
+    });
+  });
+
+  it('creates a new translation document when the key does not exist', async () => {
+    mockFindOne.mockResolvedValue(null);
+
+    const req = makeReq({
+      params: { lang: 'fr', key: 'errors.newKey' },
+      body: { value: 'Nouvelle valeur' },
+    });
+    const res = makeRes();
+
+    await controller.updateTranslation(req, res);
+
+    // MockTranslation constructor should have been called
+    expect(MockTranslation).toHaveBeenCalledWith({
+      key: 'errors.newKey',
+      translations: {},
+    });
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(res._body.success).toBe(true);
+    expect(res._body.updated.key).toBe('errors.newKey');
+    expect(res._body.updated.lang).toBe('fr');
+  });
+
+  it('sets the new value on the translations map', async () => {
+    const doc = makeDoc('greeting', { en: 'Hello' });
+    mockFindOne.mockResolvedValue(doc);
+
+    const req = makeReq({
+      params: { lang: 'es', key: 'greeting' },
+      body: { value: 'Hola' },
+    });
+    const res = makeRes();
+
+    await controller.updateTranslation(req, res);
+
+    expect(doc.translations.get('es')).toBe('Hola');
+  });
+
+  it('returns 500 when findOne throws', async () => {
+    mockFindOne.mockRejectedValue(new Error('Timeout'));
+
+    const req = makeReq({
+      params: { lang: 'en', key: 'foo' },
+      body: { value: 'bar' },
+    });
+    const res = makeRes();
+
+    await controller.updateTranslation(req, res);
+
+    expect(res._status).toBe(500);
+    expect(res._body.success).toBe(false);
+  });
+
+  it('returns 500 when save throws', async () => {
+    const doc = makeDoc('greeting', { en: 'Hello' });
+    mockFindOne.mockResolvedValue(doc);
+    mockSave.mockRejectedValue(new Error('Write failed'));
+
+    const req = makeReq({
+      params: { lang: 'en', key: 'greeting' },
+      body: { value: 'Hi' },
+    });
+    const res = makeRes();
+
+    await controller.updateTranslation(req, res);
+
+    expect(res._status).toBe(500);
+    expect(res._body.success).toBe(false);
+  });
+
+  it('invalidates the in-memory cache so subsequent reads reload from storage', async () => {
+    // Prime the cache with an initial getAllMessages call
+    mockFind.mockResolvedValue([makeDoc('k', { en: 'old' })]);
+    await controller.getAllMessages(makeReq(), makeRes());
+
+    // Now update the translation
+    const doc = makeDoc('k', { en: 'old' });
+    mockFindOne.mockResolvedValue(doc);
+    mockFind.mockResolvedValue([makeDoc('k', { en: 'new' })]);
+
+    await controller.updateTranslation(
+      makeReq({ params: { lang: 'en', key: 'k' }, body: { value: 'new' } }),
+      makeRes()
+    );
+
+    // getAllMessages should re-fetch from the model (find called again)
+    const callsBefore = mockFind.mock.calls.length;
+    await controller.getAllMessages(makeReq(), makeRes());
+    expect(mockFind.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});
+
+// ─── addLanguage ──────────────────────────────────────────────────────────────
+
+describe('addLanguage', () => {
+  it('returns 400 when code is missing', async () => {
+    const req = makeReq({ body: { name: 'Spanish' } });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toMatch(/code.*name/i);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const req = makeReq({ body: { code: 'es' } });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    expect(res._status).toBe(400);
+    expect(res._body.error).toMatch(/code.*name/i);
+  });
+
+  it('returns 201 and seeds all existing keys for the new language', async () => {
+    const doc1 = makeDoc('greeting', { en: 'Hello' });
+    const doc2 = makeDoc('farewell', { en: 'Goodbye' });
+
+    // find({}, 'key') — returns key stubs
+    mockFind.mockResolvedValue([{ key: 'greeting' }, { key: 'farewell' }]);
+    // findOne for each key
+    mockFindOne
+      .mockResolvedValueOnce(doc1)
+      .mockResolvedValueOnce(doc2);
+
+    const req = makeReq({
+      body: {
+        code: 'es',
+        name: 'Spanish',
+        translations: { greeting: 'Hola' }, // farewell has no provided translation
+      },
+    });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    expect(res._status).toBe(201);
+    expect(res._body.success).toBe(true);
+    expect(res._body.message).toMatch(/es.*Spanish/i);
+
+    // greeting should have been saved with 'Hola'
+    expect(doc1.translations.get('es')).toBe('Hola');
+    // farewell has no provided translation — falls back to empty string
+    expect(doc2.translations.get('es')).toBe('');
+    expect(mockSave).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips a key that already has the new language set', async () => {
+    // doc already has 'es'
+    const doc = makeDoc('greeting', { en: 'Hello', es: 'Hola' });
+    mockFind.mockResolvedValue([{ key: 'greeting' }]);
+    mockFindOne.mockResolvedValue(doc);
+
+    const req = makeReq({ body: { code: 'es', name: 'Spanish' } });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    // save should NOT have been called because 'es' already exists
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(res._status).toBe(201);
+  });
+
+  it('handles an empty translation store (no existing keys)', async () => {
+    mockFind.mockResolvedValue([]);
+
+    const req = makeReq({ body: { code: 'pt', name: 'Portuguese' } });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    expect(res._status).toBe(201);
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when Translation.find throws', async () => {
+    mockFind.mockRejectedValue(new Error('Storage error'));
+
+    const req = makeReq({ body: { code: 'de', name: 'German' } });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    expect(res._status).toBe(500);
+    expect(res._body.success).toBe(false);
+  });
+
+  it('returns 500 when save throws for one of the documents', async () => {
+    mockFind.mockResolvedValue([{ key: 'k1' }]);
+    const doc = makeDoc('k1', { en: 'val' });
+    mockFindOne.mockResolvedValue(doc);
+    mockSave.mockRejectedValue(new Error('Write error'));
+
+    const req = makeReq({ body: { code: 'ja', name: 'Japanese' } });
+    const res = makeRes();
+
+    await controller.addLanguage(req, res);
+
+    expect(res._status).toBe(500);
+    expect(res._body.success).toBe(false);
+  });
+});

--- a/tests/middleware/fieldFilter.test.js
+++ b/tests/middleware/fieldFilter.test.js
@@ -1,0 +1,474 @@
+'use strict';
+
+/**
+ * Tests: src/middleware/fieldFilter.js (issue #1390)
+ *
+ * fieldFilter.js exports four symbols:
+ *   fieldFilterMiddleware()  — Express middleware factory
+ *   filterObject()           — low-level object picker (used internally)
+ *   applyFilter()            — envelope-aware filter
+ *   isValidFieldPath()       — path segment validator
+ *
+ * Test categories:
+ *
+ *  isValidFieldPath
+ *    - valid simple and dotted paths
+ *    - invalid: empty, non-string, injection characters
+ *
+ *  filterObject
+ *    - picks requested top-level fields
+ *    - picks nested fields using dot notation
+ *    - handles undefined path gracefully (omits it)
+ *    - handles null/non-object input (returns as-is)
+ *    - does not include unrequested fields
+ *
+ *  applyFilter
+ *    - filters the `data` array when body has an array envelope
+ *    - filters the `data` object when body has an object envelope
+ *    - preserves top-level non-data fields (success, count, meta)
+ *    - filters the body directly when there is no `data` envelope
+ *    - passes non-object bodies through unchanged
+ *
+ *  fieldFilterMiddleware (Express middleware)
+ *    - passes through when no ?fields param is present
+ *    - passes through when ?fields is blank
+ *    - returns 400 for an invalid field path (injection chars, dots-only)
+ *    - returns 400 when a BLOCKED_FIELDS key is requested
+ *    - applies field filtering to res.json output
+ *    - sets X-Fields-Applied: true header when filtering
+ *    - handles dot-notation field paths end-to-end
+ *    - does not set the header when no filtering occurs
+ *
+ *  Security: BLOCKED_FIELDS enforcement
+ *    - password, secret, privateKey, secretKey are rejected
+ *    - blocked fields inside nested objects are stripped by filterObject
+ *      (they are not in the path list so are never included in output)
+ */
+
+const {
+  fieldFilterMiddleware,
+  filterObject,
+  applyFilter,
+  isValidFieldPath,
+} = require('../../src/middleware/fieldFilter');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a minimal Express-like req/res pair.
+ *
+ * @param {string|undefined} fieldsParam  - value of req.query.fields
+ * @param {object}           resBody      - the object res.json will be called with
+ */
+function makeReqRes(fieldsParam, resBody = {}) {
+  const req = {
+    query: fieldsParam !== undefined ? { fields: fieldsParam } : {},
+  };
+
+  const captured = {
+    status: 200,
+    headers: {},
+    body: null,
+  };
+
+  const res = {
+    _captured: captured,
+    setHeader(key, value) { captured.headers[key] = value; },
+    status(code) { captured.status = code; return this; },
+    json(body) { captured.body = body; return this; },
+  };
+
+  return { req, res, captured };
+}
+
+/**
+ * Run the middleware and return a promise that resolves with {next, captured}.
+ * `next` is true when next() was called, false when the middleware short-circuited.
+ */
+function runMiddleware(fieldsParam, resBody = {}) {
+  return new Promise((resolve) => {
+    const { req, res, captured } = makeReqRes(fieldsParam, resBody);
+    const middleware = fieldFilterMiddleware();
+
+    let nextCalled = false;
+    const next = () => { nextCalled = true; resolve({ nextCalled, captured, res }); };
+
+    const result = middleware(req, res, next);
+
+    // If the middleware returned synchronously (error path) without calling next
+    if (!nextCalled) {
+      // For the 400 paths, res.json was called synchronously
+      resolve({ nextCalled: false, captured, res });
+    }
+  });
+}
+
+// ─── isValidFieldPath ─────────────────────────────────────────────────────────
+
+describe('isValidFieldPath()', () => {
+  it('accepts simple alphanumeric field names', () => {
+    expect(isValidFieldPath('id')).toBe(true);
+    expect(isValidFieldPath('amount')).toBe(true);
+    expect(isValidFieldPath('createdAt')).toBe(true);
+  });
+
+  it('accepts underscore-separated field names', () => {
+    expect(isValidFieldPath('tx_hash')).toBe(true);
+    expect(isValidFieldPath('api_key_id')).toBe(true);
+  });
+
+  it('accepts dot-notation paths', () => {
+    expect(isValidFieldPath('wallet.address')).toBe(true);
+    expect(isValidFieldPath('donor.wallet.publicKey')).toBe(true);
+  });
+
+  it('rejects empty strings', () => {
+    expect(isValidFieldPath('')).toBe(false);
+  });
+
+  it('rejects non-string inputs', () => {
+    expect(isValidFieldPath(null)).toBe(false);
+    expect(isValidFieldPath(undefined)).toBe(false);
+    expect(isValidFieldPath(42)).toBe(false);
+  });
+
+  it('rejects paths with injection characters', () => {
+    expect(isValidFieldPath('id;DROP TABLE')).toBe(false);
+    expect(isValidFieldPath('field<script>')).toBe(false);
+    expect(isValidFieldPath('../secret')).toBe(false);
+    expect(isValidFieldPath('a b')).toBe(false);
+  });
+
+  it('rejects empty segment in path (trailing dot)', () => {
+    expect(isValidFieldPath('wallet.')).toBe(false);
+    expect(isValidFieldPath('.id')).toBe(false);
+  });
+});
+
+// ─── filterObject ─────────────────────────────────────────────────────────────
+
+describe('filterObject()', () => {
+  it('returns only the requested top-level fields', () => {
+    const obj = { id: 1, amount: 50, status: 'completed', internalCode: 'X' };
+    const result = filterObject(obj, [['id'], ['amount']]);
+    expect(result).toEqual({ id: 1, amount: 50 });
+    expect(result).not.toHaveProperty('status');
+    expect(result).not.toHaveProperty('internalCode');
+  });
+
+  it('returns nested values using dot-notation segment arrays', () => {
+    const obj = { id: 1, wallet: { address: 'GABC', balance: 100 } };
+    const result = filterObject(obj, [['id'], ['wallet', 'address']]);
+    expect(result).toEqual({ id: 1, wallet: { address: 'GABC' } });
+    expect(result.wallet).not.toHaveProperty('balance');
+  });
+
+  it('omits a path when the value does not exist in the source object', () => {
+    const obj = { id: 1 };
+    const result = filterObject(obj, [['id'], ['nonexistent']]);
+    expect(result).toEqual({ id: 1 });
+    expect(result).not.toHaveProperty('nonexistent');
+  });
+
+  it('handles deeply nested paths', () => {
+    const obj = { a: { b: { c: { d: 'deep' } } } };
+    const result = filterObject(obj, [['a', 'b', 'c', 'd']]);
+    expect(result).toEqual({ a: { b: { c: { d: 'deep' } } } });
+  });
+
+  it('returns null as-is (not an object)', () => {
+    expect(filterObject(null, [['id']])).toBeNull();
+  });
+
+  it('returns undefined as-is', () => {
+    expect(filterObject(undefined, [['id']])).toBeUndefined();
+  });
+
+  it('returns arrays as-is (not wrapped in object filter)', () => {
+    const arr = [1, 2, 3];
+    expect(filterObject(arr, [['id']])).toBe(arr);
+  });
+
+  it('returns a new object (does not mutate the source)', () => {
+    const obj = { id: 1, name: 'test' };
+    const result = filterObject(obj, [['id']]);
+    expect(result).not.toBe(obj);
+    expect(obj).toHaveProperty('name'); // original untouched
+  });
+
+  it('handles a path that traverses through a null intermediate', () => {
+    const obj = { wallet: null };
+    const result = filterObject(obj, [['wallet', 'address']]);
+    // The nested path cannot be resolved; the parent key is omitted
+    expect(result).not.toHaveProperty('wallet');
+  });
+});
+
+// ─── applyFilter ─────────────────────────────────────────────────────────────
+
+describe('applyFilter()', () => {
+  const fieldPaths = [['id'], ['amount']];
+
+  it('filters each item in a data array envelope', () => {
+    const body = {
+      success: true,
+      data: [
+        { id: 1, amount: 10, secret: 'shhh' },
+        { id: 2, amount: 20, secret: 'shhh' },
+      ],
+    };
+    const result = applyFilter(body, fieldPaths);
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toEqual({ id: 1, amount: 10 });
+    expect(result.data[1]).toEqual({ id: 2, amount: 20 });
+  });
+
+  it('filters a single object in a data envelope', () => {
+    const body = {
+      success: true,
+      data: { id: 5, amount: 100, internalRef: 'X' },
+    };
+    const result = applyFilter(body, fieldPaths);
+    expect(result.data).toEqual({ id: 5, amount: 100 });
+    expect(result.data).not.toHaveProperty('internalRef');
+  });
+
+  it('preserves top-level envelope fields (success, count, meta)', () => {
+    const body = {
+      success: true,
+      count: 2,
+      meta: { page: 1 },
+      data: [{ id: 1, amount: 5, status: 'ok' }],
+    };
+    const result = applyFilter(body, fieldPaths);
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(2);
+    expect(result.meta).toEqual({ page: 1 });
+  });
+
+  it('filters the body directly when there is no data envelope', () => {
+    const body = { id: 7, amount: 77, status: 'pending' };
+    const result = applyFilter(body, fieldPaths);
+    expect(result).toEqual({ id: 7, amount: 77 });
+    expect(result).not.toHaveProperty('status');
+  });
+
+  it('passes non-object bodies through unchanged', () => {
+    expect(applyFilter(null, fieldPaths)).toBeNull();
+    expect(applyFilter('string', fieldPaths)).toBe('string');
+    expect(applyFilter(42, fieldPaths)).toBe(42);
+  });
+
+  it('handles a body with data: null gracefully', () => {
+    const body = { success: true, data: null };
+    const result = applyFilter(body, fieldPaths);
+    expect(result.data).toBeNull();
+  });
+});
+
+// ─── fieldFilterMiddleware — pass-through paths ───────────────────────────────
+
+describe('fieldFilterMiddleware() — pass-through', () => {
+  it('calls next() immediately when no ?fields param is present', async () => {
+    const { nextCalled } = await runMiddleware(undefined);
+    expect(nextCalled).toBe(true);
+  });
+
+  it('calls next() when ?fields is an empty string', async () => {
+    const { nextCalled } = await runMiddleware('');
+    expect(nextCalled).toBe(true);
+  });
+
+  it('calls next() when ?fields is whitespace only', async () => {
+    const { nextCalled } = await runMiddleware('   ');
+    expect(nextCalled).toBe(true);
+  });
+
+  it('does NOT set X-Fields-Applied header when pass-through occurs', async () => {
+    const { captured } = await runMiddleware(undefined);
+    expect(captured.headers['X-Fields-Applied']).toBeUndefined();
+  });
+});
+
+// ─── fieldFilterMiddleware — validation errors ────────────────────────────────
+
+describe('fieldFilterMiddleware() — validation errors', () => {
+  it('returns 400 for a field path with injection characters', async () => {
+    const { captured, nextCalled } = await runMiddleware('id;DROP TABLE users');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+    expect(captured.body.success).toBe(false);
+    expect(captured.body.error.code).toBe('INVALID_FIELD_PATH');
+  });
+
+  it('returns 400 for a field path with spaces', async () => {
+    const { captured, nextCalled } = await runMiddleware('id,bad field');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+
+  it('returns 400 for a path with an empty segment (trailing dot)', async () => {
+    const { captured, nextCalled } = await runMiddleware('wallet.');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+
+  it('returns 400 for a leading-dot path', async () => {
+    const { captured, nextCalled } = await runMiddleware('.secret');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+
+  // BLOCKED_FIELDS
+  it('returns 400 when "password" is requested via ?fields', async () => {
+    const { captured, nextCalled } = await runMiddleware('password');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+    expect(captured.body.error.code).toBe('INVALID_FIELD_PATH');
+    expect(captured.body.error.message).toMatch(/password/);
+  });
+
+  it('returns 400 when "secret" is requested via ?fields', async () => {
+    const { captured, nextCalled } = await runMiddleware('secret');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+
+  it('returns 400 when "privateKey" is requested via ?fields', async () => {
+    const { captured, nextCalled } = await runMiddleware('privateKey');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+
+  it('returns 400 when "secretKey" is requested via ?fields', async () => {
+    const { captured, nextCalled } = await runMiddleware('secretKey');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+
+  it('returns 400 even when a blocked field is mixed with valid ones', async () => {
+    const { captured, nextCalled } = await runMiddleware('id,password,amount');
+    expect(nextCalled).toBe(false);
+    expect(captured.status).toBe(400);
+  });
+});
+
+// ─── fieldFilterMiddleware — filtering behaviour ──────────────────────────────
+
+describe('fieldFilterMiddleware() — filtering behaviour', () => {
+  it('strips unrequested top-level fields from the response', async () => {
+    const { nextCalled, res } = await runMiddleware('id,amount');
+    expect(nextCalled).toBe(true);
+
+    // Call the wrapped res.json to trigger filtering
+    res.json({ id: 1, amount: 50, status: 'pending', internalCode: 'X' });
+    expect(res._captured.body).toEqual({ id: 1, amount: 50 });
+    expect(res._captured.body).not.toHaveProperty('status');
+    expect(res._captured.body).not.toHaveProperty('internalCode');
+  });
+
+  it('sets X-Fields-Applied: true when filtering is active', async () => {
+    const { res } = await runMiddleware('id');
+    res.json({ id: 1, amount: 50 });
+    expect(res._captured.headers['X-Fields-Applied']).toBe('true');
+  });
+
+  it('filters nested fields using dot notation', async () => {
+    const { res } = await runMiddleware('id,wallet.address');
+
+    res.json({
+      id: 1,
+      wallet: { address: 'GABC', balance: 100, privateKey: 'should-not-appear' },
+      amount: 50,
+    });
+
+    expect(res._captured.body.id).toBe(1);
+    expect(res._captured.body.wallet).toEqual({ address: 'GABC' });
+    expect(res._captured.body.wallet).not.toHaveProperty('balance');
+    expect(res._captured.body.wallet).not.toHaveProperty('privateKey');
+    expect(res._captured.body).not.toHaveProperty('amount');
+  });
+
+  it('filters items inside a data array envelope', async () => {
+    const { res } = await runMiddleware('id,status');
+
+    res.json({
+      success: true,
+      data: [
+        { id: 1, status: 'active', secret: 'hidden' },
+        { id: 2, status: 'pending', secret: 'hidden' },
+      ],
+    });
+
+    const { body } = res._captured;
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0]).toEqual({ id: 1, status: 'active' });
+    expect(body.data[1]).toEqual({ id: 2, status: 'pending' });
+  });
+
+  it('filters a data object envelope', async () => {
+    const { res } = await runMiddleware('id,name');
+
+    res.json({
+      success: true,
+      data: { id: 99, name: 'Alice', internalId: 'XYZZY' },
+    });
+
+    const { body } = res._captured;
+    expect(body.data).toEqual({ id: 99, name: 'Alice' });
+    expect(body.data).not.toHaveProperty('internalId');
+  });
+
+  it('handles multiple comma-separated fields', async () => {
+    const { res } = await runMiddleware('id,amount,status,createdAt');
+
+    res.json({ id: 3, amount: 10, status: 'ok', createdAt: '2024-01-01', extra: 'drop' });
+
+    expect(res._captured.body).toEqual({
+      id: 3,
+      amount: 10,
+      status: 'ok',
+      createdAt: '2024-01-01',
+    });
+  });
+
+  it('handles a single requested field', async () => {
+    const { res } = await runMiddleware('id');
+    res.json({ id: 7, name: 'Bob', amount: 100 });
+    expect(res._captured.body).toEqual({ id: 7 });
+  });
+
+  it('returns an empty object when none of the requested fields exist in the response', async () => {
+    const { res } = await runMiddleware('nonexistent,alsoMissing');
+    res.json({ id: 1, amount: 50 });
+    expect(res._captured.body).toEqual({});
+  });
+});
+
+// ─── Security: blocked fields are never included in filtered output ───────────
+
+describe('Security: blocked fields never appear in filtered output', () => {
+  it('a request for valid fields never surfaces the password field', async () => {
+    const { res } = await runMiddleware('id,name');
+
+    res.json({ id: 1, name: 'Alice', password: 'hunter2' });
+
+    // password was not requested and should not be in the output
+    expect(res._captured.body).not.toHaveProperty('password');
+    expect(res._captured.body).toEqual({ id: 1, name: 'Alice' });
+  });
+
+  it('a request for valid nested fields never surfaces sibling blocked fields', async () => {
+    const { res } = await runMiddleware('id,user.name');
+
+    res.json({
+      id: 1,
+      user: { name: 'Bob', password: 'secret123' },
+    });
+
+    expect(res._captured.body.user).toEqual({ name: 'Bob' });
+    expect(res._captured.body.user).not.toHaveProperty('password');
+  });
+});

--- a/tests/services/auditLogRetentionService.test.js
+++ b/tests/services/auditLogRetentionService.test.js
@@ -1,0 +1,420 @@
+'use strict';
+
+/**
+ * Tests: AuditLogRetentionService (issue #1387)
+ *
+ * Covers:
+ *  - Retention-window cutoff calculation for various retention periods
+ *  - Records older than the cutoff are archived then deleted
+ *  - Records within the retention window are NOT touched
+ *  - Boundary-case: a record timestamped exactly AT the cutoff is preserved
+ *    (the query uses strict `<`, so the boundary record is kept)
+ *  - Empty result: returns 0 and does not call INSERT or DELETE
+ *  - Archive table is created lazily on first run
+ *  - Database errors during SELECT, INSERT, or DELETE are surfaced (not swallowed)
+ *  - start() / stop() lifecycle: timer is registered / cleared exactly once
+ */
+
+// ─── Mock heavy dependencies before any src/ module is required ──────────────
+
+// Capture the log calls so we can assert on them without console noise
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
+// Mock timerRegistry so no real setInterval is created
+jest.mock('../../src/utils/timerRegistry', () => ({
+  createInterval: jest.fn(() => ({
+    unref: jest.fn(),
+    clear: jest.fn(),
+  })),
+}));
+
+// Mock config to return a predictable retention value (avoid env-var dependency)
+jest.mock('../../src/config', () => ({
+  auditRetention: { archiveAfterDays: 90 },
+}));
+
+// ─── Set up the database mock before loading the module ──────────────────────
+// We use explicit jest.fn() handles so individual tests can override behaviour.
+const mockRun = jest.fn();
+const mockAll = jest.fn();
+
+jest.mock('../../src/utils/database', () => ({
+  run: mockRun,
+  all: mockAll,
+}));
+
+// ─── Load service AFTER mocks are in place ───────────────────────────────────
+// AuditLogRetentionService exports a singleton; we need to reset module state
+// between tests that mutate the timer field, so we use the raw prototype.
+const AuditLogRetentionService = require('../../src/services/AuditLogRetentionService');
+const timerRegistry = require('../../src/utils/timerRegistry');
+const log = require('../../src/utils/log');
+
+// ─── Constants under test ────────────────────────────────────────────────────
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_DAYS = 90;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal audit-log row fixture.
+ */
+function makeRow(overrides = {}) {
+  return {
+    id: 1,
+    timestamp: new Date(Date.now() - 100 * MS_PER_DAY).toISOString(),
+    category: 'AUTH',
+    action: 'LOGIN',
+    severity: 'INFO',
+    result: 'SUCCESS',
+    userId: 'u1',
+    requestId: 'r1',
+    ipAddress: '127.0.0.1',
+    resource: '/auth',
+    reason: null,
+    details: null,
+    integrityHash: 'abc123',
+    ...overrides,
+  };
+}
+
+// ─── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('AuditLogRetentionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: ensureArchiveTable CREATE succeeds, DELETE succeeds
+    mockRun.mockResolvedValue({});
+    // Default: no rows to archive
+    mockAll.mockResolvedValue([]);
+  });
+
+  // ── _ensureArchiveTable ────────────────────────────────────────────────────
+
+  describe('_ensureArchiveTable', () => {
+    it('calls db.run with a CREATE TABLE IF NOT EXISTS statement', async () => {
+      await AuditLogRetentionService._ensureArchiveTable();
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      const [sql] = mockRun.mock.calls[0];
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS audit_logs_archive/i);
+    });
+  });
+
+  // ── runRetention — cutoff calculation ────────────────────────────────────
+
+  describe('runRetention — cutoff calculation', () => {
+    it('selects rows older than 90 days (default)', async () => {
+      const before = Date.now();
+      await AuditLogRetentionService.runRetention();
+      const after = Date.now();
+
+      // The SELECT call is the first db.all call
+      expect(mockAll).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockAll.mock.calls[0];
+      expect(sql).toMatch(/SELECT \* FROM audit_logs WHERE timestamp < \?/i);
+
+      const cutoff = new Date(params[0]).getTime();
+      const expectedMin = before - DEFAULT_RETENTION_DAYS * MS_PER_DAY;
+      const expectedMax = after  - DEFAULT_RETENTION_DAYS * MS_PER_DAY;
+
+      expect(cutoff).toBeGreaterThanOrEqual(expectedMin);
+      expect(cutoff).toBeLessThanOrEqual(expectedMax);
+    });
+
+    it('selects rows older than a custom retention period (30 days)', async () => {
+      const before = Date.now();
+      await AuditLogRetentionService.runRetention(30);
+      const after = Date.now();
+
+      const [, params] = mockAll.mock.calls[0];
+      const cutoff = new Date(params[0]).getTime();
+
+      expect(cutoff).toBeGreaterThanOrEqual(before - 30 * MS_PER_DAY);
+      expect(cutoff).toBeLessThanOrEqual(after  - 30 * MS_PER_DAY);
+    });
+
+    it('selects rows older than a 365-day retention period', async () => {
+      const before = Date.now();
+      await AuditLogRetentionService.runRetention(365);
+      const after = Date.now();
+
+      const [, params] = mockAll.mock.calls[0];
+      const cutoff = new Date(params[0]).getTime();
+
+      expect(cutoff).toBeGreaterThanOrEqual(before - 365 * MS_PER_DAY);
+      expect(cutoff).toBeLessThanOrEqual(after  - 365 * MS_PER_DAY);
+    });
+
+    it('accepts retentionDays=1 (1-day window)', async () => {
+      const before = Date.now();
+      await AuditLogRetentionService.runRetention(1);
+      const after = Date.now();
+
+      const [, params] = mockAll.mock.calls[0];
+      const cutoff = new Date(params[0]).getTime();
+
+      expect(cutoff).toBeGreaterThanOrEqual(before - 1 * MS_PER_DAY);
+      expect(cutoff).toBeLessThanOrEqual(after  - 1 * MS_PER_DAY);
+    });
+  });
+
+  // ── runRetention — no eligible rows ──────────────────────────────────────
+
+  describe('runRetention — no eligible rows', () => {
+    it('returns 0 when no rows match the cutoff', async () => {
+      mockAll.mockResolvedValue([]);
+      const count = await AuditLogRetentionService.runRetention();
+      expect(count).toBe(0);
+    });
+
+    it('does not call INSERT or DELETE when result set is empty', async () => {
+      mockAll.mockResolvedValue([]);
+      await AuditLogRetentionService.runRetention();
+
+      // Only the CREATE TABLE call should have been made via db.run
+      const insertOrDeleteCalls = mockRun.mock.calls.filter(([sql]) =>
+        /INSERT/i.test(sql) || /DELETE/i.test(sql)
+      );
+      expect(insertOrDeleteCalls).toHaveLength(0);
+    });
+  });
+
+  // ── runRetention — archiving eligible rows ────────────────────────────────
+
+  describe('runRetention — archiving eligible rows', () => {
+    it('archives and deletes rows older than the cutoff', async () => {
+      const row1 = makeRow({ id: 1 });
+      const row2 = makeRow({ id: 2, userId: 'u2' });
+      mockAll.mockResolvedValue([row1, row2]);
+
+      const count = await AuditLogRetentionService.runRetention();
+
+      expect(count).toBe(2);
+
+      // Each row should generate one INSERT … INTO audit_logs_archive
+      const insertCalls = mockRun.mock.calls.filter(([sql]) =>
+        /INSERT.*audit_logs_archive/i.test(sql)
+      );
+      expect(insertCalls).toHaveLength(2);
+
+      // There should be exactly one DELETE … FROM audit_logs
+      const deleteCalls = mockRun.mock.calls.filter(([sql]) =>
+        /DELETE FROM audit_logs/i.test(sql)
+      );
+      expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('inserts each row with the correct column values', async () => {
+      const row = makeRow({
+        id: 42,
+        category: 'TX',
+        action: 'SEND',
+        severity: 'HIGH',
+        result: 'FAILED',
+        userId: 'user-99',
+        requestId: 'req-abc',
+        ipAddress: '10.0.0.1',
+        resource: '/donations',
+        reason: 'test',
+        details: JSON.stringify({ amount: 10 }),
+        integrityHash: 'hash-xyz',
+      });
+      mockAll.mockResolvedValue([row]);
+
+      await AuditLogRetentionService.runRetention();
+
+      const [insertSql, insertParams] = mockRun.mock.calls.find(([sql]) =>
+        /INSERT.*audit_logs_archive/i.test(sql)
+      );
+      expect(insertSql).toMatch(/INSERT OR IGNORE INTO audit_logs_archive/i);
+      // params: id, timestamp, category, action, severity, result,
+      //         userId, requestId, ipAddress, resource, reason,
+      //         details, integrityHash, archivedAt
+      expect(insertParams[0]).toBe(42);
+      expect(insertParams[2]).toBe('TX');
+      expect(insertParams[3]).toBe('SEND');
+      expect(insertParams[4]).toBe('HIGH');
+      expect(insertParams[6]).toBe('user-99');
+      expect(insertParams[12]).toBe('hash-xyz');
+      // archivedAt is the last param and must be a valid ISO string
+      expect(() => new Date(insertParams[13]).toISOString()).not.toThrow();
+    });
+
+    it('DELETE uses the same cutoff timestamp passed to the SELECT', async () => {
+      mockAll.mockResolvedValue([makeRow()]);
+
+      await AuditLogRetentionService.runRetention(90);
+
+      const selectParams = mockAll.mock.calls[0][1];
+      const deleteCalls = mockRun.mock.calls.filter(([sql]) =>
+        /DELETE FROM audit_logs/i.test(sql)
+      );
+      expect(deleteCalls).toHaveLength(1);
+      const deleteParams = deleteCalls[0][1];
+      expect(deleteParams[0]).toBe(selectParams[0]);
+    });
+  });
+
+  // ── runRetention — boundary case ─────────────────────────────────────────
+
+  describe('runRetention — boundary case', () => {
+    it('does NOT archive a record timestamped exactly AT the cutoff (strict <)', async () => {
+      // We return no rows (simulating that the boundary record was not matched).
+      // This test asserts that the SELECT query uses strict < (not <=).
+      mockAll.mockResolvedValue([]);
+
+      await AuditLogRetentionService.runRetention(90);
+
+      const [sql] = mockAll.mock.calls[0];
+      // Strict less-than, not <=
+      expect(sql).toMatch(/timestamp\s*</);
+      expect(sql).not.toMatch(/timestamp\s*<=/);
+    });
+  });
+
+  // ── runRetention — logging ────────────────────────────────────────────────
+
+  describe('runRetention — logging', () => {
+    it('logs an info message when rows are archived', async () => {
+      mockAll.mockResolvedValue([makeRow(), makeRow({ id: 2 })]);
+
+      await AuditLogRetentionService.runRetention(90);
+
+      expect(log.info).toHaveBeenCalledWith(
+        'AUDIT_RETENTION',
+        expect.stringContaining('2'),
+        expect.objectContaining({ retentionDays: 90, archivedCount: 2 })
+      );
+    });
+
+    it('does NOT log when there is nothing to archive', async () => {
+      mockAll.mockResolvedValue([]);
+      await AuditLogRetentionService.runRetention();
+      expect(log.info).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── runRetention — error handling ─────────────────────────────────────────
+
+  describe('runRetention — error handling', () => {
+    it('propagates database errors from db.all (SELECT)', async () => {
+      mockAll.mockRejectedValue(new Error('DB connection lost'));
+      await expect(AuditLogRetentionService.runRetention()).rejects.toThrow('DB connection lost');
+    });
+
+    it('propagates database errors from db.run (INSERT)', async () => {
+      mockAll.mockResolvedValue([makeRow()]);
+      // CREATE TABLE succeeds, then INSERT fails
+      mockRun
+        .mockResolvedValueOnce({})          // CREATE TABLE
+        .mockRejectedValueOnce(new Error('Disk full'));
+
+      await expect(AuditLogRetentionService.runRetention()).rejects.toThrow('Disk full');
+    });
+
+    it('propagates database errors from db.run (DELETE)', async () => {
+      mockAll.mockResolvedValue([makeRow()]);
+      mockRun
+        .mockResolvedValueOnce({})  // CREATE TABLE
+        .mockResolvedValueOnce({})  // INSERT archive row
+        .mockRejectedValueOnce(new Error('DELETE constraint')); // DELETE fails
+
+      await expect(AuditLogRetentionService.runRetention()).rejects.toThrow('DELETE constraint');
+    });
+  });
+
+  // ── start / stop lifecycle ────────────────────────────────────────────────
+
+  describe('start / stop lifecycle', () => {
+    let service;
+
+    beforeEach(() => {
+      // Create a fresh instance for each lifecycle test to avoid singleton state
+      const { AuditLogRetentionService: Cls } =
+        jest.isolateModules(() =>
+          // Re-require the class by accessing the constructor via the singleton
+          ({ AuditLogRetentionService: Object.getPrototypeOf(AuditLogRetentionService).constructor })
+        );
+
+      // Use the exported singleton but manipulate _timer directly
+      service = AuditLogRetentionService;
+      service._timer = null; // reset timer state
+    });
+
+    afterEach(() => {
+      service.stop();
+    });
+
+    it('start() registers a timer via timerRegistry.createInterval', () => {
+      service.start();
+      expect(timerRegistry.createInterval).toHaveBeenCalledTimes(1);
+      expect(timerRegistry.createInterval).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Number),
+        'audit-log-retention'
+      );
+    });
+
+    it('start() logs that the service started', () => {
+      service.start();
+      expect(log.info).toHaveBeenCalledWith(
+        'AUDIT_RETENTION',
+        expect.stringContaining('started'),
+        expect.any(Object)
+      );
+    });
+
+    it('start() is idempotent — calling twice registers the timer only once', () => {
+      service.start();
+      service.start();
+      expect(timerRegistry.createInterval).toHaveBeenCalledTimes(1);
+    });
+
+    it('stop() clears the timer', () => {
+      service.start();
+      const mockTimer = timerRegistry.createInterval.mock.results[0].value;
+      service.stop();
+      expect(mockTimer.clear).toHaveBeenCalledTimes(1);
+      expect(service._timer).toBeNull();
+    });
+
+    it('stop() is safe to call when service was never started', () => {
+      expect(() => service.stop()).not.toThrow();
+    });
+
+    it('the interval callback catches errors and logs them', async () => {
+      mockAll.mockRejectedValue(new Error('scheduled failure'));
+
+      service.start();
+
+      // Extract and invoke the callback registered with timerRegistry
+      const [callback] = timerRegistry.createInterval.mock.calls[0];
+      await callback();
+
+      expect(log.error).toHaveBeenCalledWith(
+        'AUDIT_RETENTION',
+        expect.stringContaining('failed'),
+        expect.objectContaining({ error: 'scheduled failure' })
+      );
+    });
+  });
+
+  // ── return value contract ─────────────────────────────────────────────────
+
+  describe('return value', () => {
+    it('returns the number of archived entries', async () => {
+      mockAll.mockResolvedValue([makeRow(), makeRow({ id: 2 }), makeRow({ id: 3 })]);
+      const count = await AuditLogRetentionService.runRetention();
+      expect(count).toBe(3);
+    });
+
+    it('returns 0 when no entries qualify', async () => {
+      mockAll.mockResolvedValue([]);
+      const count = await AuditLogRetentionService.runRetention();
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/tests/utils/stellarErrorHandler.test.js
+++ b/tests/utils/stellarErrorHandler.test.js
@@ -1,0 +1,335 @@
+'use strict';
+
+/**
+ * Tests: src/utils/stellarErrorHandler.js (issue #1389)
+ *
+ * Covers every classification branch in StellarErrorHandler.handle() and
+ * the StellarErrorHandler.wrap() convenience wrapper. No real network calls
+ * are made — all errors are constructed in-process.
+ *
+ * Classification matrix tested:
+ *  NETWORK_ERROR       — ENOTFOUND / ECONNREFUSED
+ *  NETWORK_TIMEOUT     — timeout / ETIMEDOUT
+ *  INSUFFICIENT_BALANCE— "insufficient" / "underfunded"
+ *  INVALID_DESTINATION — "destination" / "not found"
+ *  ACCOUNT_NOT_FUNDED  — "not funded" / "op_no_destination"
+ *  INVALID_CREDENTIALS — "Invalid source" / "secret key"
+ *  TRANSACTION_FAILED  — "tx_failed" / "transaction failed"
+ *  WALLET_NOT_FOUND    — "Wallet not found"
+ *  INVALID_TRANSACTION — "must be different"
+ *  TRANSACTION_NOT_FOUND — "Transaction not found"
+ *  STELLAR_ERROR       — unknown / unrecognized error
+ *
+ * Each classification is verified for:
+ *  - correct status code
+ *  - correct error code
+ *  - presence of a human-readable message
+ *
+ * wrap():
+ *  - resolves to the operation result on success
+ *  - re-throws the classified error object on failure
+ */
+
+// ─── Mock the logger so no noise appears in test output ──────────────────────
+jest.mock('../../src/utils/log', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+}));
+
+const StellarErrorHandler = require('../../src/utils/stellarErrorHandler');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build an Error with an optional message and optional response body.
+ */
+function makeError(message, responseData = undefined) {
+  const err = new Error(message);
+  if (responseData !== undefined) {
+    err.response = { data: responseData };
+  }
+  return err;
+}
+
+// ─── StellarErrorHandler.handle() ────────────────────────────────────────────
+
+describe('StellarErrorHandler.handle()', () => {
+  // ── Network errors ──────────────────────────────────────────────────────────
+
+  describe('Network connectivity errors', () => {
+    it('classifies ENOTFOUND as NETWORK_ERROR with status 503', () => {
+      const result = StellarErrorHandler.handle(makeError('getaddrinfo ENOTFOUND horizon.stellar.org'));
+      expect(result.status).toBe(503);
+      expect(result.code).toBe('NETWORK_ERROR');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies ECONNREFUSED as NETWORK_ERROR with status 503', () => {
+      const result = StellarErrorHandler.handle(makeError('connect ECONNREFUSED 127.0.0.1:11626'));
+      expect(result.status).toBe(503);
+      expect(result.code).toBe('NETWORK_ERROR');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "timeout" messages as NETWORK_TIMEOUT with status 504', () => {
+      const result = StellarErrorHandler.handle(makeError('Request timeout after 30000ms'));
+      expect(result.status).toBe(504);
+      expect(result.code).toBe('NETWORK_TIMEOUT');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies ETIMEDOUT as NETWORK_TIMEOUT with status 504', () => {
+      const result = StellarErrorHandler.handle(makeError('connection ETIMEDOUT 192.168.1.1:443'));
+      expect(result.status).toBe(504);
+      expect(result.code).toBe('NETWORK_TIMEOUT');
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── Balance errors ──────────────────────────────────────────────────────────
+
+  describe('Balance / funding errors', () => {
+    it('classifies "insufficient" message as INSUFFICIENT_BALANCE with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Account has insufficient funds'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INSUFFICIENT_BALANCE');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "underfunded" as INSUFFICIENT_BALANCE with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('op_underfunded: not enough XLM'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INSUFFICIENT_BALANCE');
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── Destination / account errors ────────────────────────────────────────────
+
+  describe('Destination / account errors', () => {
+    it('classifies "destination" message as INVALID_DESTINATION with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Invalid destination account'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INVALID_DESTINATION');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "not found" message as INVALID_DESTINATION with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Account not found on network'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INVALID_DESTINATION');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "not funded" as ACCOUNT_NOT_FUNDED with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Account is not funded'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('ACCOUNT_NOT_FUNDED');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "op_no_destination" as ACCOUNT_NOT_FUNDED with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Transaction failed: op_no_destination'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('ACCOUNT_NOT_FUNDED');
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── Credential errors ───────────────────────────────────────────────────────
+
+  describe('Credential errors', () => {
+    it('classifies "Invalid source" as INVALID_CREDENTIALS with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Invalid source account'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INVALID_CREDENTIALS');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "secret key" message as INVALID_CREDENTIALS with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Malformed secret key provided'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INVALID_CREDENTIALS');
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── Transaction failures ────────────────────────────────────────────────────
+
+  describe('Transaction failures', () => {
+    it('classifies "tx_failed" as TRANSACTION_FAILED with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Transaction result: tx_failed'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('TRANSACTION_FAILED');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "transaction failed" as TRANSACTION_FAILED with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('The transaction failed on Stellar'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('TRANSACTION_FAILED');
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── Domain-specific errors ──────────────────────────────────────────────────
+
+  describe('Domain-specific errors', () => {
+    it('classifies "Wallet not found" as WALLET_NOT_FOUND with status 404', () => {
+      const result = StellarErrorHandler.handle(makeError('Wallet not found for key GABCD'));
+      expect(result.status).toBe(404);
+      expect(result.code).toBe('WALLET_NOT_FOUND');
+      expect(result.message).toMatch(/Wallet not found/);
+    });
+
+    it('classifies "must be different" as INVALID_TRANSACTION with status 400', () => {
+      const result = StellarErrorHandler.handle(makeError('Sender and recipient must be different'));
+      expect(result.status).toBe(400);
+      expect(result.code).toBe('INVALID_TRANSACTION');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('classifies "Transaction not found" as TRANSACTION_NOT_FOUND with status 404', () => {
+      const result = StellarErrorHandler.handle(makeError('Transaction not found in ledger'));
+      expect(result.status).toBe(404);
+      expect(result.code).toBe('TRANSACTION_NOT_FOUND');
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── Default / unknown errors ────────────────────────────────────────────────
+
+  describe('Unknown / unrecognized errors', () => {
+    it('returns STELLAR_ERROR with status 500 for unrecognized messages', () => {
+      const result = StellarErrorHandler.handle(makeError('Some completely unknown blockchain error'));
+      expect(result.status).toBe(500);
+      expect(result.code).toBe('STELLAR_ERROR');
+      expect(result.message).toBeTruthy();
+    });
+
+    it('returns STELLAR_ERROR for an error with an empty message', () => {
+      const result = StellarErrorHandler.handle(makeError(''));
+      expect(result.status).toBe(500);
+      expect(result.code).toBe('STELLAR_ERROR');
+    });
+
+    it('handles an error with no .message property gracefully', () => {
+      const errNoMessage = {};
+      const result = StellarErrorHandler.handle(errNoMessage);
+      expect(result).toHaveProperty('status');
+      expect(result).toHaveProperty('code');
+      expect(result).toHaveProperty('message');
+    });
+  });
+
+  // ── Return shape contract ───────────────────────────────────────────────────
+
+  describe('Return shape contract', () => {
+    it('always returns an object with status, code, and message properties', () => {
+      const errors = [
+        makeError('ENOTFOUND example.com'),
+        makeError('timeout'),
+        makeError('insufficient funds'),
+        makeError('destination invalid'),
+        makeError('not funded'),
+        makeError('Invalid source'),
+        makeError('tx_failed'),
+        makeError('Wallet not found'),
+        makeError('must be different'),
+        makeError('Transaction not found'),
+        makeError('completely unknown error xyz'),
+      ];
+
+      for (const err of errors) {
+        const result = StellarErrorHandler.handle(err);
+        expect(result).toHaveProperty('status');
+        expect(result).toHaveProperty('code');
+        expect(result).toHaveProperty('message');
+        expect(typeof result.status).toBe('number');
+        expect(typeof result.code).toBe('string');
+        expect(typeof result.message).toBe('string');
+      }
+    });
+
+    it('accepts an optional context parameter without changing the classification', () => {
+      const result = StellarErrorHandler.handle(makeError('ENOTFOUND stellar.org'), 'sendDonation');
+      expect(result.code).toBe('NETWORK_ERROR');
+    });
+
+    it('uses default context "operation" when no context is provided', () => {
+      // Simply verifying it does not throw when context is omitted
+      expect(() => StellarErrorHandler.handle(makeError('ENOTFOUND x'))).not.toThrow();
+    });
+  });
+
+  // ── Logging side-effect ─────────────────────────────────────────────────────
+
+  describe('Logging side-effect', () => {
+    const log = require('../../src/utils/log');
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('calls log.error with the STELLAR_ERROR_HANDLER category', () => {
+      StellarErrorHandler.handle(makeError('some error'), 'testContext');
+      expect(log.error).toHaveBeenCalledWith(
+        'STELLAR_ERROR_HANDLER',
+        expect.stringContaining('testContext'),
+        expect.any(Object)
+      );
+    });
+  });
+});
+
+// ─── StellarErrorHandler.wrap() ───────────────────────────────────────────────
+
+describe('StellarErrorHandler.wrap()', () => {
+  it('returns the operation result when the operation resolves', async () => {
+    const result = await StellarErrorHandler.wrap(
+      async () => ({ txHash: 'abc123', ledger: 100 }),
+      'sendDonation'
+    );
+    expect(result).toEqual({ txHash: 'abc123', ledger: 100 });
+  });
+
+  it('re-throws a classified error object when the operation rejects', async () => {
+    await expect(
+      StellarErrorHandler.wrap(
+        async () => { throw new Error('ECONNREFUSED 127.0.0.1:11626'); },
+        'getBalance'
+      )
+    ).rejects.toMatchObject({
+      status: 503,
+      code: 'NETWORK_ERROR',
+    });
+  });
+
+  it('re-throws TRANSACTION_FAILED when the operation throws a tx_failed error', async () => {
+    await expect(
+      StellarErrorHandler.wrap(
+        async () => { throw new Error('tx_failed: bad sequence'); },
+        'submitTransaction'
+      )
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'TRANSACTION_FAILED',
+    });
+  });
+
+  it('re-throws STELLAR_ERROR for unrecognized errors', async () => {
+    await expect(
+      StellarErrorHandler.wrap(
+        async () => { throw new Error('Completely unrecognised error zzz'); },
+        'unknown'
+      )
+    ).rejects.toMatchObject({
+      status: 500,
+      code: 'STELLAR_ERROR',
+    });
+  });
+
+  it('passes the operation result through when it is a falsy value', async () => {
+    const result = await StellarErrorHandler.wrap(async () => null, 'getNull');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds test suites for four source files that previously had zero test coverage, addressing the compliance/security risks identified in issues #1387–#1390.

---

## Changes

### `tests/services/auditLogRetentionService.test.js` — closes #1387
Covers the audit-log retention service end-to-end:
- Retention-window cutoff calculation for 90 / 30 / 365 / 1-day periods
- Archive-then-delete path: verifies INSERT into `audit_logs_archive` and DELETE from `audit_logs` with matching cutoff timestamps
- Boundary case: asserts `timestamp <` (strict, not `<=`) so boundary records are preserved
- Empty fast-path: returns 0 and skips INSERT/DELETE when no rows qualify
- Error propagation from SELECT, INSERT, and DELETE database calls
- `start()` / `stop()` lifecycle, idempotency, and interval-callback error handling

### `tests/admin/i18nController.test.js` — closes #1388
Covers every operation exposed by the admin i18n controller:
- `getAllMessages`: list all translations, empty result, DB error → 500
- `updateTranslation`: update existing doc, create new doc when key absent, 400 on missing value, Map mutation, cache invalidation after write, error paths
- `addLanguage`: seed all keys (provided value or empty string), skip keys that already carry the language, 400 for missing `code`/`name`, empty store, error paths

### `tests/utils/stellarErrorHandler.test.js` — closes #1389
Covers all 11 classification branches in `StellarErrorHandler.handle()`:
`NETWORK_ERROR`, `NETWORK_TIMEOUT`, `INSUFFICIENT_BALANCE`, `INVALID_DESTINATION`, `ACCOUNT_NOT_FUNDED`, `INVALID_CREDENTIALS`, `TRANSACTION_FAILED`, `WALLET_NOT_FOUND`, `INVALID_TRANSACTION`, `TRANSACTION_NOT_FOUND`, `STELLAR_ERROR` (default/unknown).
Also covers the return-shape contract (status/code/message on every path), context parameter, logging side-effect, and `wrap()` success and failure paths.

### `tests/middleware/fieldFilter.test.js` — closes #1390
Covers all four exported symbols:
- `isValidFieldPath`: valid simple/underscore/dot paths; rejects empty, non-string, injection chars, empty segments
- `filterObject`: top-level pick, nested pick, missing path, null/array input, no mutation, null intermediate
- `applyFilter`: array envelope, object envelope, preserves `success`/`count`/`meta`, direct body, non-object pass-through
- `fieldFilterMiddleware`: pass-through (no param, empty, whitespace), 400 for malformed paths, **BLOCKED_FIELDS enforcement** (`password`, `secret`, `privateKey`, `secretKey`), field stripping, `X-Fields-Applied` header, dot-notation, data array/object envelopes, security assertions

---

## Testing

All new tests use Jest mocks only — no live database or network connections.

```bash
npm test tests/services/auditLogRetentionService.test.js
npm test tests/admin/i18nController.test.js
npm test tests/utils/stellarErrorHandler.test.js
npm test tests/middleware/fieldFilter.test.js
```

---

Closes #1387
Closes #1388
Closes #1389
Closes #1390